### PR TITLE
:adhesive_bandage: Deserialising project.version to use it with on dependencies version resolving

### DIFF
--- a/pkg/lockfile/fixtures/maven/children/with-parent.xml
+++ b/pkg/lockfile/fixtures/maven/children/with-parent.xml
@@ -30,5 +30,10 @@
       <artifactId>my.package</artifactId>
       <version>${my.package.version}</version>
     </dependency>
+    <dependency>
+      <groupId>dev.foo</groupId>
+      <artifactId>bar</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/pkg/lockfile/fixtures/maven/parent.xml
+++ b/pkg/lockfile/fixtures/maven/parent.xml
@@ -5,6 +5,7 @@
     <my.package.version>2.3.4</my.package.version>
     <version-range>[9.4.35.v20201120,9.5)</version-range>
   </properties>
+  <version>1.0-SNAPSHOT</version>
 
   <dependencyManagement>
     <dependencies>

--- a/pkg/lockfile/fixtures/maven/with-project-version-property.xml
+++ b/pkg/lockfile/fixtures/maven/with-project-version-property.xml
@@ -1,0 +1,14 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+  </properties>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>dev.foo</groupId>
+      <artifactId>bar</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -13,7 +13,8 @@ import (
 	"github.com/google/osv-scanner/internal/cachedregexp"
 )
 
-const MaxParentDepth = 10
+const maxParentDepth = 10
+const projectVersionPropName = "project.version"
 
 type MavenLockDependency struct {
 	XMLName    xml.Name `xml:"dependency"`
@@ -59,7 +60,7 @@ func (mld MavenLockDependency) resolveVersionValue(lockfile MavenLockFile) strin
 		var ok bool
 
 		// If the property is the internal version property, then lets use the one declared
-		if strings.ToLower(propName) == "project.version" && len(lockfile.Version) > 0 {
+		if strings.ToLower(propName) == projectVersionPropName && len(lockfile.Version) > 0 {
 			property = lockfile.Version
 			ok = true
 		} else {
@@ -209,8 +210,8 @@ func (e MavenLockExtractor) enrichDependencies(f DepFile, dependencies []MavenLo
 
 func (e MavenLockExtractor) decodeMavenFile(f DepFile, depth int) (*MavenLockFile, error) {
 	var parsedLockfile *MavenLockFile
-	if depth >= MaxParentDepth {
-		return nil, fmt.Errorf("maven file decoding reached the max depth (%d/%d), check for a circular dependency", depth, MaxParentDepth)
+	if depth >= maxParentDepth {
+		return nil, fmt.Errorf("maven file decoding reached the max depth (%d/%d), check for a circular dependency", depth, maxParentDepth)
 	}
 	// Decoding the original lockfile and enrich its dependencies
 	err := xml.NewDecoder(f).Decode(&parsedLockfile)

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -290,8 +290,8 @@ func TestMavenLock_WithParent(t *testing.T) {
 			Version:    "3.0.2",
 			Ecosystem:  lockfile.MavenEcosystem,
 			CompareAs:  lockfile.MavenEcosystem,
-			Start:      models.FilePosition{Line: 25, Column: 5},
-			End:        models.FilePosition{Line: 28, Column: 18},
+			Start:      models.FilePosition{Line: 26, Column: 5},
+			End:        models.FilePosition{Line: 29, Column: 18},
 			SourceFile: parentPath,
 		},
 		{
@@ -328,6 +328,15 @@ func TestMavenLock_WithParent(t *testing.T) {
 			CompareAs:  lockfile.MavenEcosystem,
 			Start:      models.FilePosition{Line: 28, Column: 5},
 			End:        models.FilePosition{Line: 32, Column: 18},
+			SourceFile: childPath,
+		},
+		{
+			Name:       "dev.foo:bar",
+			Version:    "1.0-SNAPSHOT",
+			Ecosystem:  lockfile.MavenEcosystem,
+			CompareAs:  lockfile.MavenEcosystem,
+			Start:      models.FilePosition{Line: 33, Column: 5},
+			End:        models.FilePosition{Line: 37, Column: 18},
 			SourceFile: childPath,
 		},
 	})
@@ -483,8 +492,8 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			Version:    "3.0.2",
 			Ecosystem:  lockfile.MavenEcosystem,
 			CompareAs:  lockfile.MavenEcosystem,
-			Start:      models.FilePosition{Line: 25, Column: 5},
-			End:        models.FilePosition{Line: 28, Column: 18},
+			Start:      models.FilePosition{Line: 26, Column: 5},
+			End:        models.FilePosition{Line: 29, Column: 18},
 			SourceFile: rootPath,
 		},
 		{
@@ -522,6 +531,15 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			Start:      models.FilePosition{Line: 14, Column: 5},
 			End:        models.FilePosition{Line: 18, Column: 18},
 			SourceFile: childPath,
+		},
+		{
+			Name:       "dev.foo:bar",
+			Version:    "1.0-SNAPSHOT",
+			Ecosystem:  lockfile.MavenEcosystem,
+			CompareAs:  lockfile.MavenEcosystem,
+			Start:      models.FilePosition{Line: 33, Column: 5},
+			End:        models.FilePosition{Line: 37, Column: 18},
+			SourceFile: parentPath,
 		},
 	})
 }

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -713,3 +713,37 @@ func TestParseMavenLock_WithOverriddenDependencyVersions(t *testing.T) {
 		},
 	})
 }
+
+func TestParseMavenLock_WithProjectVersionProperty(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	lockfilePath := filepath.Join(dir, filepath.FromSlash("fixtures/maven/with-project-version-property.xml"))
+
+	packages, err := lockfile.ParseMavenLock(lockfilePath)
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:       "dev.foo:bar",
+			Version:    "1.0-SNAPSHOT",
+			Ecosystem:  lockfile.MavenEcosystem,
+			CompareAs:  lockfile.MavenEcosystem,
+			Commit:     "",
+			SourceFile: lockfilePath,
+			Start: models.FilePosition{
+				Line:   8,
+				Column: 5,
+			},
+			End: models.FilePosition{
+				Line:   12,
+				Column: 18,
+			},
+			DepGroups: nil,
+		},
+	})
+}


### PR DESCRIPTION
## What does this PR do?

- We now deserialise the version tag to use it during dependencies version resolution