### PR TITLE
✨ Detect line of code for Python/Pip

### DIFF
--- a/pkg/lockfile/parse-pipenv-lock.go
+++ b/pkg/lockfile/parse-pipenv-lock.go
@@ -3,11 +3,13 @@ package lockfile
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/google/osv-scanner/pkg/models"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
+
+	"github.com/google/osv-scanner/internal/cachedregexp"
+
+	"github.com/google/osv-scanner/pkg/models"
 )
 
 type PipenvPackage struct {
@@ -49,7 +51,7 @@ func (e PipenvLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	packageType := ""
 
 	for i, line := range lines {
-		startRe := regexp.MustCompile(`"(\w+)": {`)
+		startRe := cachedregexp.MustCompile(`"(\w+)": {`)
 		startMatch := startRe.FindStringSubmatch(line)
 
 		if len(startMatch) == 2 {
@@ -67,12 +69,10 @@ func (e PipenvLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 					dep := parsedLockfile.Packages[key]
 					dep.Start = models.FilePosition{Line: i + 1}
 					parsedLockfile.Packages[key] = dep
-					break
 				case "packages-dev":
 					dep := parsedLockfile.PackagesDev[key]
 					dep.Start = models.FilePosition{Line: i + 1}
 					parsedLockfile.PackagesDev[key] = dep
-					break
 				}
 			}
 		}
@@ -83,12 +83,10 @@ func (e PipenvLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 				dep := parsedLockfile.Packages[key]
 				dep.End = models.FilePosition{Line: i + 1}
 				parsedLockfile.Packages[key] = dep
-				break
 			case "packages-dev":
 				dep := parsedLockfile.PackagesDev[key]
 				dep.End = models.FilePosition{Line: i + 1}
 				parsedLockfile.PackagesDev[key] = dep
-				break
 			}
 			key = ""
 		}

--- a/pkg/lockfile/parse-pipenv-lock_test.go
+++ b/pkg/lockfile/parse-pipenv-lock_test.go
@@ -1,9 +1,10 @@
 package lockfile_test
 
 import (
-	"github.com/google/osv-scanner/pkg/models"
 	"io/fs"
 	"testing"
+
+	"github.com/google/osv-scanner/pkg/models"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
 )

--- a/pkg/lockfile/parse-pipenv-lock_test.go
+++ b/pkg/lockfile/parse-pipenv-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"github.com/google/osv-scanner/pkg/models"
 	"io/fs"
 	"testing"
 
@@ -73,7 +74,7 @@ func TestParsePipenvLock_InvalidJson(t *testing.T) {
 
 	packages, err := lockfile.ParsePipenvLock("fixtures/pipenv/not-json.txt")
 
-	expectErrContaining(t, err, "could not extract from")
+	expectErrContaining(t, err, "could not decode json from")
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
@@ -104,6 +105,8 @@ func TestParsePipenvLock_OnePackage(t *testing.T) {
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			Start:     models.FilePosition{Line: 19},
+			End:       models.FilePosition{Line: 64},
 		},
 	})
 }
@@ -123,6 +126,8 @@ func TestParsePipenvLock_OnePackageDev(t *testing.T) {
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			Start:     models.FilePosition{Line: 20},
+			End:       models.FilePosition{Line: 65},
 			DepGroups: []string{"dev"},
 		},
 	})
@@ -143,12 +148,16 @@ func TestParsePipenvLock_TwoPackages(t *testing.T) {
 			Version:   "2.1.2",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			Start:     models.FilePosition{Line: 19},
+			End:       models.FilePosition{Line: 26},
 		},
 		{
 			Name:      "markupsafe",
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			Start:     models.FilePosition{Line: 29},
+			End:       models.FilePosition{Line: 74},
 			DepGroups: []string{"dev"},
 		},
 	})
@@ -169,12 +178,16 @@ func TestParsePipenvLock_TwoPackagesAlt(t *testing.T) {
 			Version:   "2.1.2",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			Start:     models.FilePosition{Line: 19},
+			End:       models.FilePosition{Line: 26},
 		},
 		{
 			Name:      "markupsafe",
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			Start:     models.FilePosition{Line: 27},
+			End:       models.FilePosition{Line: 72},
 		},
 	})
 }
