### PR TITLE
:bug: Fix DD SBOM reporter to extract name from packages without a namespace

### DIFF
--- a/pkg/reporter/purl/golang_extractor.go
+++ b/pkg/reporter/purl/golang_extractor.go
@@ -9,12 +9,14 @@ import (
 
 func ExtractPURLFromGolang(packageInfo models.PackageInfo) (namespace string, name string, ok bool) {
 	nameParts := strings.Split(packageInfo.Name, "/")
-	if len(nameParts) < 2 {
+	if len(nameParts) == 0 {
 		log.Printf("invalid golang package_name=%s", packageInfo.Name)
 		return
 	}
 	ok = true
-	namespace = strings.Join(nameParts[:len(nameParts)-1], "/")
+	if len(nameParts) > 1 {
+		namespace = strings.Join(nameParts[:len(nameParts)-1], "/")
+	}
 	name = nameParts[len(nameParts)-1]
 
 	return

--- a/pkg/reporter/purl/golang_extractor_test.go
+++ b/pkg/reporter/purl/golang_extractor_test.go
@@ -41,6 +41,19 @@ func TestGolangExtraction_shouldExtractPackages(t *testing.T) {
 			expectedNamespace: "github.com/urfave/cli",
 			expectedName:      "v2",
 		},
+		{
+			name: "when_package_uses_a_domain",
+			packageInfo: models.PackageInfo{
+				Name:      "go.opencensus.io",
+				Version:   "v0.24.0",
+				Ecosystem: string(models.EcosystemGo),
+				Commit:    "",
+				Start:     models.FilePosition{},
+				End:       models.FilePosition{},
+			},
+			expectedNamespace: "",
+			expectedName:      "go.opencensus.io",
+		},
 	}
 
 	for _, test := range testCases {
@@ -68,17 +81,6 @@ func TestGolangExtraction_shouldFilterPackages(t *testing.T) {
 		name        string
 		packageInfo models.PackageInfo
 	}{
-		{
-			name: "when_package_contains_less_than_2_parts",
-			packageInfo: models.PackageInfo{
-				Name:      "go.consensus.io",
-				Version:   "v2.26.0",
-				Ecosystem: string(models.EcosystemGo),
-				Commit:    "",
-				Start:     models.FilePosition{},
-				End:       models.FilePosition{},
-			},
-		},
 		{
 			name: "when_package_have_no_name",
 			packageInfo: models.PackageInfo{


### PR DESCRIPTION
## What does this PR do?

- golang packages expressed without a namespace (e.g. domains only package like [go.opencensus.io](https://pkg.go.dev/go.opencensus.io#section-readme)) are now reported with an empty namespace rather than being filtered.


## Additional information
**Why are we doing this :** In the [Package URL specifications](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst), namespace is defined as optional and type specific. As golang does not define it to be mandatory, we should report packages without namespace instead of filtering them
