### PR TITLE
Fixing resolve version for maven with multiple properties

### DIFF
--- a/pkg/lockfile/fixtures/maven/multiple-version-variables.xml
+++ b/pkg/lockfile/fixtures/maven/multiple-version-variables.xml
@@ -1,0 +1,15 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+    <revision>1.0.0</revision>
+    <changelist>-SNAPSHOT</changelist>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>${revision}${changelist}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -28,34 +28,32 @@ func (mld MavenLockDependency) parseResolvedVersion(version string) string {
 	return results[1]
 }
 
+/*
+You can see the regex working here : https://regex101.com/r/inAPiN/2
+*/
 func (mld MavenLockDependency) resolveVersionValue(lockfile MavenLockFile) string {
-	interpolationReg := cachedregexp.MustCompile(`\${(.+)}`)
-
-	results := interpolationReg.FindStringSubmatch(mld.Version)
-
-	// no interpolation, so just return the version as-is
-	if results == nil {
-		return mld.Version
-	}
-	if val, ok := lockfile.Properties.m[results[1]]; ok {
-		return val
-	}
-
-	fmt.Fprintf(
-		os.Stderr,
-		"Failed to resolve version of %s: property \"%s\" could not be found for \"%s\"\n",
-		mld.GroupID+":"+mld.ArtifactID,
-		results[1],
-		lockfile.GroupID+":"+lockfile.ArtifactID,
-	)
-
-	return "0"
+	interpolationReg := cachedregexp.MustCompile(`\${([^}]+)}`)
+	result := interpolationReg.ReplaceAllFunc([]byte(mld.Version), func(bytes []byte) []byte {
+		propStr := string(bytes)
+		propName := propStr[2 : len(propStr)-1]
+		property, ok := lockfile.Properties.m[propName]
+		if !ok {
+			fmt.Fprintf(
+				os.Stderr,
+				"Failed to resolve version of %s: property \"%s\" could not be found for \"%s\"\n",
+				mld.GroupID+":"+mld.ArtifactID,
+				string(bytes),
+				lockfile.GroupID+":"+lockfile.ArtifactID,
+			)
+			return []byte("0")
+		}
+		return []byte(mld.parseResolvedVersion(property))
+	})
+	return mld.parseResolvedVersion(string(result))
 }
 
 func (mld MavenLockDependency) ResolveVersion(lockfile MavenLockFile) string {
-	version := mld.resolveVersionValue(lockfile)
-
-	return mld.parseResolvedVersion(version)
+	return mld.resolveVersionValue(lockfile)
 }
 
 type MavenLockFile struct {

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -117,6 +117,24 @@ func TestParseMavenLock_OnePackage(t *testing.T) {
 	})
 }
 
+func TestParseMavenLock_OnePackageWithMultipleVersionVariable(t *testing.T) {
+	t.Parallel()
+	lockfileRelativePath := "fixtures/maven/multiple-version-variables.xml"
+	packages, err := lockfile.ParseMavenLock(lockfileRelativePath)
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "org.apache.maven:maven-artifact",
+			Version:   "1.0.0-SNAPSHOT",
+			Ecosystem: lockfile.MavenEcosystem,
+			CompareAs: lockfile.MavenEcosystem,
+		},
+	})
+}
+
 func TestParseMavenLock_TwoPackages(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What is this PR doing ?

- Updating the resolve function to detect and expand all variables used to define a single version (before if multiple variables was next to each others, osv scanner considered it was the same variable)