### PR TITLE
Internal option to scan and return the grouped sources (packages)

### DIFF
--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -49,6 +49,7 @@ type ExperimentalScannerActions struct {
 	CompareOffline        bool
 	ShowAllPackages       bool
 	ScanLicenses          bool
+	OnlyPackages          bool
 	ScanLicensesAllowlist []string
 
 	LocalDBPath string
@@ -778,6 +779,12 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 
 	if len(filteredScannedPackages) != len(scannedPackages) {
 		r.PrintText(fmt.Sprintf("Filtered %d local package/s from the scan.\n", len(scannedPackages)-len(filteredScannedPackages)))
+	}
+
+	if actions.OnlyPackages {
+		vulnerabilityResults := groupBySource(r, scannedPackages)
+
+		return vulnerabilityResults, nil
 	}
 
 	vulnsResp, err := makeRequest(r, filteredScannedPackages, actions.CompareLocally, actions.CompareOffline, actions.LocalDBPath)

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -115,3 +115,51 @@ func buildVulnerabilityResults(
 
 	return output
 }
+
+// grouped by source location.
+func groupBySource(r reporter.Reporter, packages []scannedPackage) models.VulnerabilityResults {
+	output := models.VulnerabilityResults{
+		Results: []models.PackageSource{},
+	}
+	groupedBySource := map[models.SourceInfo][]models.PackageVulns{}
+
+	for _, p := range packages {
+		var pkg models.PackageVulns
+		switch {
+		case p.Ecosystem != "" && p.Name != "" && p.Version != "":
+			pkg = models.PackageVulns{
+				Package: models.PackageInfo{
+					Name:      p.Name,
+					Version:   p.Version,
+					Ecosystem: string(p.Ecosystem),
+				},
+			}
+		case p.Commit != "":
+			pkg.Package.Version = p.Commit
+			pkg.Package.Ecosystem = "GIT"
+		case p.PURL != "":
+			var err error
+			pkg.Package, err = models.PURLToPackage(p.PURL)
+			if err != nil {
+				r.PrintError(fmt.Sprintf("Failed to parse purl: %s, with error: %s", p.PURL, err))
+				continue
+			}
+		default:
+			r.PrintError(fmt.Sprintf("package %v does not have a commit, PURL or ecosystem/name/version identifier", p))
+			continue
+		}
+
+		pkg.Vulnerabilities = nil
+		pkg.Groups = nil
+		groupedBySource[p.Source] = append(groupedBySource[p.Source], pkg)
+	}
+
+	for source, packages := range groupedBySource {
+		output.Results = append(output.Results, models.PackageSource{
+			Source:   source,
+			Packages: packages,
+		})
+	}
+
+	return output
+}

--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -468,3 +468,102 @@ func makeLicenses(strLicenses []string) []models.License {
 
 	return licenses
 }
+
+func Test_groupBySource(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		r        reporter.Reporter
+		packages []scannedPackage
+	}
+	packages := []scannedPackage{
+		{
+			Name:      "pkg-1",
+			Ecosystem: lockfile.Ecosystem("npm"),
+			Version:   "1.0.0",
+			Source: models.SourceInfo{
+				Path: "dir/package-lock.json",
+				Type: "lockfile",
+			},
+		},
+		{
+			Name:      "pkg-2",
+			Ecosystem: lockfile.Ecosystem("npm"),
+			Version:   "1.0.0",
+			Source: models.SourceInfo{
+				Path: "dir/package-lock.json",
+				Type: "lockfile",
+			},
+		},
+		{
+			Name:      "pkg-3",
+			Ecosystem: lockfile.Ecosystem("npm"),
+			Version:   "1.0.0",
+			Source: models.SourceInfo{
+				Path: "other-dir/package-lock.json",
+				Type: "lockfile",
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want models.VulnerabilityResults
+	}{{
+		name: "group packages",
+		args: args{
+			r:        &reporter.VoidReporter{},
+			packages: packages,
+		},
+		want: models.VulnerabilityResults{
+			Results: []models.PackageSource{
+				{
+					Source: models.SourceInfo{
+						Path: "dir/package-lock.json",
+						Type: "lockfile",
+					},
+					Packages: []models.PackageVulns{
+						{
+							Package: models.PackageInfo{
+								Name:      "pkg-1",
+								Ecosystem: "npm",
+								Version:   "1.0.0",
+							},
+						},
+						{
+							Package: models.PackageInfo{
+								Name:      "pkg-2",
+								Ecosystem: "npm",
+								Version:   "1.0.0",
+							},
+						},
+					},
+				},
+				{
+					Source: models.SourceInfo{
+						Path: "other-dir/package-lock.json",
+						Type: "lockfile",
+					},
+					Packages: []models.PackageVulns{
+						{
+							Package: models.PackageInfo{
+								Name:      "pkg-3",
+								Ecosystem: "npm",
+								Version:   "1.0.0",
+							},
+						},
+					},
+				},
+			},
+		},
+	}}
+	for _, tt := range tests {
+		tt := tt // Reinitialize for t.Parallel()
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := groupBySource(tt.args.r, tt.args.packages); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("groupBySource() = %v,\nwant %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Skips vulnerability detection.
- Return only the scanned packages from lockfile(s).