@@ -194,18 +207,24 @@ func TestParsePipenvLock_MultiplePackages(t *testing.T) {
 			Version:   "2.1.2",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			Start:     models.FilePosition{Line: 19},
+			End:       models.FilePosition{Line: 26},
 		},
 		{
 			Name:      "pluggy",
 			Version:   "1.0.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			Start:     models.FilePosition{Line: 27},
+			End:       models.FilePosition{Line: 31},
 		},
 		{
 			Name:      "pluggy",
 			Version:   "1.0.0",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			Start:     models.FilePosition{Line: 88},
+			End:       models.FilePosition{Line: 95},
 			DepGroups: []string{"dev"},
 		},
 		{
@@ -213,6 +232,8 @@ func TestParsePipenvLock_MultiplePackages(t *testing.T) {
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
+			Start:     models.FilePosition{Line: 32},
+			End:       models.FilePosition{Line: 77},
 		},
 	})
 }

--- a/pkg/lockfile/parse-requirements-txt.go
+++ b/pkg/lockfile/parse-requirements-txt.go
@@ -3,6 +3,7 @@ package lockfile
 import (
 	"bufio"
 	"fmt"
+	"github.com/google/osv-scanner/pkg/models"
 	"path/filepath"
 	"strings"
 
@@ -14,7 +15,7 @@ const PipEcosystem Ecosystem = "PyPI"
 // todo: expand this to support more things, e.g.
 //
 //	https://pip.pypa.io/en/stable/reference/requirements-file-format/#example
-func parseLine(line string) PackageDetails {
+func parseLine(path string, line string, lineNumber int, lineOffset int) PackageDetails {
 	// Remove environment markers
 	// pre https://pip.pypa.io/en/stable/reference/requirement-specifiers/#overview
 	line = strings.Split(line, ";")[0]
@@ -53,10 +54,13 @@ func parseLine(line string) PackageDetails {
 	}
 
 	return PackageDetails{
-		Name:      normalizedRequirementName(name),
-		Version:   version,
-		Ecosystem: PipEcosystem,
-		CompareAs: PipEcosystem,
+		Name:       normalizedRequirementName(name),
+		Version:    version,
+		Start:      models.FilePosition{Line: lineNumber},
+		End:        models.FilePosition{Line: lineNumber + lineOffset},
+		Ecosystem:  PipEcosystem,
+		CompareAs:  PipEcosystem,
+		SourceFile: path,
 	}
 }
 
@@ -131,13 +135,20 @@ func parseRequirementsTxt(f DepFile, requiredAlready map[string]struct{}) ([]Pac
 	}
 
 	scanner := bufio.NewScanner(f)
+	lineNumber := 0
+	lineOffset := 0
+
 	for scanner.Scan() {
+		lineNumber += lineOffset + 1
+		lineOffset = 0
+
 		line := scanner.Text()
 
 		for isLineContinuation(line) {
 			line = strings.TrimSuffix(line, "\\")
 
 			if scanner.Scan() {
+				lineOffset++
 				line += scanner.Text()
 			}
 		}
@@ -183,7 +194,7 @@ func parseRequirementsTxt(f DepFile, requiredAlready map[string]struct{}) ([]Pac
 			continue
 		}
 
-		detail := parseLine(line)
+		detail := parseLine(f.Path(), line, lineNumber, lineOffset)
 		key := detail.Name + "@" + detail.Version
 		if _, ok := packages[key]; !ok {
 			packages[key] = detail

--- a/pkg/lockfile/parse-requirements-txt.go
+++ b/pkg/lockfile/parse-requirements-txt.go
@@ -3,9 +3,10 @@ package lockfile
 import (
 	"bufio"
 	"fmt"
-	"github.com/google/osv-scanner/pkg/models"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/osv-scanner/pkg/models"
 
 	"github.com/google/osv-scanner/internal/cachedregexp"
 )

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -2,6 +2,9 @@ package lockfile_test
 
 import (
 	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/models"
@@ -97,19 +100,28 @@ func TestParseRequirementsTxt_CommentsOnly(t *testing.T) {
 func TestParseRequirementsTxt_OneRequirementUnconstrained(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/one-package-unconstrained.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/one-package-unconstrained.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "flask",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"one-package-unconstrained"},
+			Name:       "flask",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"one-package-unconstrained"},
 		},
 	})
 }
@@ -117,19 +129,28 @@ func TestParseRequirementsTxt_OneRequirementUnconstrained(t *testing.T) {
 func TestParseRequirementsTxt_OneRequirementConstrained(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/one-package-constrained.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/one-package-constrained.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "django",
-			Version:   "2.2.24",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"one-package-constrained"},
+			Name:       "django",
+			Version:    "2.2.24",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"one-package-constrained"},
 		},
 	})
 }
