### PR TITLE
✨ Detect line of code for Javascript/npm

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -725,7 +725,7 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 			wantExitCode: 127,
 			wantStdout:   "",
 			wantStderr: `
-				(extracting as package-lock.json) could not extract from <rootdir>/fixtures/locks-many/yarn.lock: invalid character '#' looking for beginning of value
+				(extracting as package-lock.json) could not decode json from <rootdir>/fixtures/locks-many/yarn.lock: invalid character '#' looking for beginning of value
 			`,
 		},
 		// "apk-installed" is supported
@@ -1267,10 +1267,10 @@ Filtered 2 vulnerabilities from output
 									"version": "6.23.0",
 									"ecosystem": "npm",
 									"start": {
-										"line": 0
+										"line": 13
 									},
 									"end": {
-										"line": 0
+										"line": 23
 									}
 								},
 								"licenses": [
@@ -1283,10 +1283,10 @@ Filtered 2 vulnerabilities from output
 									"version": "5.0.0",
 									"ecosystem": "npm",
 									"start": {
-										"line": 0
+										"line": 24
 									},
 									"end": {
-										"line": 0
+										"line": 31
 									}
 								},
 								"licenses": [
@@ -1302,10 +1302,10 @@ Filtered 2 vulnerabilities from output
 									"version": "2.1.3",
 									"ecosystem": "npm",
 									"start": {
-										"line": 0
+										"line": 32
 									},
 									"end": {
-										"line": 0
+										"line": 36
 									}
 								},
 								"licenses": [
@@ -1349,10 +1349,10 @@ Filtered 2 vulnerabilities from output
 									"version": "5.0.0",
 									"ecosystem": "npm",
 									"start": {
-										"line": 0
+										"line": 24
 									},
 									"end": {
-										"line": 0
+										"line": 31
 									}
 								},
 								"licenses": [
@@ -1399,10 +1399,10 @@ Filtered 2 vulnerabilities from output
 									"version": "6.23.0",
 									"ecosystem": "npm",
 									"start": {
-										"line": 0
+										"line": 13
 									},
 									"end": {
-										"line": 0
+										"line": 23
 									}
 								},
 								"licenses": [
@@ -1415,10 +1415,10 @@ Filtered 2 vulnerabilities from output
 									"version": "5.0.0",
 									"ecosystem": "npm",
 									"start": {
-										"line": 0
+										"line": 24
 									},
 									"end": {
-										"line": 0
+										"line": 31
 									}
 								},
 								"licenses": [
@@ -1431,10 +1431,10 @@ Filtered 2 vulnerabilities from output
 									"version": "2.1.3",
 									"ecosystem": "npm",
 									"start": {
-										"line": 0
+										"line": 32
 									},
 									"end": {
-										"line": 0
+										"line": 36
 									}
 								},
 								"licenses": [
@@ -1479,10 +1479,10 @@ Filtered 2 vulnerabilities from output
 									"version": "6.23.0",
 									"ecosystem": "npm",
 									"start": {
-										"line": 0
+										"line": 13
 									},
 									"end": {
-										"line": 0
+										"line": 23
 									}
 								},
 								"licenses": [
@@ -1495,10 +1495,10 @@ Filtered 2 vulnerabilities from output
 									"version": "5.0.0",
 									"ecosystem": "npm",
 									"start": {
-										"line": 0
+										"line": 24
 									},
 									"end": {
-										"line": 0
+										"line": 31
 									}
 								},
 								"licenses": [
@@ -1511,10 +1511,10 @@ Filtered 2 vulnerabilities from output
 									"version": "2.1.3",
 									"ecosystem": "npm",
 									"start": {
-										"line": 0
+										"line": 32
 									},
 									"end": {
-										"line": 0
+										"line": 36
 									}
 								},
 								"licenses": [

--- a/internal/utility/lineposition/json.go
+++ b/internal/utility/lineposition/json.go
@@ -1,0 +1,69 @@
+package lineposition
+
+import (
+	"strings"
+
+	"github.com/google/osv-scanner/internal/cachedregexp"
+	"github.com/google/osv-scanner/pkg/models"
+)
+
+func InJSON[P models.ILinePosition](groupKey string, dependencies map[string]P, lines []string, offset int) {
+	var group, dependency string
+	var groupLevel, stack int
+	for lineNumber, line := range lines {
+		if strings.Contains(line, "{") {
+			stack++
+			keyRegexp := cachedregexp.MustCompile(`"(.+)"`)
+			match := keyRegexp.FindStringSubmatch(line)
+			if len(match) == 2 {
+				key := match[1]
+				if group != "" {
+					if stack == groupLevel+1 {
+						if dep, ok := dependencies[key]; ok {
+							// Start line of a dependency
+							dependency = key
+							dep.SetStart(models.FilePosition{Line: lineNumber + offset + 1})
+							dependencies[dependency] = dep
+						}
+					}
+				}
+				if groupKey == key {
+					if group == "" {
+						// Start line of a group
+						group = key
+						groupLevel = stack
+					} else {
+						if dep, ok := dependencies[dependency]; ok {
+							// Nested groupKey
+							nestedDependencies := dep.GetNestedDependencies()
+							if nestedDependencies != nil {
+								// Handling nested dependencies
+								InJSON(groupKey, nestedDependencies, lines[lineNumber:], lineNumber)
+							}
+						}
+					}
+				}
+			}
+		}
+		if strings.Contains(line, "}") {
+			stack--
+			if group != "" {
+				if stack == groupLevel {
+					if dep, ok := dependencies[dependency]; ok {
+						// End line of a dependency
+						dep.SetEnd(models.FilePosition{Line: lineNumber + offset + 1})
+						dependencies[dependency] = dep
+						dependency = ""
+					}
+				} else if stack == groupLevel-1 {
+					// End line of a group
+					group = ""
+					if offset != 0 {
+						// End of nested dependencies
+						return
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -4,6 +4,8 @@ import (
 	"io/fs"
 	"testing"
 
+	"github.com/google/osv-scanner/pkg/models"
+
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
@@ -21,7 +23,7 @@ func TestParseNpmLock_v1_InvalidJson(t *testing.T) {
 
 	packages, err := lockfile.ParseNpmLock("fixtures/npm/not-json.txt")
 
-	expectErrContaining(t, err, "could not extract from")
+	expectErrContaining(t, err, "could not decode json from")
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
@@ -50,6 +52,8 @@ func TestParseNpmLock_v1_OnePackage(t *testing.T) {
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
+			Start:     models.FilePosition{Line: 5},
+			End:       models.FilePosition{Line: 9},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -69,6 +73,8 @@ func TestParseNpmLock_v1_OnePackageDev(t *testing.T) {
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
+			Start:     models.FilePosition{Line: 5},
+			End:       models.FilePosition{Line: 10},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev"},
@@ -89,12 +95,16 @@ func TestParseNpmLock_v1_TwoPackages(t *testing.T) {
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
+			Start:     models.FilePosition{Line: 5},
+			End:       models.FilePosition{Line: 9},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "supports-color",
 			Version:   "5.5.0",
+			Start:     models.FilePosition{Line: 10},
+			End:       models.FilePosition{Line: 17},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -114,12 +124,16 @@ func TestParseNpmLock_v1_ScopedPackages(t *testing.T) {
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
+			Start:     models.FilePosition{Line: 13},
+			End:       models.FilePosition{Line: 17},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "@babel/code-frame",
 			Version:   "7.0.0",
+			Start:     models.FilePosition{Line: 5},
+			End:       models.FilePosition{Line: 12},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -139,30 +153,40 @@ func TestParseNpmLock_v1_NestedDependencies(t *testing.T) {
 		{
 			Name:      "postcss",
 			Version:   "6.0.23",
+			Start:     models.FilePosition{Line: 5},
+			End:       models.FilePosition{Line: 14},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "postcss",
 			Version:   "7.0.16",
+			Start:     models.FilePosition{Line: 26},
+			End:       models.FilePosition{Line: 35},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "postcss-calc",
 			Version:   "7.0.1",
+			Start:     models.FilePosition{Line: 15},
+			End:       models.FilePosition{Line: 45},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "supports-color",
 			Version:   "6.1.0",
+			Start:     models.FilePosition{Line: 36},
+			End:       models.FilePosition{Line: 43},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "supports-color",
 			Version:   "5.5.0",
+			Start:     models.FilePosition{Line: 46},
+			End:       models.FilePosition{Line: 53},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -186,6 +210,8 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 	expectPackage(t, packages, lockfile.PackageDetails{
 		Name:      "supports-color",
 		Version:   "6.1.0",
+		Start:     models.FilePosition{Line: 21},
+		End:       models.FilePosition{Line: 28},
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
 	})
@@ -193,6 +219,8 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 	expectPackage(t, packages, lockfile.PackageDetails{
 		Name:      "supports-color",
 		Version:   "5.5.0",
+		Start:     models.FilePosition{Line: 759},
+		End:       models.FilePosition{Line: 766},
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
 	})
@@ -200,6 +228,8 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 	expectPackage(t, packages, lockfile.PackageDetails{
 		Name:      "supports-color",
 		Version:   "2.0.0",
+		Start:     models.FilePosition{Line: 64},
+		End:       models.FilePosition{Line: 68},
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
 	})
@@ -218,6 +248,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "@segment/analytics.js-integration-facebook-pixel",
 			Version:   "",
+			Start:     models.FilePosition{Line: 5},
+			End:       models.FilePosition{Line: 18},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "3b1bb80b302c2e552685dc8a029797ec832ea7c9",
@@ -225,6 +257,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "ansi-styles",
 			Version:   "1.0.0",
+			Start:     models.FilePosition{Line: 19},
+			End:       models.FilePosition{Line: 23},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -232,6 +266,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "babel-preset-php",
 			Version:   "",
+			Start:     models.FilePosition{Line: 24},
+			End:       models.FilePosition{Line: 30},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
@@ -239,6 +275,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "is-number-1",
 			Version:   "",
+			Start:     models.FilePosition{Line: 31},
+			End:       models.FilePosition{Line: 37},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -247,6 +285,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "is-number-1",
 			Version:   "",
+			Start:     models.FilePosition{Line: 75},
+			End:       models.FilePosition{Line: 81},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
@@ -255,6 +295,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "is-number-2",
 			Version:   "",
+			Start:     models.FilePosition{Line: 38},
+			End:       models.FilePosition{Line: 41},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
@@ -262,6 +304,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "is-number-2",
 			Version:   "",
+			Start:     models.FilePosition{Line: 82},
+			End:       models.FilePosition{Line: 85},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82dcc8e914dabd9305ab9ae580709a7825e824f5",
@@ -269,6 +313,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "is-number-3",
 			Version:   "",
+			Start:     models.FilePosition{Line: 42},
+			End:       models.FilePosition{Line: 46},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
@@ -277,6 +323,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "is-number-3",
 			Version:   "",
+			Start:     models.FilePosition{Line: 86},
+			End:       models.FilePosition{Line: 90},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
@@ -285,6 +333,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "is-number-4",
 			Version:   "",
+			Start:     models.FilePosition{Line: 47},
+			End:       models.FilePosition{Line: 54},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -293,6 +343,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "is-number-5",
 			Version:   "",
+			Start:     models.FilePosition{Line: 55},
+			End:       models.FilePosition{Line: 62},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -301,6 +353,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "is-number-6",
 			Version:   "",
+			Start:     models.FilePosition{Line: 63},
+			End:       models.FilePosition{Line: 69},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -309,6 +363,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "postcss-calc",
 			Version:   "7.0.1",
+			Start:     models.FilePosition{Line: 70},
+			End:       models.FilePosition{Line: 92},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -316,6 +372,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "raven-js",
 			Version:   "",
+			Start:     models.FilePosition{Line: 93},
+			End:       models.FilePosition{Line: 96},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c2b377e7a254264fd4a1fe328e4e3cfc9e245570",
@@ -323,6 +381,8 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:      "slick-carousel",
 			Version:   "",
+			Start:     models.FilePosition{Line: 97},
+			End:       models.FilePosition{Line: 101},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "280b560161b751ba226d50c7db1e0a14a78c2de0",
@@ -344,6 +404,8 @@ func TestParseNpmLock_v1_Files(t *testing.T) {
 		{
 			Name:      "lodash",
 			Version:   "1.3.1",
+			Start:     models.FilePosition{Line: 5},
+			End:       models.FilePosition{Line: 9},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -351,6 +413,8 @@ func TestParseNpmLock_v1_Files(t *testing.T) {
 		{
 			Name:      "other_package",
 			Version:   "",
+			Start:     models.FilePosition{Line: 10},
+			End:       models.FilePosition{Line: 15},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -371,18 +435,24 @@ func TestParseNpmLock_v1_Alias(t *testing.T) {
 		{
 			Name:      "@babel/code-frame",
 			Version:   "7.0.0",
+			Start:     models.FilePosition{Line: 5},
+			End:       models.FilePosition{Line: 12},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "string-width",
 			Version:   "4.2.0",
+			Start:     models.FilePosition{Line: 23},
+			End:       models.FilePosition{Line: 32},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "string-width",
 			Version:   "5.1.2",
+			Start:     models.FilePosition{Line: 13},
+			End:       models.FilePosition{Line: 22},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -402,6 +472,8 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
+			Start:     models.FilePosition{Line: 5},
+			End:       models.FilePosition{Line: 11},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev", "optional"},
@@ -409,6 +481,8 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 		{
 			Name:      "supports-color",
 			Version:   "5.5.0",
+			Start:     models.FilePosition{Line: 12},
+			End:       models.FilePosition{Line: 20},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"optional"},

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -4,6 +4,8 @@ import (
 	"io/fs"
 	"testing"
 
+	"github.com/google/osv-scanner/pkg/models"
+
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
@@ -21,7 +23,7 @@ func TestParseNpmLock_v2_InvalidJson(t *testing.T) {
 
 	packages, err := lockfile.ParseNpmLock("fixtures/npm/not-json.txt")
 
-	expectErrContaining(t, err, "could not extract from")
+	expectErrContaining(t, err, "could not decode json from")
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
@@ -50,6 +52,8 @@ func TestParseNpmLock_v2_OnePackage(t *testing.T) {
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
+			Start:     models.FilePosition{Line: 10},
+			End:       models.FilePosition{Line: 14},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -69,6 +73,8 @@ func TestParseNpmLock_v2_OnePackageDev(t *testing.T) {
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
+			Start:     models.FilePosition{Line: 10},
+			End:       models.FilePosition{Line: 15},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev"},
@@ -89,12 +95,16 @@ func TestParseNpmLock_v2_TwoPackages(t *testing.T) {
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
+			Start:     models.FilePosition{Line: 13},
+			End:       models.FilePosition{Line: 17},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "supports-color",
 			Version:   "5.5.0",
+			Start:     models.FilePosition{Line: 18},
+			End:       models.FilePosition{Line: 28},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -114,12 +124,16 @@ func TestParseNpmLock_v2_ScopedPackages(t *testing.T) {
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
+			Start:     models.FilePosition{Line: 18},
+			End:       models.FilePosition{Line: 22},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "@babel/code-frame",
 			Version:   "7.0.0",
+			Start:     models.FilePosition{Line: 10},
+			End:       models.FilePosition{Line: 17},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -139,30 +153,40 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 		{
 			Name:      "postcss",
 			Version:   "6.0.23",
+			Start:     models.FilePosition{Line: 10},
+			End:       models.FilePosition{Line: 22},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "postcss",
 			Version:   "7.0.16",
+			Start:     models.FilePosition{Line: 34},
+			End:       models.FilePosition{Line: 46},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "postcss-calc",
 			Version:   "7.0.1",
+			Start:     models.FilePosition{Line: 23},
+			End:       models.FilePosition{Line: 33},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "supports-color",
 			Version:   "6.1.0",
+			Start:     models.FilePosition{Line: 47},
+			End:       models.FilePosition{Line: 57},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "supports-color",
 			Version:   "5.5.0",
+			Start:     models.FilePosition{Line: 58},
+			End:       models.FilePosition{Line: 68},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -182,12 +206,16 @@ func TestParseNpmLock_v2_NestedDependenciesDup(t *testing.T) {
 		{
 			Name:      "supports-color",
 			Version:   "6.1.0",
+			Start:     models.FilePosition{Line: 10},
+			End:       models.FilePosition{Line: 20},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "supports-color",
 			Version:   "2.0.0",
+			Start:     models.FilePosition{Line: 32},
+			End:       models.FilePosition{Line: 39},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -207,6 +235,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "@segment/analytics.js-integration-facebook-pixel",
 			Version:   "2.4.1",
+			Start:     models.FilePosition{Line: 26},
+			End:       models.FilePosition{Line: 41},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "3b1bb80b302c2e552685dc8a029797ec832ea7c9",
@@ -214,6 +244,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "ansi-styles",
 			Version:   "1.0.0",
+			Start:     models.FilePosition{Line: 42},
+			End:       models.FilePosition{Line: 49},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -221,6 +253,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "babel-preset-php",
 			Version:   "1.1.1",
+			Start:     models.FilePosition{Line: 50},
+			End:       models.FilePosition{Line: 59},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
@@ -229,6 +263,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "is-number-1",
 			Version:   "3.0.0",
+			Start:     models.FilePosition{Line: 60},
+			End:       models.FilePosition{Line: 72},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -237,6 +273,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "is-number-1",
 			Version:   "3.0.0",
+			Start:     models.FilePosition{Line: 130},
+			End:       models.FilePosition{Line: 142},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
@@ -245,6 +283,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "is-number-2",
 			Version:   "2.0.0",
+			Start:     models.FilePosition{Line: 73},
+			End:       models.FilePosition{Line: 82},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
@@ -253,6 +293,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "is-number-2",
 			Version:   "2.0.0",
+			Start:     models.FilePosition{Line: 143},
+			End:       models.FilePosition{Line: 152},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82dcc8e914dabd9305ab9ae580709a7825e824f5",
@@ -261,6 +303,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "is-number-3",
 			Version:   "2.0.0",
+			Start:     models.FilePosition{Line: 83},
+			End:       models.FilePosition{Line: 92},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
@@ -271,12 +315,16 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Version:   "3.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			Start:     models.FilePosition{Line: 153},
+			End:       models.FilePosition{Line: 162},
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
 			DepGroups: []string{"dev"},
 		},
 		{
 			Name:      "is-number-4",
 			Version:   "3.0.0",
+			Start:     models.FilePosition{Line: 93},
+			End:       models.FilePosition{Line: 105},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -285,6 +333,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "is-number-5",
 			Version:   "3.0.0",
+			Start:     models.FilePosition{Line: 106},
+			End:       models.FilePosition{Line: 118},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -293,6 +343,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "postcss-calc",
 			Version:   "7.0.1",
+			Start:     models.FilePosition{Line: 119},
+			End:       models.FilePosition{Line: 129},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -300,6 +352,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "raven-js",
 			Version:   "",
+			Start:     models.FilePosition{Line: 163},
+			End:       models.FilePosition{Line: 165},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c2b377e7a254264fd4a1fe328e4e3cfc9e245570",
@@ -307,6 +361,8 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		{
 			Name:      "slick-carousel",
 			Version:   "1.7.1",
+			Start:     models.FilePosition{Line: 166},
+			End:       models.FilePosition{Line: 175},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "280b560161b751ba226d50c7db1e0a14a78c2de0",
@@ -328,6 +384,8 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 		{
 			Name:      "etag",
 			Version:   "1.8.0",
+			Start:     models.FilePosition{Line: 16},
+			End:       models.FilePosition{Line: 35},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -336,6 +394,8 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 		{
 			Name:      "abbrev",
 			Version:   "1.0.9",
+			Start:     models.FilePosition{Line: 36},
+			End:       models.FilePosition{Line: 41},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -344,6 +404,8 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 		{
 			Name:      "abbrev",
 			Version:   "2.3.4",
+			Start:     models.FilePosition{Line: 42},
+			End:       models.FilePosition{Line: 47},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -365,18 +427,24 @@ func TestParseNpmLock_v2_Alias(t *testing.T) {
 		{
 			Name:      "@babel/code-frame",
 			Version:   "7.0.0",
+			Start:     models.FilePosition{Line: 13},
+			End:       models.FilePosition{Line: 21},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "string-width",
 			Version:   "4.2.0",
+			Start:     models.FilePosition{Line: 32},
+			End:       models.FilePosition{Line: 42},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:      "string-width",
 			Version:   "5.1.2",
+			Start:     models.FilePosition{Line: 22},
+			End:       models.FilePosition{Line: 31},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -396,6 +464,8 @@ func TestParseNpmLock_v2_OptionalPackage(t *testing.T) {
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
+			Start:     models.FilePosition{Line: 10},
+			End:       models.FilePosition{Line: 15},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"optional"},
@@ -403,6 +473,8 @@ func TestParseNpmLock_v2_OptionalPackage(t *testing.T) {
 		{
 			Name:      "supports-color",
 			Version:   "5.5.0",
+			Start:     models.FilePosition{Line: 16},
+			End:       models.FilePosition{Line: 27},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev", "optional"},

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -3,18 +3,35 @@ package lockfile
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
+
+	"github.com/google/osv-scanner/internal/utility/lineposition"
+	"github.com/google/osv-scanner/pkg/models"
 )
 
 type NpmLockDependency struct {
 	// For an aliased package, Version is like "npm:[name]@[version]"
-	Version      string                       `json:"version"`
-	Dependencies map[string]NpmLockDependency `json:"dependencies,omitempty"`
+	Version      string                        `json:"version"`
+	Dependencies map[string]*NpmLockDependency `json:"dependencies,omitempty"`
 
 	Dev      bool `json:"dev,omitempty"`
 	Optional bool `json:"optional,omitempty"`
+
+	models.LinePosition
+}
+
+func (npmLockDependency *NpmLockDependency) GetNestedDependencies() map[string]*models.LinePosition {
+	result := make(map[string]*models.LinePosition)
+	for key, value := range npmLockDependency.Dependencies {
+		result[key] = &value.LinePosition
+	}
+
+	return result
 }
 
 type NpmLockPackage struct {
@@ -27,14 +44,16 @@ type NpmLockPackage struct {
 	Dev         bool `json:"dev,omitempty"`
 	DevOptional bool `json:"devOptional,omitempty"`
 	Optional    bool `json:"optional,omitempty"`
+
+	models.LinePosition
 }
 
 type NpmLockfile struct {
 	Version int `json:"lockfileVersion"`
 	// npm v1- lockfiles use "dependencies"
-	Dependencies map[string]NpmLockDependency `json:"dependencies"`
+	Dependencies map[string]*NpmLockDependency `json:"dependencies"`
 	// npm v2+ lockfiles use "packages"
-	Packages map[string]NpmLockPackage `json:"packages,omitempty"`
+	Packages map[string]*NpmLockPackage `json:"packages,omitempty"`
 }
 
 const NpmEcosystem Ecosystem = "npm"
@@ -57,30 +76,38 @@ func mergePkgDetailsMap(m1 map[string]PackageDetails, m2 map[string]PackageDetai
 	}
 
 	for name, detail := range m2 {
-		details[name] = detail
+		if _, ok := details[name]; !ok {
+			details[name] = detail
+		}
 	}
 
 	return details
 }
 
-func (dep NpmLockDependency) depGroups() []string {
-	if dep.Dev && dep.Optional {
+func (npmLockDependency *NpmLockDependency) depGroups() []string {
+	if npmLockDependency.Dev && npmLockDependency.Optional {
 		return []string{"dev", "optional"}
 	}
-	if dep.Dev {
+	if npmLockDependency.Dev {
 		return []string{"dev"}
 	}
-	if dep.Optional {
+	if npmLockDependency.Optional {
 		return []string{"optional"}
 	}
 
 	return nil
 }
 
-func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[string]PackageDetails {
+func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[string]PackageDetails {
 	details := map[string]PackageDetails{}
 
-	for name, detail := range dependencies {
+	keys := reflect.ValueOf(dependencies).MapKeys()
+	keysOrder := func(i, j int) bool { return keys[i].Interface().(string) < keys[j].Interface().(string) }
+	sort.Slice(keys, keysOrder)
+
+	for _, key := range keys {
+		name := key.Interface().(string)
+		detail := dependencies[name]
 		if detail.Dependencies != nil {
 			details = mergePkgDetailsMap(details, parseNpmLockDependencies(detail.Dependencies))
 		}
@@ -117,6 +144,8 @@ func parseNpmLockDependencies(dependencies map[string]NpmLockDependency) map[str
 			Version:   finalVersion,
 			Ecosystem: NpmEcosystem,
 			CompareAs: NpmEcosystem,
+			Start:     detail.Start,
+			End:       detail.End,
 			Commit:    commit,
 			DepGroups: detail.depGroups(),
 		}
@@ -136,24 +165,30 @@ func extractNpmPackageName(name string) string {
 	return pkgName
 }
 
-func (pkg NpmLockPackage) depGroups() []string {
-	if pkg.Dev {
+func (npmLockDependency NpmLockPackage) depGroups() []string {
+	if npmLockDependency.Dev {
 		return []string{"dev"}
 	}
-	if pkg.Optional {
+	if npmLockDependency.Optional {
 		return []string{"optional"}
 	}
-	if pkg.DevOptional {
+	if npmLockDependency.DevOptional {
 		return []string{"dev", "optional"}
 	}
 
 	return nil
 }
 
-func parseNpmLockPackages(packages map[string]NpmLockPackage) map[string]PackageDetails {
+func parseNpmLockPackages(packages map[string]*NpmLockPackage) map[string]PackageDetails {
 	details := map[string]PackageDetails{}
 
-	for namePath, detail := range packages {
+	keys := reflect.ValueOf(packages).MapKeys()
+	keysOrder := func(i, j int) bool { return keys[i].Interface().(string) < keys[j].Interface().(string) }
+	sort.Slice(keys, keysOrder)
+
+	for _, key := range keys {
+		namePath := key.Interface().(string)
+		detail := packages[namePath]
 		if namePath == "" {
 			continue
 		}
@@ -173,23 +208,31 @@ func parseNpmLockPackages(packages map[string]NpmLockPackage) map[string]Package
 			finalVersion = commit
 		}
 
-		details[finalName+"@"+finalVersion] = PackageDetails{
-			Name:      finalName,
-			Version:   detail.Version,
-			Ecosystem: NpmEcosystem,
-			CompareAs: NpmEcosystem,
-			Commit:    commit,
-			DepGroups: detail.depGroups(),
+		if _, ok := details[finalName+"@"+finalVersion]; !ok {
+			details[finalName+"@"+finalVersion] = PackageDetails{
+				Name:      finalName,
+				Version:   detail.Version,
+				Ecosystem: NpmEcosystem,
+				CompareAs: NpmEcosystem,
+				Start:     detail.Start,
+				End:       detail.End,
+				Commit:    commit,
+				DepGroups: detail.depGroups(),
+			}
 		}
 	}
 
 	return details
 }
 
-func parseNpmLock(lockfile NpmLockfile) map[string]PackageDetails {
+func parseNpmLock(lockfile NpmLockfile, lines []string) map[string]PackageDetails {
 	if lockfile.Packages != nil {
+		lineposition.InJSON("packages", lockfile.Packages, lines, 0)
+
 		return parseNpmLockPackages(lockfile.Packages)
 	}
+
+	lineposition.InJSON("dependencies", lockfile.Dependencies, lines, 0)
 
 	return parseNpmLockDependencies(lockfile.Dependencies)
 }
@@ -203,13 +246,20 @@ func (e NpmLockExtractor) ShouldExtract(path string) bool {
 func (e NpmLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	var parsedLockfile *NpmLockfile
 
-	err := json.NewDecoder(f).Decode(&parsedLockfile)
-
+	content, err := os.ReadFile(f.Path())
 	if err != nil {
 		return []PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}
 
-	return pkgDetailsMapToSlice(parseNpmLock(*parsedLockfile)), nil
+	contentString := string(content)
+	lines := strings.Split(contentString, "\n")
+	decoder := json.NewDecoder(strings.NewReader(contentString))
+
+	if err := decoder.Decode(&parsedLockfile); err != nil {
+		return []PackageDetails{}, fmt.Errorf("could not decode json from %s: %w", f.Path(), err)
+	}
+
+	return pkgDetailsMapToSlice(parseNpmLock(*parsedLockfile, lines)), nil
 }
 
 var _ Extractor = NpmLockExtractor{}

--- a/pkg/models/FilePosition.go
+++ b/pkg/models/FilePosition.go
@@ -3,3 +3,24 @@ package models
 type FilePosition struct {
 	Line int `json:"line"`
 }
+
+type LinePosition struct {
+	Start FilePosition `json:"start"`
+	End   FilePosition `json:"end"`
+}
+
+type ILinePosition interface {
+	SetStart(position FilePosition)
+	SetEnd(position FilePosition)
+	GetNestedDependencies() map[string]*LinePosition
+}
+
+func (line *LinePosition) SetStart(position FilePosition) {
+	line.Start = position
+}
+func (line *LinePosition) SetEnd(position FilePosition) {
+	line.End = position
+}
+func (line *LinePosition) GetNestedDependencies() map[string]*LinePosition {
+	return nil
+}


### PR DESCRIPTION
## What does this PR do?
### Refactor `findPackagesLinePosition` function
- Extract it from `parse-pipenv-lock.go` to `utility/lineposition/json`
- New struct `LinePosition` to hold both `Start` and `End` properties
  - TODO: Refactor previous implementations to use this struct (`maven`, `requirements.txt`, etc.)
  - TODO: Remove `FilePosition` struct (without the `column` property makes no sense any more)
- New interface `ILinePosition` to be able to generalize the usage of the function by defining the common setters for all structs implementing it

### `package-lock.json` / npm
- Include Start/End line for `package-lock.json` lock files
- Update unit tests for line location

## Additional Notes
- Will be nice to have a `--debug` flag to be able to print some info and ease following the file scanning while finding the line position for the different libraries
- We will have to handle multiple positions for a library (with the same version). By the moment, it's always showing the first occurrence (same behaviour as with `requirements.txt`)