### PR TITLE
📄 Adding 3rd party license file and a way to generate it

### DIFF
--- a/.copyright-overrides.yml
+++ b/.copyright-overrides.yml
@@ -282,3 +282,6 @@ github.com/pjbgf/sha1cd:
   - Copyright 2009 The Go Authors. All rights reserved.
   - Copyright 2017 Marc Stevens <marc@marc-stevens.nl>, Dan Shumow <danshu@microsoft.com>
   - Copyright 2022 Paulo Gomes <pjbgf@linux.com>
+
+deps.dev/api/v3alpha: Copyright 2023 Google LLC
+github.com/anchore/go-struct-converter: "" # At date, this repository have no copyright

--- a/.copyright-overrides.yml
+++ b/.copyright-overrides.yml
@@ -1,0 +1,284 @@
+# this file contains overrides for the automatic determination of copyright
+# implemented in tasks/licenses.py.  The table keys are the golang package name
+# or pattern, and the value is either a copyright owner or a list of owners.
+#
+# Package patterns may end with a `*`.  When multiple patterns match, the longer
+# is preferred.
+#
+# Copyright statements should reflect the copyright exactly as it is shown on
+# the original component.
+
+# NOTE: in general, we prefer to pull data from the repository so that it will
+# be updated automatically, so prefer to make such a change in
+# tasks/licenses.py if possible.  Line-wrapping can be difficult to handle, and
+# may be overridden here.
+
+# These whole classes of package names have fixed copyright
+cloud.google.com/*: Copyright 2019 Google LLC
+code.cloudfoundry.org/*: Copyright (c) 2016-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+github.com/GoogleCloudPlatform/docker-credential-gcr: Copyright 2016 Google, Inc.
+github.com/aws/aws-lambda-go: Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+github.com/aws/aws-sdk-go: ["Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.", "Copyright 2014-2015 Stripe, Inc."]
+github.com/aws/aws-sdk-go-v2: ["Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.", "Copyright 2014-2015 Stripe, Inc."]
+github.com/containerd/*: Copyright 2012-2015 Docker, Inc.
+github.com/coreos/*: Copyright 2017 CoreOS, Inc
+github.com/docker/*: Copyright 2012-2017 Docker, Inc.
+github.com/elastic/*: Copyright 2017-2018 Elasticsearch B.V.
+github.com/golang/*: Copyright (c) 2009 The Go Authors. All rights reserved.
+github.com/googleapis/*: Copyright 2017 Google Inc.
+github.com/google/go-cmp/*: Copyright (c) 2017 The Go Authors. All rights reserved.
+github.com/grpc-ecosystem/*: Copyright (c) 2015, Gengo, Inc.
+github.com/hashicorp/*: Copyright © 2014-2018 HashiCorp, Inc
+github.com/prometheus/*: Copyright 2012-2015 The Prometheus Authors
+github.com/open-telemetry/*: Copyright The OpenTelemetry Authors
+go.etcd.io/*: Copyright 2016 The etcd Authors
+google.golang.org/appengine: Copyright 2011 Google Inc. All rights reserved.
+google.golang.org/appengine/*: Copyright 2011 Google Inc. All rights reserved.
+google.golang.org/genproto: Copyright 2020 Google LLC
+google.golang.org/genproto/*: Copyright 2020 Google LLC
+go.opentelemetry.io/*: Copyright The OpenTelemetry Authors
+gopkg.in/DataDog/*: Copyright 2016-Present Datadog, Inc.
+k8s.io/*: Copyright 2014 The Kubernetes Authors.
+sigs.k8s.io/*: Copyright 2017 The Kubernetes Authors.
+contrib.go.opencensus.io/exporter/prometheus: Copyright 2020, OpenCensus Authors
+go.opencensus.io: Copyright 2018, OpenCensus Authors
+go.opencensus.io/*: Copyright 2018, OpenCensus Authors
+github.com/grpc-ecosystem/*: Copyright 2016 Michal Witkowski. All Rights Reserved.
+google.golang.org/genproto/*: Copyright 2015 Google LLC
+google.golang.org/grpc: Copyright 2014 gRPC authors.
+google.golang.org/grpc/*: Copyright 2014 gRPC authors.
+github.com/skydive-project/go-debouncer: Copyright (C) 2018 Red Hat, Inc.
+
+# NOTE: We cannot use
+#   github.com/DataDog/*: Datadog, Inc.
+# because many of those repos are forks, where DD does not own the copyright.
+
+# https://raw.githubusercontent.com/golang/go/master/LICENSE
+golang/go: Copyright (c) 2009 The Go Authors. All rights reserved.
+
+# This has old and new code licensed to two different names, with some awkward
+# line wrapping
+gopkg.in/yaml.v3: ["Copyright (c) 2006-2010 Kirill Simonov", "Copyright 2011-2016 Canonical Ltd"]
+
+# This has awkward line wrapping.
+gopkg.in/inf.v0: "Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go Authors. All rights reserved."
+
+# See https://github.com/googleapis/google-api-go-client/blob/master/AUTHORS
+google.golang.org/api/*: Copyright (c) 2011 Google Inc. All rights reserved.
+
+# See https://github.com/openshift/api/blob/master/quota/OWNERS
+github.com/openshift/api: Copyright 2020 Red Hat, Inc.
+
+# https://datadoghq.atlassian.net/browse/AC-1296
+github.com/DataDog/mmh3: Copyright (c) 2017 Datadog, Inc.
+
+# https://datadoghq.atlassian.net/browse/OTEL-345
+github.com/DataDog/opentelemetry-mapping-go: Copyright (c) 2023 Datadog, Inc.
+
+# https://github.com/briandowns/spinner/blob/master/NOTICE.txt
+github.com/briandowns/spinner: Copyright (c) 2022 Brian J. Downs
+
+# https://github.com/shibumi/go-pathspec/blob/master/GO-LICENSE
+github.com/shibumi/go-pathspec: Copyright (c) 2012 The Go Authors. All rights reserved.
+
+# https://github.com/acomagu/bufpipe/blob/master/LICENSE
+github.com/acomagu/bufpipe: Copyright (c) 2019 acomagu
+
+# For Apache projects, copyright is typically in individual source files and
+# not scanned automatically.
+github.com/tklauser/numcpus: Copyright 2018 Tobias Klauser
+github.com/Masterminds/goutils: "Copyright 2014 Alexander Okoli"
+github.com/outcaste-io/ristretto:
+  - "Copyright 2019 Dgraph Labs, Inc. and Contributors"
+  - "Copyright 2020 Dgraph Labs, Inc. and Contributors"
+  - "Copyright 2021 Dgraph Labs, Inc. and Contributors"
+  - "Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved."
+  - "Copyright (c) 2014 Andreas Briese, eduToolbox@Bri-C GmbH, Sarstedt"
+  - "Copyright (c) 2019 Ewan Chou"
+github.com/dgraph-io/ristretto:
+  - "Copyright 2019 Dgraph Labs, Inc. and Contributors"
+  - "Copyright 2020 Dgraph Labs, Inc. and Contributors"
+  - "Copyright 2020 The LevelDB-Go and Pebble Authors. All rights reserved."
+  - "Copyright (c) 2014 Andreas Briese, eduToolbox@Bri-C GmbH, Sarstedt"
+  - "Copyright (c) 2019 Ewan Chou"
+github.com/go-logr/logr: ["Copyright 2019 The logr Authors.", "Copyright 2020 The logr Authors."]
+github.com/go-logr/stdr: "Copyright 2019 The logr Authors."
+github.com/go-openapi/analysis: Copyright 2015 go-swagger maintainers
+github.com/go-openapi/errors: Copyright 2015 go-swagger maintainers
+github.com/go-openapi/jsonpointer: "Copyright 2013 sigu-399 ( https://github.com/sigu-399 )"
+github.com/go-openapi/jsonreference: "Copyright 2013 sigu-399 ( https://github.com/sigu-399 )"
+github.com/go-openapi/loads: Copyright 2015 go-swagger maintainers
+github.com/go-openapi/runtime: Copyright 2015 go-swagger maintainers
+github.com/go-openapi/spec: Copyright 2015 go-swagger maintainers
+github.com/go-openapi/strfmt: Copyright 2015 go-swagger maintainers
+github.com/go-openapi/swag: Copyright 2015 go-swagger maintainers
+github.com/go-openapi/validate: Copyright 2015 go-swagger maintainers
+github.com/google/gofuzz: Copyright 2014 Google Inc. All rights reserved.
+github.com/kubernetes-sigs/custom-metrics-apiserver: Copyright 2018 The Kubernetes Authors.
+github.com/mostynb/go-grpc-compression/snappy: Copyright 2017 gRPC authors.
+github.com/mostynb/go-grpc-compression/zstd: ["Copyright 2020 Mostyn Bramley-Moore.","Copyright 2020 Mostyn Bramley-Moore."]
+github.com/sassoftware/go-rpmutils: Copyright (c) SAS Institute Inc.
+github.com/spf13/cobra: Copyright © 2013 Steve Francia <spf@spf13.com>.
+github.com/xeipuuv/gojsonpointer: Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+github.com/xeipuuv/gojsonreference: Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+github.com/xeipuuv/gojsonschema: Copyright 2015 xeipuuv
+github.com/open-policy-agent/opa: Copyright 2016 The OPA Authors.  All rights reserved.
+github.com/containernetworking/*: Copyright 2019 CNI authors
+github.com/xanzy/ssh-agent: ["Copyright (c) 2014 David Mzareulyan", "Copyright 2015, Sander van Harmelen"]
+github.com/google/go-containerregistry:
+  - "Copyright 2018 Google LLC All Rights Reserved."
+  - "Copyright 2019 Google LLC All Rights Reserved."
+  - "Copyright 2020 Google LLC All Rights Reserved."
+  - "Copyright 2021 Google LLC All Rights Reserved."
+  - "Copyright 2022 Google LLC All Rights Reserved."
+github.com/google/go-containerregistry/internal/compression:
+  - "Copyright 2018 Google LLC All Rights Reserved."
+  - "Copyright 2019 Google LLC All Rights Reserved."
+  - "Copyright 2020 Google LLC All Rights Reserved."
+  - "Copyright 2021 Google LLC All Rights Reserved."
+  - "Copyright 2022 Google LLC All Rights Reserved."
+github.com/google/go-containerregistry/internal/zstd:
+  - "Copyright 2018 Google LLC All Rights Reserved."
+  - "Copyright 2019 Google LLC All Rights Reserved."
+  - "Copyright 2020 Google LLC All Rights Reserved."
+  - "Copyright 2021 Google LLC All Rights Reserved."
+  - "Copyright 2022 Google LLC All Rights Reserved."
+github.com/google/go-containerregistry/pkg/compression:
+  - "Copyright 2018 Google LLC All Rights Reserved."
+  - "Copyright 2019 Google LLC All Rights Reserved."
+  - "Copyright 2020 Google LLC All Rights Reserved."
+  - "Copyright 2021 Google LLC All Rights Reserved."
+  - "Copyright 2022 Google LLC All Rights Reserved."
+github.com/google/licenseclassifier/v2:
+  - "Copyright 2017 Google LLC All Rights Reserved."
+  - "Copyright 2020 Google LLC All Rights Reserved."
+github.com/dgraph-io/badger:
+  - "Copyright 2013 The LevelDB-Go Authors. All rights reserved."
+  - "Copyright 2017 Dgraph Labs, Inc. and Contributors"
+  - "Copyright 2018 Dgraph Labs, Inc. and Contributors"
+  - "Copyright 2019 Dgraph Labs, Inc. and Contributors"
+  - "Copyright 2020 Dgraph Labs, Inc. and Contributors"
+  - "Copyright 2021 Dgraph Labs, Inc. and Contributors"
+github.com/mostynb/go-grpc-compression: "Copyright 2023 Mostyn Bramley-Moore."
+github.com/stormcat24/protodep: "Copyright Akinori Yamada"
+
+# These have large AUTHORS/CONTRIBUTORS files but attribute copyright as a group
+github.com/aptly-dev/aptly: Copyright 2013-2015 aptly authors. All rights reserved.
+github.com/google/gopacket: ["Copyright (c) 2012 Google, Inc. All rights reserved.", "Copyright (c) 2009-2011 Andreas Krennmair. All rights reserved."]
+github.com/fsnotify/fsnotify: ["Copyright (c) 2012 The Go Authors. All rights reserved.","Copyright (c) 2012-2019 fsnotify Authors. All rights reserved."]
+github.com/gosnmp/gosnmp: Copyright 2012-2020 The GoSNMP Authors. All rights reserved.
+github.com/shuLhan/go-bindata: Copyright 2018 The go-bindata Authors. All rights reserved.
+github.com/lxn/walk: Copyright (c) 2010 The Walk Authors. All rights reserved.
+github.com/lxn/win: Copyright (c) 2010 The win Authors. All rights reserved.
+github.com/klauspost/compress/snappy: Copyright (c) 2011 The Snappy-Go Authors. All rights reserved.
+github.com/klauspost/compress/s2: ["Copyright (c) 2011 The Snappy-Go Authors. All rights reserved.", "Copyright (c) 2019 Klaus Post. All rights reserved."]
+github.com/golang/snappy: Copyright (c) 2011 The Snappy-Go Authors. All rights reserved.
+github.com/shirou/w32: Copyright (c) 2010-2012 The w32 Authors. All rights reserved.
+github.com/gogo/protobuf: ["Copyright (c) 2013, The GoGo Authors. All rights reserved.", "Copyright 2010 The Go Authors.  All rights reserved."]
+
+# These are just difficult to figure out, as they have no full copyright declaration.
+# The following rules are applied:
+#  * Automatic "Copyright (c)"
+#  * Year is based on the year of the first commit to the repository
+#  * Author, when known only by GitHub username, is "GitHub Full Name (github-username)"
+github.com/moby/sys/mountinfo: Copyright (c) 2014-2018 The Docker & Go Authors. All rights reserved.
+github.com/moby/sys/signal: Copyright (c) 2014-2018 The Docker & Go Authors. All rights reserved.
+github.com/modern-go/concurrent: Copyright (c) 2018 Tao Wen
+github.com/modern-go/reflect2: Copyright (c) 2018 Tao Wen
+github.com/opencontainers/selinux/*: Copyright (c) 2017 The Authors
+github.com/spf13/afero: ["Copyright © 2014 Steve Francia <spf@spf13.com>.","Copyright 2013 tsuru authors. All rights reserved."]
+github.com/vito/go-sse/sse: Copyright (c) 2014 Alex Suraci
+gomodules.xyz/jsonpatch: Copyright (c) 2015 The Authors
+github.com/bytecodealliance/wasmtime-go: Copyright (c) 2020 The Bytecode Alliance
+github.com/OneOfOne/xxhash: Copyright (c) 2014 Ahmed W. (OneOfOne)
+github.com/yashtewari/glob-intersection: Copyright (c) 2018 Yash Tewari (yashtewari)
+go.mongodb.org/mongo-driver/*: Copyright © 2018 MongoDB, Inc.
+github.com/masahiro331/go-ext4-filesystem: Copyright (c) 2021 masahiro331
+github.com/masahiro331/go-mvn-version: Copyright (c) 2020 masahiro331
+github.com/masahiro331/go-vmdk-parser: Copyright (c) 2020 masahiro331
+github.com/masahiro331/go-xfs-filesystem: Copyright (c) 2021 masahiro331
+github.com/knqyf263/go-apk-version: Copyright (c) 2020 Teppei Fukuda (knqyf263)
+github.com/aquasecurity/go-gem-version: Copyright (c) 2020 Teppei Fukuda (knqyf263)
+github.com/aquasecurity/go-npm-version: Copyright (c) 2020 Teppei Fukuda (knqyf263)
+github.com/aquasecurity/go-pep440-version: Copyright (c) 2020 Teppei Fukuda (knqyf263)
+github.com/aquasecurity/go-version: Copyright (c) 2020 Teppei Fukuda (knqyf263)
+github.com/spdx/tools-golang: Copyright (c) 2018 The Authors
+github.com/google/flatbuffers: Copyright (c) 2014 Google
+github.com/gocomply/scap: "CC0 1.0 Universal"
+
+# The Copyright information is not contained in the LICENSE file, but it can be found in other
+# files in the package, such as:
+#  * https://github.com/godror/knownpb/blob/main/timestamppb/timestamp_test.go
+#  * https://github.com/godror/knownpb/blob/main/timestamppb/timestamp.go
+#  * https://github.com/godror/knownpb/blob/main/internal/writer.go
+github.com/godror/knownpb/internal: Copyright 2014, 2021 Tamás Gulácsi
+github.com/godror/knownpb/timestamppb: Copyright 2019, 2021 Tamás Gulácsi
+
+# Copyright information is in the README
+github.com/google/gnostic/compiler: Copyright 2017-2020, Google LLC.
+github.com/google/gnostic/extensions: Copyright 2017-2020, Google LLC.
+github.com/google/gnostic/jsonschema: Copyright 2017-2020, Google LLC.
+github.com/google/gnostic/openapiv2: Copyright 2017-2020, Google LLC.
+github.com/google/gnostic/openapiv3: Copyright 2017-2020, Google LLC.
+github.com/google/s2a-go: Copyright (c) 2020 Google
+github.com/google/s2a-go/fallback: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/authinfo: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/handshaker: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/handshaker/service: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/proto/common_go_proto: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/proto/s2a_context_go_proto: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/proto/s2a_go_proto: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/proto/v2/common_go_proto: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/proto/v2/s2a_context_go_proto: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/proto/v2/s2a_go_proto: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/record: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/record/internal/aeadcrypter: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/record/internal/halfconn: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/tokenmanager: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/v2: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/v2/certverifier: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/v2/remotesigner: Copyright (c) 2020 Google
+github.com/google/s2a-go/internal/v2/tlsconfigstore: Copyright (c) 2020 Google
+github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1: Copyright 2018 New York University
+go.opentelemetry.io/otel/semconv/internal: Copyright The OpenTelemetry Authors
+go.opentelemetry.io/otel/semconv/v1.12.0: Copyright The OpenTelemetry Authors
+golang.org/x/crypto/chacha20poly1305: Copyright (c) 2009 The Go Authors. All rights reserved
+
+# Not added by inv generate-licenses but spotted by inv-e lint-licenses
+github.com/AdaLogics/go-fuzz-headers: AdamKorcz <44787359+AdamKorcz@users.noreply.github.com>|AdamKorcz <adam@adalogics.com>|Sebastiaan van Stijn <github@gone.nl>|AdaLogics <48351493+AdaLogics@users.noreply.github.com>|Kazuyoshi Kato <kato.kazuyoshi@gmail.com>
+github.com/AdamKorcz/go-118-fuzz-build/testing: AdamKorcz <adam@adalogics.com>|AdamKorcz <44787359+AdamKorcz@users.noreply.github.com>|John Howard <howardjohn@google.com>|Kazuyoshi Kato <katokazu@amazon.com>|Khaled Yakdan <yakdan@code-intelligence.de>|AdamKorcz <Adam@adalogics.com>|Sebastiaan van Stijn <thaJeztah@users.noreply.github.com>
+github.com/Microsoft/go-winio/pkg/bindfilter: Copyright (c) 2015 Microsoft
+github.com/Microsoft/go-winio/tools/mkwinsyscall: Copyright (c) 2015 Microsoft
+github.com/Microsoft/hcsshim/internal/memory: Copyright (c) 2015 Microsoft | Copyright (c) 2018 Microsoft Corp.  All rights reserved
+github.com/Microsoft/hcsshim/internal/protocol/guestrequest: Copyright (c) 2015 Microsoft | Copyright (c) 2018 Microsoft Corp.  All rights reserved
+github.com/Microsoft/hcsshim/internal/security: Copyright (c) 2015 Microsoft | Copyright (c) 2018 Microsoft Corp.  All rights reserved
+github.com/containerd/containerd/api/runtime/sandbox/v1: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/api/services/sandbox/v1: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/api/services/streaming/v1: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/api/services/transfer/v1: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/api/types/transfer: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/content/local: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/pkg/cleanup: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/pkg/epoch: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/pkg/randutil: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/pkg/streaming: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/pkg/transfer: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/pkg/transfer/proxy: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/pkg/transfer/streaming: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/pkg/unpack: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/protobuf: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/protobuf/plugin: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/protobuf/proto: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/protobuf/types: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/sandbox: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/sandbox/proxy: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/containerd/tracing: Copyright 2012-2015 Docker, Inc.
+github.com/containerd/typeurl/v2: Copyright 2012-2015 Docker, Inc.
+github.com/moby/sys/sequential: Kir Kolyshkin <kolyshkin@gmail.com>|Sebastiaan van Stijn <github@gone.nl>|Sebastiaan van Stijn <thaJeztah@users.noreply.github.com>|Tibor Vass <teabee89@gmail.com>|Brian Goff <cpuguy83@gmail.com>|John Howard <jhoward@microsoft.com>|Victor Vieux <victor.vieux@docker.com>|Michael Crosby <crosby.michael@gmail.com>|Daniel Nephin <dnephin@docker.com>|Tianon Gravi <admwiggin@gmail.com>|Vincent Batts <vbatts@redhat.com>|Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>|Michael Crosby <michael@crosbymichael.com>|Yong Tang <yong.tang.github@outlook.com>|Kir Kolyshkin <kolyshkin@users.noreply.github.com>|Christopher Jones <tophj@linux.vnet.ibm.com>|Guillaume J. Charmes <guillaume@charmes.net>|Kato Kazuyoshi <kato.kazuyoshi@gmail.com>|Manu Gupta <manugupt1@gmail.com>|Michael Crosby <crosbymichael@gmail.com>|Vincent Demeester <vincent@sbr.pm>|Aleksa Sarai <cyphar@cyphar.com>|Amit Krishnan <amit.krishnan@oracle.com>|Arnaud Porterie <arnaud.porterie@docker.com>|Brian Goff <brian.goff@microsoft.com>|Brian Goff <cpuguy@hey.com>|Dan Walsh <dwalsh@redhat.com>|Michael Crosby <michael@docker.com>|Phil Estes <estesp@gmail.com>|Shengjing Zhu <zhsj@debian.org>|Solomon Hykes <solomon@docker.com>|Tobias Klauser <tklauser@distanz.ch>|lalyos <lalyos@yahoo.com>|unclejack <unclejacksons@gmail.com>|Akihiro Suda <suda.kyoto@gmail.com>|Alexander Morozov <lk4d4@docker.com>|Jessica Frazelle <acidburn@docker.com>|Jessica Frazelle <jess@docker.com>|Jessie Frazelle <jfrazelle@users.noreply.github.com>|Justas Brazauskas <brazauskasjustas@gmail.com>|Justin Cormack <justin.cormack@docker.com>|Kazuyoshi Kato <katokazu@amazon.com>|Naveed Jamil <naveed.jamil@tenpearls.com>|Vincent Demeester <vincent.demeester@docker.com>|shuai-z <zs.broccoli@gmail.com>|Ahmet Alp Balkan <ahmetb@microsoft.com>|Aleksa Sarai <asarai@suse.com>|Alexander Larsson <alexl@redhat.com>|Alexander Morozov <lk4d4math@gmail.com>|Alexandr Morozov <lk4d4@docker.com>|Alexandr Morozov <lk4d4math@gmail.com>|Antonio Murdaca <me@runcom.ninja>|Antonio Murdaca <runcom@linux.com>|Antonio Murdaca <runcom@users.noreply.github.com>|Artem Khramov <akhramov@pm.me>|Cezar Sa Espinola <cezarsa@gmail.com>|Chen Hanxiao <chenhanxiao@cn.fujitsu.com>|Darren Stahl <darst@microsoft.com>|David Calavera <david.calavera@gmail.com>|Derek McGowan <derek@mcgstyle.net>|Eng Zer Jun <engzerjun@gmail.com>|Erik Dubbelboer <erik@dubbelboer.com>|Fabian Kramm <kramm@covexo.com>|Guillaume Dufour <gdufour.prestataire@voyages-sncf.com>|Guillaume J. Charmes <guillaume.charmes@docker.com>|Hajime Tazaki <thehajime@gmail.com>|Jamie Hannaford <jamie.hannaford@rackspace.com>|Jason A. Donenfeld <Jason@zx2c4.com>|Jhon Honce <jhonce@redhat.com>|Josh Soref <jsoref@users.noreply.github.com>|Kasper Fabæch Brandt <poizan@poizan.dk>|Kathryn Baldauf <kabaldau@microsoft.com>|Kenfe-Mickael Laventure <mickael.laventure@gmail.com>|Kirill Kolyshkin <kolyshkin@users.noreply.github.com>|Muhammad Kaisar Arkhan <hi@yukiisbo.red>|Oli <oli@overrateddev.co>|Olli Janatuinen <olli.janatuinen@gmail.com>|Paul Nasrat <pnasrat@gmail.com>|Peter Bourgon <peter@bourgon.org>|Peter Waller <peter@scraperwiki.com>|Phil Estes <estesp@linux.vnet.ibm.com>|Samuel Karp <skarp@amazon.com>|Stefan J. Wernli <swernli@microsoft.com>|Steven Hartland <steven.hartland@multiplay.co.uk>|Stig Larsson <stig@larsson.dev>|Tim Wang <timwangdev@gmail.com>|Victor Vieux <victorvieux@gmail.com>|Victor Vieux <vieux@docker.com>|Yan Feng <yanfeng2@huawei.com>|jhowardmsft <jhoward@microsoft.com>|liuxiaodong <liuxiaodong@loongson.cn>|phineas <phin@phineas.io>|unclejack <unclejack@users.noreply.github.com>|yuexiao-wang <wang.yuexiao@zte.com.cn>|谢致邦 (XIE Zhibang) <Yeking@Red54.com>
+github.com/wk8/go-ordered-map/v2: Copyright 2023 Jean Rougé <wk8.github@gmail.com>
+github.com/ebitengine/purego: Copyright 2022 The Ebitengine Authors
+
+github.com/pjbgf/sha1cd:
+  - Copyright 2009 The Go Authors. All rights reserved.
+  - Copyright 2017 Marc Stevens <marc@marc-stevens.nl>, Dan Shumow <danshu@microsoft.com>
+  - Copyright 2022 Paulo Gomes <pjbgf@linux.com>

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 **/fixtures/**
 **/fixtures-go/**
 /docs/vendor/**
+.copyright-overrides.yml
+.wwhrd.yml
+tasks/**

--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -1,0 +1,32 @@
+---
+denylist:
+  - GPL-2.0
+  - GPL-3.0
+
+allowlist:
+  - 0BSD
+  - Apache-2.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - ISC
+  - JSON
+  - MIT
+  - MPL-2.0
+  - MPL-2.0-no-copyleft-exception
+  - NewBSD
+  - FreeBSD
+
+overrides:
+  # https://github.com/bmizerany/pat/blob/master/LICENSE
+  "github.com/bmizerany/pat": MIT
+  # https://github.com/xi2/xz/blob/master/LICENSE
+  "github.com/xi2/xz": Public Domain
+  # https://github.com/acomagu/bufpipe/blob/master/LICENSE
+  "github.com/acomagu/bufpipe": MIT
+
+exceptions:
+  - "golang.org/x/mod/..."
+
+additional:
+  # list here paths to additional licenses
+  golang/go: "raw.githubusercontent.com/golang/go/master/LICENSE"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,0 +1,329 @@
+Component,Origin,License,Copyright
+core,dario.cat/mergo,BSD-3-Clause,Copyright (c) 2012 The Go Authors. All rights reserved | Copyright (c) 2013 Dario Castañé. All rights reserved
+core,deps.dev/api/v3alpha,Apache-2.0,Copyright 2023 Google LLC
+core,github.com/BurntSushi/toml,MIT,Copyright (c) 2013 TOML authors
+core,github.com/BurntSushi/toml/internal,MIT,Copyright (c) 2013 TOML authors
+core,github.com/CycloneDX/cyclonedx-go,Apache-2.0,Copyright & License | Copyright (c) OWASP Foundation | Copyright (c) OWASP Foundation. All Rights Reserved | Copyright OWASP Foundation
+core,github.com/Microsoft/go-winio,MIT,Copyright (c) 2015 Microsoft
+core,github.com/Microsoft/go-winio/internal/fs,MIT,Copyright (c) 2015 Microsoft
+core,github.com/Microsoft/go-winio/internal/socket,MIT,Copyright (c) 2015 Microsoft
+core,github.com/Microsoft/go-winio/internal/stringbuffer,MIT,Copyright (c) 2015 Microsoft
+core,github.com/Microsoft/go-winio/pkg/guid,MIT,Copyright (c) 2015 Microsoft
+core,github.com/ProtonMail/go-crypto/bitcurves,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/brainpool,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/eax,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/internal/byteutil,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/ocb,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/aes/keywrap,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/armor,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/ecdh,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/ecdsa,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/eddsa,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/elgamal,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/errors,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/internal/algorithm,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/internal/ecc,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/internal/encoding,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/packet,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ProtonMail/go-crypto/openpgp/s2k,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/anchore/go-struct-converter,Apache-2.0,
+core,github.com/cloudflare/circl/dh/x25519,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cloudflare/circl/dh/x448,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cloudflare/circl/ecc/goldilocks,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cloudflare/circl/internal/conv,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cloudflare/circl/internal/sha3,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cloudflare/circl/math,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cloudflare/circl/math/fp25519,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cloudflare/circl/math/fp448,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cloudflare/circl/math/mlsbset,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cloudflare/circl/sign,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cloudflare/circl/sign/ed25519,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cloudflare/circl/sign/ed448,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved | Copyright (c) 2019 Cloudflare. All rights reserved
+core,github.com/cpuguy83/go-md2man/v2/md2man,MIT,Copyright (c) 2014 Brian Goff
+core,github.com/cyphar/filepath-securejoin,BSD-3-Clause,Copyright (C) 2014-2015 Docker Inc & Go Authors. All rights reserved | Copyright (C) 2017 SUSE LLC. All rights reserved
+core,github.com/emirpasic/gods/containers,BSD-2-Clause,"Copyright (c) 2015, Emir Pasic | Copyright (c) 2017 Benjamin Scher Purcell <benjapurcell@gmail.com>"
+core,github.com/emirpasic/gods/lists,BSD-2-Clause,"Copyright (c) 2015, Emir Pasic | Copyright (c) 2017 Benjamin Scher Purcell <benjapurcell@gmail.com>"
+core,github.com/emirpasic/gods/lists/arraylist,BSD-2-Clause,"Copyright (c) 2015, Emir Pasic | Copyright (c) 2017 Benjamin Scher Purcell <benjapurcell@gmail.com>"
+core,github.com/emirpasic/gods/trees,BSD-2-Clause,"Copyright (c) 2015, Emir Pasic | Copyright (c) 2017 Benjamin Scher Purcell <benjapurcell@gmail.com>"
+core,github.com/emirpasic/gods/trees/binaryheap,BSD-2-Clause,"Copyright (c) 2015, Emir Pasic | Copyright (c) 2017 Benjamin Scher Purcell <benjapurcell@gmail.com>"
+core,github.com/emirpasic/gods/utils,BSD-2-Clause,"Copyright (c) 2015, Emir Pasic | Copyright (c) 2017 Benjamin Scher Purcell <benjapurcell@gmail.com>"
+core,github.com/go-git/gcfg,BSD-3-Clause,Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+core,github.com/go-git/gcfg/scanner,BSD-3-Clause,Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+core,github.com/go-git/gcfg/token,BSD-3-Clause,Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+core,github.com/go-git/gcfg/types,BSD-3-Clause,Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+core,github.com/go-git/go-billy/v5,Apache-2.0,Copyright 2017 Sourced Technologies S.L
+core,github.com/go-git/go-billy/v5/helper/chroot,Apache-2.0,Copyright 2017 Sourced Technologies S.L
+core,github.com/go-git/go-billy/v5/helper/polyfill,Apache-2.0,Copyright 2017 Sourced Technologies S.L
+core,github.com/go-git/go-billy/v5/memfs,Apache-2.0,Copyright 2017 Sourced Technologies S.L
+core,github.com/go-git/go-billy/v5/osfs,Apache-2.0,Copyright 2017 Sourced Technologies S.L
+core,github.com/go-git/go-billy/v5/util,Apache-2.0,Copyright 2017 Sourced Technologies S.L
+core,github.com/go-git/go-git/v5,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/config,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/internal/path_util,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/internal/revision,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/internal/url,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/cache,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/color,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/filemode,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/format/config,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/format/diff,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/format/gitignore,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/format/idxfile,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/format/index,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/format/objfile,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/format/packfile,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/format/pktline,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/hash,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/object,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/protocol/packp,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/protocol/packp/capability,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/protocol/packp/sideband,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/revlist,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/storer,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/transport,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/transport/client,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/transport/file,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/transport/git,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/transport/http,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/transport/internal/common,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/transport/server,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/plumbing/transport/ssh,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/storage,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/storage/filesystem,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/storage/filesystem/dotgit,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/storage/memory,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/utils/binary,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/utils/diff,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/utils/ioutil,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/utils/merkletrie,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/utils/merkletrie/filesystem,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/utils/merkletrie/index,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/utils/merkletrie/internal/frame,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/utils/merkletrie/noder,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/utils/sync,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/go-git/go-git/v5/utils/trace,Apache-2.0,"Copyright 2018 Sourced Technologies, S.L"
+core,github.com/golang/groupcache/lru,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved.
+core,github.com/golang/protobuf/jsonpb,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved.
+core,github.com/golang/protobuf/proto,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved.
+core,github.com/golang/protobuf/ptypes,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved.
+core,github.com/golang/protobuf/ptypes/any,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved.
+core,github.com/golang/protobuf/ptypes/duration,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved.
+core,github.com/golang/protobuf/ptypes/timestamp,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved.
+core,github.com/google/go-cmp/cmp,BSD-3-Clause,Copyright (c) 2017 The Go Authors. All rights reserved.
+core,github.com/google/go-cmp/cmp/internal/diff,BSD-3-Clause,Copyright (c) 2017 The Go Authors. All rights reserved.
+core,github.com/google/go-cmp/cmp/internal/flags,BSD-3-Clause,Copyright (c) 2017 The Go Authors. All rights reserved.
+core,github.com/google/go-cmp/cmp/internal/function,BSD-3-Clause,Copyright (c) 2017 The Go Authors. All rights reserved.
+core,github.com/google/go-cmp/cmp/internal/value,BSD-3-Clause,Copyright (c) 2017 The Go Authors. All rights reserved.
+core,github.com/hexops/gotextdiff,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/hexops/gotextdiff/myers,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/hexops/gotextdiff/span,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/ianlancetaylor/demangle,BSD-3-Clause,Copyright (c) 2015 The Go Authors. All rights reserved
+core,github.com/jbenet/go-context/io,MIT,Copyright (c) 2014 Juan Batiz-Benet
+core,github.com/jedib0t/go-pretty/v6/table,MIT,Copyright (c) 2018 jedib0t
+core,github.com/jedib0t/go-pretty/v6/text,MIT,Copyright (c) 2018 jedib0t
+core,github.com/kevinburke/ssh_config,MIT,"Copyright (c) 2013 - 2017 Thomas Pelletier, Eric Anderton | Copyright (c) 2017 Kevin Burke"
+core,github.com/mattn/go-runewidth,MIT,Copyright (c) 2016 Yasuhiro Matsumoto
+core,github.com/owenrumney/go-sarif/v2/sarif,Unlicense,"copyright interest in the | copyright law | copyright laws, the author or authors"
+core,github.com/package-url/packageurl-go,MIT,Copyright (c) the purl authors
+core,github.com/pandatix/go-cvss/20,MIT,Copyright (c) 2022 Lucas TESSON - PandatiX <lucastesson@protonmail.com>
+core,github.com/pandatix/go-cvss/30,MIT,Copyright (c) 2022 Lucas TESSON - PandatiX <lucastesson@protonmail.com>
+core,github.com/pandatix/go-cvss/31,MIT,Copyright (c) 2022 Lucas TESSON - PandatiX <lucastesson@protonmail.com>
+core,github.com/pandatix/go-cvss/40,MIT,Copyright (c) 2022 Lucas TESSON - PandatiX <lucastesson@protonmail.com>
+core,github.com/pjbgf/sha1cd,Apache-2.0,"Copyright 2009 The Go Authors. All rights reserved. | Copyright 2017 Marc Stevens <marc@marc-stevens.nl>, Dan Shumow <danshu@microsoft.com> | Copyright 2022 Paulo Gomes <pjbgf@linux.com>"
+core,github.com/pjbgf/sha1cd/internal,Apache-2.0,"Copyright 2009 The Go Authors. All rights reserved. | Copyright 2017 Marc Stevens <marc@marc-stevens.nl>, Dan Shumow <danshu@microsoft.com> | Copyright 2022 Paulo Gomes <pjbgf@linux.com>"
+core,github.com/pjbgf/sha1cd/ubc,Apache-2.0,"Copyright 2009 The Go Authors. All rights reserved. | Copyright 2017 Marc Stevens <marc@marc-stevens.nl>, Dan Shumow <danshu@microsoft.com> | Copyright 2022 Paulo Gomes <pjbgf@linux.com>"
+core,github.com/rivo/uniseg,MIT,Copyright (c) 2019 Oliver Kuederle
+core,github.com/russross/blackfriday/v2,BSD-2-Clause,Copyright © 2011 Russ Ross
+core,github.com/sergi/go-diff/diffmatchpatch,MIT,Copyright (c) 2012-2016 The go-diff Authors. All rights reserved | Danny Yoo <dannyyoo@google.com> | James Kolb <jkolb@google.com> | Jonathan Amsterdam <jba@google.com> | Markus Zimmermann <markus.zimmermann@nethead.at> <markus.zimmermann@symflower.com> <zimmski@gmail.com> | Matt Kovars <akaskik@gmail.com> | Osman Masood <oamasood@gmail.com> | Robert Carlsen <rwcarlsen@gmail.com> | Rory Flynn <roryflynn@users.noreply.github.com> | Sergi Mansilla <sergi.mansilla@gmail.com> | Shatrugna Sadhu <ssadhu@apcera.com> | Shawn Smith <shawnpsmith@gmail.com> | Stas Maksimov <maksimov@gmail.com> | Tor Arvid Lund <torarvid@gmail.com> | Zac Bergquist <zbergquist99@gmail.com> | Örjan Persson <orjan@spotify.com>
+core,github.com/skeema/knownhosts,Apache-2.0,Copyright 2023 Skeema LLC and the Skeema Knownhosts authors | copyright 2023 Skeema LLC and the Skeema Knownhosts authors**
+core,github.com/spdx/gordf/rdfloader,MIT,Copyright (c) 2020 SPDX
+core,github.com/spdx/gordf/rdfloader/parser,MIT,Copyright (c) 2020 SPDX
+core,github.com/spdx/gordf/rdfloader/xmlreader,MIT,Copyright (c) 2020 SPDX
+core,github.com/spdx/gordf/rdfwriter,MIT,Copyright (c) 2020 SPDX
+core,github.com/spdx/gordf/uri,MIT,Copyright (c) 2020 SPDX
+core,github.com/spdx/tools-golang/convert,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/json,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/rdf,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/common,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/common,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/v2_1,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/v2_1/tagvalue/reader,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/v2_1/tagvalue/writer,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/v2_2,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/v2_2/rdf/reader,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/v2_2/tagvalue/reader,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/v2_2/tagvalue/writer,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/v2_3,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/v2_3/rdf/reader,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/v2_3/tagvalue/reader,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/spdx/v2/v2_3/tagvalue/writer,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/tagvalue,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/spdx/tools-golang/tagvalue/reader,Apache-2.0,Copyright (c) 2018 The Authors
+core,github.com/urfave/cli/v2,MIT,Copyright (c) 2022 urfave/cli maintainers
+core,github.com/xanzy/ssh-agent,Apache-2.0,"Copyright (c) 2014 David Mzareulyan | Copyright 2015, Sander van Harmelen"
+core,github.com/xrash/smetrics,MIT,Copyright (C) 2016 Felipe da Cunha Gonçalves
+core,golang.org/x/crypto/argon2,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/blake2b,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/blowfish,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/cast5,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/chacha20,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/curve25519,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/curve25519/internal/field,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/hkdf,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/internal/alias,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/internal/poly1305,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/sha3,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/ssh,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/ssh/agent,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/ssh/internal/bcrypt_pbkdf,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/crypto/ssh/knownhosts,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/exp/maps,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/net/context,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/net/http/httpguts,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/net/http2,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/net/http2/hpack,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/net/idna,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/net/internal/socks,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/net/internal/timeseries,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/net/proxy,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/net/trace,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/sync/errgroup,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/sync/semaphore,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/sys/cpu,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/sys/execabs,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/sys/plan9,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/sys/unix,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/sys/windows,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/term,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/text/secure/bidirule,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/text/transform,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/text/unicode/bidi,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/text/unicode/norm,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/cmd/stringer,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/ast/astutil,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/buildutil,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/callgraph,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/callgraph/cha,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/callgraph/vta,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/callgraph/vta/internal/trie,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/gcexportdata,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/internal/cgo,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/internal/packagesdriver,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/loader,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/packages,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/ssa,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/ssa/ssautil,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/types/objectpath,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/go/types/typeutil,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/event,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/event/core,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/event/keys,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/event/label,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/event/tag,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/gcimporter,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/gocommand,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/packagesinternal,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/pkgbits,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/tokeninternal,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/typeparams,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/tools/internal/typesinternal,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/internal,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/internal/client,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/internal/derrors,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/internal/govulncheck,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/internal/osv,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/internal/scan,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/internal/semver,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/internal/vulncheck,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/internal/vulncheck/internal/buildinfo,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/internal/vulncheck/internal/gosym,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/internal/web,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang.org/x/vuln/scan,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved
+core,golang/go,BSD-3-Clause,Copyright (c) 2009 The Go Authors. All rights reserved.
+core,google.golang.org/genproto/googleapis/rpc/status,Apache-2.0,Copyright 2015 Google LLC
+core,google.golang.org/grpc,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/attributes,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/backoff,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/balancer,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/balancer/base,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/balancer/grpclb/state,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/balancer/roundrobin,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/binarylog/grpc_binarylog_v1,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/channelz,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/codes,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/connectivity,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/credentials,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/credentials/insecure,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/encoding,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/encoding/proto,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/grpclog,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/backoff,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/balancer/gracefulswitch,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/balancerload,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/binarylog,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/buffer,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/channelz,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/credentials,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/envconfig,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/grpclog,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/grpcrand,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/grpcsync,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/grpcutil,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/idle,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/metadata,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/pretty,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/resolver,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/resolver/dns,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/resolver/passthrough,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/resolver/unix,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/serviceconfig,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/status,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/syscall,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/transport,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/internal/transport/networktype,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/keepalive,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/metadata,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/peer,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/resolver,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/serviceconfig,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/stats,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/status,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/grpc/tap,Apache-2.0,Copyright 2014 gRPC authors.
+core,google.golang.org/protobuf/encoding/protojson,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/encoding/prototext,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/encoding/protowire,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/descfmt,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/descopts,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/detrand,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/encoding/defval,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/encoding/json,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/encoding/messageset,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/encoding/tag,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/encoding/text,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/errors,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/filedesc,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/filetype,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/flags,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/genid,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/impl,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/order,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/pragma,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/set,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/strs,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/internal/version,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/proto,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/reflect/protodesc,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/reflect/protoreflect,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/reflect/protoregistry,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/runtime/protoiface,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/runtime/protoimpl,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/types/descriptorpb,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/types/known/anypb,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/types/known/durationpb,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,google.golang.org/protobuf/types/known/timestamppb,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
+core,gopkg.in/warnings.v0,BSD-2-Clause,Copyright (c) 2016 Péter Surányi
+core,gopkg.in/yaml.v3,MIT,Copyright (c) 2006-2010 Kirill Simonov | Copyright 2011-2016 Canonical Ltd

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This section will only explain how to build the project and run the tests. If yo
 
 To build OSV-Scanner you'll need :
 
+- [Python]() 3.10 or later with the [invoke package](https://www.pyinvoke.org/installing.html) installed
 - [Go](https://golang.org/doc/install) 1.21 or later. You'll also need to set your `$GOPATH` and have `$GOPATH/bin` in your path.
 - [GoReleaser](https://goreleaser.com/) (Optional, only if you want reproducible builds)
 
@@ -64,6 +65,17 @@ To lint your code, run the following command :
 
 ```bash
 ./scripts/run_lints.sh
+```
+
+### Updating LICENSE-3rdparty.csv
+
+Whenever you need to add or upgrade a dependency, you should update the file called `LICENSE-3rdparty.csv`
+(This file represents the different license and copyrights of dependencies used in this project)
+
+To do it, please run the following command :
+
+```bash
+inv -e generate-licenses
 ```
 
 ## Documentation

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.3
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect


### PR DESCRIPTION
## What does this PR do?

- Updating configuration file to override copyright on libraries failing to automatically detecting them
- Generating the LICENSE-3rdparty.csv file
- Updating the README to add a section about LICENSE-3rd party generation

## Additional Notes
It is advised to review it commit by commit for a more comprehensive PR.

Please note everything in the commit [🔨 Adding license generation and license linting tasks from datadog-agent repository](https://github.com/DataDog/osv-scanner/commit/1ae01d916c7c828eaa0ff8d168a232762b2cc4b3) has been imported from  [datadog-agent](https://www.github.com/DataDog/datadog-agent) production branch. 