@@ -137,103 +158,148 @@ func TestParseRequirementsTxt_OneRequirementConstrained(t *testing.T) {
 func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/multiple-packages-constrained.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/multiple-packages-constrained.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "astroid",
-			Version:   "2.5.1",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "astroid",
+			Version:    "2.5.1",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "beautifulsoup4",
-			Version:   "4.9.3",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "beautifulsoup4",
+			Version:    "4.9.3",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 3},
+			End:        models.FilePosition{Line: 3},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "boto3",
-			Version:   "1.17.19",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "boto3",
+			Version:    "1.17.19",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 5},
+			End:        models.FilePosition{Line: 5},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "botocore",
-			Version:   "1.20.19",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "botocore",
+			Version:    "1.20.19",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 7},
+			End:        models.FilePosition{Line: 7},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "certifi",
-			Version:   "2020.12.5",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "certifi",
+			Version:    "2020.12.5",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 11},
+			End:        models.FilePosition{Line: 11},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "chardet",
-			Version:   "4.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "chardet",
+			Version:    "4.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 13},
+			End:        models.FilePosition{Line: 13},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "circus",
-			Version:   "0.17.1",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "circus",
+			Version:    "0.17.1",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 15},
+			End:        models.FilePosition{Line: 15},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "click",
-			Version:   "7.1.2",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "click",
+			Version:    "7.1.2",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 17},
+			End:        models.FilePosition{Line: 17},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "django-debug-toolbar",
-			Version:   "3.2.1",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "django-debug-toolbar",
+			Version:    "3.2.1",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 19},
+			End:        models.FilePosition{Line: 19},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "django-filter",
-			Version:   "2.4.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "django-filter",
+			Version:    "2.4.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 21},
+			End:        models.FilePosition{Line: 21},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "django-nose",
-			Version:   "1.4.7",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "django-nose",
+			Version:    "1.4.7",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 23},
+			End:        models.FilePosition{Line: 23},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "django-storages",
-			Version:   "1.11.1",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "django-storages",
+			Version:    "1.11.1",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 25},
+			End:        models.FilePosition{Line: 25},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 		{
-			Name:      "django",
-			Version:   "2.2.24",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-constrained"},
+			Name:       "django",
+			Version:    "2.2.24",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 27},
+			End:        models.FilePosition{Line: 27},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-constrained"},
 		},
 	})
 }
@@ -241,68 +307,98 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/multiple-packages-mixed.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/multiple-packages-mixed.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "flask",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "flask",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "flask-cors",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "flask-cors",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 2},
+			End:        models.FilePosition{Line: 2},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "pandas",
-			Version:   "0.23.4",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "pandas",
+			Version:    "0.23.4",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 3},
+			End:        models.FilePosition{Line: 3},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "numpy",
-			Version:   "1.16.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "numpy",
+			Version:    "1.16.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 4},
+			End:        models.FilePosition{Line: 4},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "scikit-learn",
-			Version:   "0.20.1",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "scikit-learn",
+			Version:    "0.20.1",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 5},
+			End:        models.FilePosition{Line: 5},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "sklearn",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "sklearn",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 6},
+			End:        models.FilePosition{Line: 6},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "requests",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "requests",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 7},
+			End:        models.FilePosition{Line: 7},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "gevent",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "gevent",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 8},
+			End:        models.FilePosition{Line: 8},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 	})
 }
