### PR TITLE
Packaging OSV-Scanner

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,6 @@
-What does this PR do?
----------------------
+## What does this PR do?
 
 - One sentence describing what we do and why
 - [JIRA link](https://datadoghq.atlassian.net/browse/<card-id>)
 
-Additional Notes
-----------------
+## Additional Notes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+What does this PR do?
+---------------------
+
+- One sentence describing what we do and why
+- [JIRA link](https://datadoghq.atlassian.net/browse/<card-id>)
+
+Additional Notes
+----------------

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,62 @@
+name: Release new version
+
+on:
+  push:
+    tags:
+      - "*" # triggers only if push new tag version, like `v0.8.4`
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+
+jobs:
+  goreleaser:
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    permissions:
+      contents: write # for goreleaser/goreleaser-action to create a GitHub release
+    runs-on: ubuntu-latest
+    env:
+      # Required for buildx on docker 19.x
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.commit }}
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: .go-version
+          check-latest: true
+      - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
+      - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+      - name: Run GoReleaser
+        id: run-goreleaser
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate subject
+        id: hash
+        env:
+          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+  provenance:
+    needs: [goreleaser]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
+    with:
+      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
+      upload-assets: true # upload to a new release
+      draft-release: true # upload to a new draft release

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -46,7 +46,7 @@ on:
         description: "Whether to upload to Security > Code Scanning"
         type: boolean
         required: false
-        default: true
+        default: false
 
 jobs:
   osv-scan:
@@ -62,7 +62,7 @@ jobs:
           name: "${{ inputs.download-artifact }}"
           path: "./"
       - name: "Run scanner"
-        uses: DataDog/osv-scanner/actions/scanner@staging
+        uses: DataDog/osv-scanner/actions/scanner@main
         with:
           scan-args: |-
             --output=results.json
@@ -70,7 +70,7 @@ jobs:
             ${{ inputs.scan-args }}
         continue-on-error: true
       - name: "Run osv-scanner-reporter"
-        uses: DataDog/osv-scanner/actions/reporter@staging
+        uses: DataDog/osv-scanner/actions/reporter@main
         with:
           report-args: |-
             --output=${{ inputs.results-file-name }}

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -62,7 +62,7 @@ jobs:
           name: "${{ inputs.download-artifact }}"
           path: "./"
       - name: "Run scanner"
-        uses: DataDog/osv-scanner/actions/scanner@main
+        uses: DataDog/osv-scanner/.github/actions/scanner@main
         with:
           scan-args: |-
             --output=results.json
@@ -70,7 +70,7 @@ jobs:
             ${{ inputs.scan-args }}
         continue-on-error: true
       - name: "Run osv-scanner-reporter"
-        uses: DataDog/osv-scanner/actions/reporter@main
+        uses: DataDog/osv-scanner/.github/actions/reporter@main
         with:
           report-args: |-
             --output=${{ inputs.results-file-name }}

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -46,7 +46,7 @@ on:
         description: "Whether to upload to Security > Code Scanning"
         type: boolean
         required: false
-        default: false
+        default: true
 
 jobs:
   osv-scan:

--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -18,15 +18,6 @@ permissions:
   security-events: write
 
 jobs:
-  osv-scan:
-    uses: ./.github/workflows/osv-scanner-reusable.yml
-    with:
-      # Only scan the top level go.mod file without recursively scanning directories since
-      # this is pipeline is about releasing the go module and binary
-      scan-args: |-
-        --skip-git
-        ./
-
   format:
     name: prettier
     runs-on: ubuntu-latest

--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -70,7 +70,6 @@ jobs:
       - format
       - lint
       - tests
-      - osv-scan
     steps:
       - name: Print Scripts
         env:

--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -74,9 +74,9 @@ jobs:
       - name: Print Scripts
         env:
           OUTPUT: |
-            git fetch upstream &&
+            git fetch &&
             git tag ${{ inputs.version }} ${{ inputs.commit }} &&
-            git push upstream ${{ inputs.version }}
+            git push origin ${{ inputs.version }}
         shell: bash
         run: |
           echo $OUTPUT

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
       # - freebsd
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       # 32bit does not compile at the moment because of spdx dependency

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ builds:
     main: ./cmd/osv-scanner/
 
 archives:
-  - format: binary
+  - format: zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - -trimpath
     ldflags:
       # prettier-ignore
-      - '-s -w -X github.com/google/osv-scanner/internal/version.OSVVersion={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
+      - '-s -w -X github.com/DataDog/osv-scanner/internal/version.OSVVersion={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
     goos:
       # Further testing before supporting freebsd
       # - freebsd
@@ -27,53 +27,6 @@ builds:
       # - arm
       - arm64
     main: ./cmd/osv-scanner/
-
-dockers:
-  # Arch: amd64
-  - image_templates:
-      - "ghcr.io/google/osv-scanner:{{ .Tag }}-amd64"
-    dockerfile: goreleaser.dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.title=osv-scanner"
-      - "--label=org.opencontainers.image.description=Vulnerability scanner written in Go which uses the data provided by https://osv.dev"
-      - "--label=org.opencontainers.image.licenses=Apache License 2.0"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.name={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--label=org.opencontainers.image.url={{.GitURL}}"
-      - "--platform=linux/amd64"
-  # Arch: arm64
-  - image_templates:
-      - "ghcr.io/google/osv-scanner:{{ .Tag }}-arm64"
-    dockerfile: goreleaser.dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.title=osv-scanner"
-      - "--label=org.opencontainers.image.description=Vulnerability scanner written in Go which uses the data provided by https://osv.dev"
-      - "--label=org.opencontainers.image.licenses=Apache-2.0"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.name={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--label=org.opencontainers.image.url={{.GitURL}}"
-      - "--platform=linux/arm64"
-    goarch: arm64
-
-docker_manifests:
-  - name_template: "ghcr.io/google/osv-scanner:{{ .Tag }}"
-    image_templates:
-      - "ghcr.io/google/osv-scanner:{{ .Tag }}-amd64"
-      - "ghcr.io/google/osv-scanner:{{ .Tag }}-arm64"
-  - name_template: "ghcr.io/google/osv-scanner:latest"
-    image_templates:
-      - "ghcr.io/google/osv-scanner:{{ .Tag }}-amd64"
-      - "ghcr.io/google/osv-scanner:{{ .Tag }}-arm64"
 
 archives:
   - format: binary


### PR DESCRIPTION
What does this PR do?
---------------------

- Adding the OSV way of packaging the command line
- Adding a PR template
- Customizing config files to:
     1. Refer to the Datadog github org instead of google one
     2. Remove the generation of Docker images
- [JIRA link](https://datadoghq.atlassian.net/browse/APPSEC-18363)

Additional Notes
----------------
This PR only add workflows as the original repo handles it. In future PRs I'll create a README explaining how to use and release a new version, and also creating the LICENSE-3rdparty.csv mandatory file