@@ -310,82 +406,120 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/file-format-example.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/file-format-example.txt")
+	otherRelativePath := filepath.FromSlash("fixtures/pip/other-file.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
+	otherPath := path.Join(dir, otherRelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "pytest",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"file-format-example"},
+			Name:       "pytest",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 3},
+			End:        models.FilePosition{Line: 3},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"file-format-example"},
 		},
 		{
-			Name:      "pytest-cov",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"file-format-example"},
+			Name:       "pytest-cov",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 4},
+			End:        models.FilePosition{Line: 4},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"file-format-example"},
 		},
 		{
-			Name:      "beautifulsoup4",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"file-format-example"},
+			Name:       "beautifulsoup4",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 5},
+			End:        models.FilePosition{Line: 5},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"file-format-example"},
 		},
 		{
-			Name:      "docopt",
-			Version:   "0.6.1",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"file-format-example"},
+			Name:       "docopt",
+			Version:    "0.6.1",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 9},
+			End:        models.FilePosition{Line: 9},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"file-format-example"},
 		},
 		{
-			Name:      "keyring",
-			Version:   "4.1.1",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"file-format-example"},
+			Name:       "keyring",
+			Version:    "4.1.1",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 10},
+			End:        models.FilePosition{Line: 10},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"file-format-example"},
 		},
 		{
-			Name:      "coverage",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"file-format-example"},
+			Name:       "coverage",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 11},
+			End:        models.FilePosition{Line: 11},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"file-format-example"},
 		},
 		{
-			Name:      "mopidy-dirble",
-			Version:   "1.1",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"file-format-example"},
+			Name:       "mopidy-dirble",
+			Version:    "1.1",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 12},
+			End:        models.FilePosition{Line: 12},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"file-format-example"},
 		},
 		{
-			Name:      "rejected",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"file-format-example"},
+			Name:       "rejected",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 23},
+			End:        models.FilePosition{Line: 23},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"file-format-example"},
 		},
 		{
-			Name:      "green",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"file-format-example"},
+			Name:       "green",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 24},
+			End:        models.FilePosition{Line: 24},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"file-format-example"},
 		},
 		{
-			Name:      "django",
-			Version:   "2.2.24",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"other-file"},
+			Name:       "django",
+			Version:    "2.2.24",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
+			SourceFile: filepath.FromSlash(otherPath),
+			DepGroups:  []string{"other-file"},
 		},
 	})
 }
@@ -393,19 +527,28 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 func TestParseRequirementsTxt_WithAddedSupport(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/with-added-support.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/with-added-support.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "twisted",
-			Version:   "20.3.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"with-added-support"},
+			Name:       "twisted",
+			Version:    "20.3.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"with-added-support"},
 		},
 	})
 }
@@ -413,33 +556,48 @@ func TestParseRequirementsTxt_WithAddedSupport(t *testing.T) {
 func TestParseRequirementsTxt_NonNormalizedNames(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/non-normalized-names.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/non-normalized-names.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "zope-interface",
-			Version:   "5.4.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"non-normalized-names"},
+			Name:       "zope-interface",
+			Version:    "5.4.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"non-normalized-names"},
 		},
 		{
-			Name:      "pillow",
-			Version:   "1.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"non-normalized-names"},
+			Name:       "pillow",
+			Version:    "1.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 6},
+			End:        models.FilePosition{Line: 6},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"non-normalized-names"},
 		},
 		{
-			Name:      "twisted",
-			Version:   "20.3.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"non-normalized-names"},
+			Name:       "twisted",
+			Version:    "20.3.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 8},
+			End:        models.FilePosition{Line: 8},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"non-normalized-names"},
 		},
 	})
 }
@@ -447,82 +605,122 @@ func TestParseRequirementsTxt_NonNormalizedNames(t *testing.T) {
 func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/with-multiple-r-options.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/with-multiple-r-options.txt")
+	onePackageRelativePath := filepath.FromSlash("fixtures/pip/one-package-constrained.txt")
+	multiplePackagesRelativePath := filepath.FromSlash("fixtures/pip/multiple-packages-mixed.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
+	onePackagePath := path.Join(dir, onePackageRelativePath)
+	multiplePackagesPath := path.Join(dir, multiplePackagesRelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "flask",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "flask",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
+			SourceFile: filepath.FromSlash(multiplePackagesPath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "flask-cors",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "flask-cors",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 2},
+			End:        models.FilePosition{Line: 2},
+			SourceFile: filepath.FromSlash(multiplePackagesPath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "pandas",
-			Version:   "0.23.4",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed", "with-multiple-r-options"},
+			Name:       "pandas",
+			Version:    "0.23.4",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 3},
+			End:        models.FilePosition{Line: 3},
+			SourceFile: filepath.FromSlash(multiplePackagesPath),
+			DepGroups:  []string{"multiple-packages-mixed", "with-multiple-r-options"},
 		},
 		{
-			Name:      "numpy",
-			Version:   "1.16.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "numpy",
+			Version:    "1.16.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 4},
+			End:        models.FilePosition{Line: 4},
+			SourceFile: filepath.FromSlash(multiplePackagesPath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "scikit-learn",
-			Version:   "0.20.1",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "scikit-learn",
+			Version:    "0.20.1",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 5},
+			End:        models.FilePosition{Line: 5},
+			SourceFile: filepath.FromSlash(multiplePackagesPath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "sklearn",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "sklearn",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 6},
+			End:        models.FilePosition{Line: 6},
+			SourceFile: filepath.FromSlash(multiplePackagesPath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "requests",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "requests",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 7},
+			End:        models.FilePosition{Line: 7},
+			SourceFile: filepath.FromSlash(multiplePackagesPath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "gevent",
-			Version:   "0.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"multiple-packages-mixed"},
+			Name:       "gevent",
+			Version:    "0.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 8},
+			End:        models.FilePosition{Line: 8},
+			SourceFile: filepath.FromSlash(multiplePackagesPath),
+			DepGroups:  []string{"multiple-packages-mixed"},
 		},
 		{
-			Name:      "requests",
-			Version:   "1.2.3",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"with-multiple-r-options"},
+			Name:       "requests",
+			Version:    "1.2.3",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 4},
+			End:        models.FilePosition{Line: 4},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"with-multiple-r-options"},
 		},
 		{
-			Name:      "django",
-			Version:   "2.2.24",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"one-package-constrained"},
+			Name:       "django",
+			Version:    "2.2.24",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
+			SourceFile: filepath.FromSlash(onePackagePath),
+			DepGroups:  []string{"one-package-constrained"},
 		},
 	})
 }
@@ -539,7 +737,21 @@ func TestParseRequirementsTxt_WithBadROption(t *testing.T) {
 func TestParseRequirementsTxt_DuplicateROptions(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/duplicate-r-dev.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/duplicate-r-dev.txt")
+	baseRelativePath := filepath.FromSlash("fixtures/pip/duplicate-r-base.txt")
+	testRelativePath := filepath.FromSlash("fixtures/pip/duplicate-r-test.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
+	basePath := path.Join(dir, baseRelativePath)
+	testPath := path.Join(dir, testRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
@@ -547,32 +759,44 @@ func TestParseRequirementsTxt_DuplicateROptions(t *testing.T) {
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "django",
-			Version:   "0.1.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"duplicate-r-base"},
+			Name:       "django",
+			Version:    "0.1.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
+			SourceFile: filepath.FromSlash(basePath),
+			DepGroups:  []string{"duplicate-r-base"},
 		},
 		{
-			Name:      "pandas",
-			Version:   "0.23.4",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"duplicate-r-dev"},
+			Name:       "pandas",
+			Version:    "0.23.4",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 4},
+			End:        models.FilePosition{Line: 4},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"duplicate-r-dev"},
 		},
 		{
-			Name:      "requests",
-			Version:   "1.2.3",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"duplicate-r-test", "duplicate-r-dev"},
+			Name:       "requests",
+			Version:    "1.2.3",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 3},
+			End:        models.FilePosition{Line: 3},
+			SourceFile: filepath.FromSlash(testPath),
+			DepGroups:  []string{"duplicate-r-test", "duplicate-r-dev"},
 		},
 		{
-			Name:      "unittest",
-			Version:   "1.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"duplicate-r-test"},
+			Name:       "unittest",
+			Version:    "1.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 4},
+			End:        models.FilePosition{Line: 4},
+			SourceFile: filepath.FromSlash(testPath),
+			DepGroups:  []string{"duplicate-r-test"},
 		},
 	})
 }
@@ -580,26 +804,38 @@ func TestParseRequirementsTxt_DuplicateROptions(t *testing.T) {
 func TestParseRequirementsTxt_CyclicRSelf(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/cyclic-r-self.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/cyclic-r-self.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "pandas",
-			Version:   "0.23.4",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"cyclic-r-self"},
+			Name:       "pandas",
+			Version:    "0.23.4",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 4},
+			End:        models.FilePosition{Line: 4},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"cyclic-r-self"},
 		},
 		{
-			Name:      "requests",
-			Version:   "1.2.3",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"cyclic-r-self"},
+			Name:       "requests",
+			Version:    "1.2.3",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 3},
+			End:        models.FilePosition{Line: 3},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"cyclic-r-self"},
 		},
 	})
 }
@@ -607,33 +843,52 @@ func TestParseRequirementsTxt_CyclicRSelf(t *testing.T) {
 func TestParseRequirementsTxt_CyclicRComplex(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/cyclic-r-complex-1.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/cyclic-r-complex-1.txt")
+	cyclic2RelativePath := filepath.FromSlash("fixtures/pip/cyclic-r-complex-2.txt")
+	cyclic3RelativePath := filepath.FromSlash("fixtures/pip/cyclic-r-complex-3.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
+	cyclic2Path := path.Join(dir, cyclic2RelativePath)
+	cyclic3Path := path.Join(dir, cyclic3RelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "cyclic-r-complex",
-			Version:   "1",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"cyclic-r-complex-1"},
+			Name:       "cyclic-r-complex",
+			Version:    "1",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 3},
+			End:        models.FilePosition{Line: 3},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"cyclic-r-complex-1"},
 		},
 		{
-			Name:      "cyclic-r-complex",
-			Version:   "2",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"cyclic-r-complex-2"},
+			Name:       "cyclic-r-complex",
+			Version:    "2",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 4},
+			End:        models.FilePosition{Line: 4},
+			SourceFile: filepath.FromSlash(cyclic2Path),
+			DepGroups:  []string{"cyclic-r-complex-2"},
 		},
 		{
-			Name:      "cyclic-r-complex",
-			Version:   "3",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"cyclic-r-complex-3"},
+			Name:       "cyclic-r-complex",
+			Version:    "3",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 4},
+			End:        models.FilePosition{Line: 4},
+			SourceFile: filepath.FromSlash(cyclic3Path),
+			DepGroups:  []string{"cyclic-r-complex-3"},
 		},
 	})
 }
@@ -641,40 +896,58 @@ func TestParseRequirementsTxt_CyclicRComplex(t *testing.T) {
 func TestParseRequirementsTxt_WithPerRequirementOptions(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/with-per-requirement-options.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/with-per-requirement-options.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "boto3",
-			Version:   "1.26.121",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"with-per-requirement-options"},
+			Name:       "boto3",
+			Version:    "1.26.121",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"with-per-requirement-options"},
 		},
 		{
-			Name:      "foo",
-			Version:   "1.0.0",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"with-per-requirement-options"},
+			Name:       "foo",
+			Version:    "1.0.0",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 2},
+			End:        models.FilePosition{Line: 2},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"with-per-requirement-options"},
 		},
 		{
-			Name:      "fooproject",
-			Version:   "1.2",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"with-per-requirement-options"},
+			Name:       "fooproject",
+			Version:    "1.2",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 6},
+			End:        models.FilePosition{Line: 8},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"with-per-requirement-options"},
 		},
 		{
-			Name:      "barproject",
-			Version:   "1.2",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"with-per-requirement-options"},
+			Name:       "barproject",
+			Version:    "1.2",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 12},
+			End:        models.FilePosition{Line: 12},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"with-per-requirement-options"},
 		},
 	})
 }
@@ -682,40 +955,58 @@ func TestParseRequirementsTxt_WithPerRequirementOptions(t *testing.T) {
 func TestParseRequirementsTxt_LineContinuation(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/line-continuation.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/line-continuation.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "foo",
-			Version:   "1.2.3",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"line-continuation"},
+			Name:       "foo",
+			Version:    "1.2.3",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 2},
+			End:        models.FilePosition{Line: 6},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"line-continuation"},
 		},
 		{
-			Name:      "bar",
-			Version:   "4.5\\\\",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"line-continuation"},
+			Name:       "bar",
+			Version:    "4.5\\\\",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 9},
+			End:        models.FilePosition{Line: 9},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"line-continuation"},
 		},
 		{
-			Name:      "baz",
-			Version:   "7.8.9",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"line-continuation"},
+			Name:       "baz",
+			Version:    "7.8.9",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 13},
+			End:        models.FilePosition{Line: 14},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"line-continuation"},
 		},
 		{
-			Name:      "qux",
-			Version:   "10.11.12",
-			Ecosystem: lockfile.PipEcosystem,
-			CompareAs: lockfile.PipEcosystem,
-			DepGroups: []string{"line-continuation"},
+			Name:       "qux",
+			Version:    "10.11.12",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Start:      models.FilePosition{Line: 17},
+			End:        models.FilePosition{Line: 17},
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"line-continuation"},
 		},
 	})
 }
@@ -723,7 +1014,17 @@ func TestParseRequirementsTxt_LineContinuation(t *testing.T) {
 func TestParseRequirementsTxt_EnvironmentMarkers(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/environment-markers.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/environment-markers.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
@@ -735,10 +1036,10 @@ func TestParseRequirementsTxt_EnvironmentMarkers(t *testing.T) {
 			Version:    "0.0.0",
 			Ecosystem:  lockfile.PipEcosystem,
 			CompareAs:  lockfile.PipEcosystem,
-			Start:      models.FilePosition{Line: 0},
-			End:        models.FilePosition{Line: 0},
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
 			Commit:     "",
-			SourceFile: "",
+			SourceFile: filepath.FromSlash(sourcePath),
 			DepGroups:  []string{"environment-markers"},
 		},
 		{
@@ -746,10 +1047,10 @@ func TestParseRequirementsTxt_EnvironmentMarkers(t *testing.T) {
 			Version:    "0.0.0",
 			Ecosystem:  lockfile.PipEcosystem,
 			CompareAs:  lockfile.PipEcosystem,
-			Start:      models.FilePosition{Line: 0},
-			End:        models.FilePosition{Line: 0},
+			Start:      models.FilePosition{Line: 2},
+			End:        models.FilePosition{Line: 2},
 			Commit:     "",
-			SourceFile: "",
+			SourceFile: filepath.FromSlash(sourcePath),
 			DepGroups:  []string{"environment-markers"},
 		},
 		{
@@ -757,10 +1058,10 @@ func TestParseRequirementsTxt_EnvironmentMarkers(t *testing.T) {
 			Version:    "5.4",
 			Ecosystem:  lockfile.PipEcosystem,
 			CompareAs:  lockfile.PipEcosystem,
-			Start:      models.FilePosition{Line: 0},
-			End:        models.FilePosition{Line: 0},
+			Start:      models.FilePosition{Line: 3},
+			End:        models.FilePosition{Line: 3},
 			Commit:     "",
-			SourceFile: "",
+			SourceFile: filepath.FromSlash(sourcePath),
 			DepGroups:  []string{"environment-markers"},
 		},
 	})
@@ -769,7 +1070,17 @@ func TestParseRequirementsTxt_EnvironmentMarkers(t *testing.T) {
 func TestParseRequirementsTxt_UrlPackages(t *testing.T) {
 	t.Parallel()
 
-	packages, err := lockfile.ParseRequirementsTxt("fixtures/pip/url-packages.txt")
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/url-packages.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
@@ -780,10 +1091,10 @@ func TestParseRequirementsTxt_UrlPackages(t *testing.T) {
 			Version:    "0.0.0",
 			Ecosystem:  lockfile.PipEcosystem,
 			CompareAs:  lockfile.PipEcosystem,
-			Start:      models.FilePosition{Line: 0},
-			End:        models.FilePosition{Line: 0},
+			Start:      models.FilePosition{Line: 1},
+			End:        models.FilePosition{Line: 1},
 			Commit:     "",
-			SourceFile: "",
+			SourceFile: filepath.FromSlash(sourcePath),
 			DepGroups:  []string{"url-packages"},
 		},
 	})


### PR DESCRIPTION
## What does this PR do?

### `Requirements.txt`
- Include Start/End line for r`equirements.txt` lock files
- Fix `location_file` for -r packages (before, the `location_file` was always the main file for all the dependencies)
- Update unit tests for both line location and source file

### `Pipenv.lock`
- Include Start/End line for `Pipenv.lock` lock files
- Update unit tests for line location

## Aditional Notes
- `Pipenv.lock` line location is enough right now, but ideally we should be reporting the line location of the file where the developer defines the dependencies, not of the lock file
- `Pipenv.lock` line location logic could be reused for other lock files: all of those that use `JSON` lock files
- For `requirements.txt`, no comments at all are included for the line location. Some of those would be interesting to be included in the future.