### PR TITLE
:memo: Updating README with release information and CycloneDX 1.4 command information

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,16 @@ inv -e generate-licenses
 You can download the latest version of the scanner from the [release page](https://www.github.com/DataDog/osv-scanner/releases)
 
 Run the scanner using the following command to export the sbom in the file `result.json` :
-   ```bash
-   ./osv-scanner_<version>_<target>_<architecture> \
-      --skip-git \
-      --recursive \
-      --experimental-only-packages
-      --format=cyclonedx-1-4 \
-      --output=result.json
-      <path to your repository root directory>
-   ```
+
+```bash
+./osv-scanner_<version>_<target>_<architecture> \
+   --skip-git \
+   --recursive \
+   --experimental-only-packages
+   --format=cyclonedx-1-4 \
+   --output=result.json
+   <path to your repository root directory>
+```
 
 The SBOM will be formatted using the CycloneDX 1.4 format.
 
@@ -102,6 +103,7 @@ The SBOM will be formatted using the CycloneDX 1.4 format.
 ## Releasing OSV-Scanner
 
 Releasing OSV-Scanner is a pretty simple task :
+
 1. Go to the [Prerelease-check GitHub action](https://github.com/DataDog/osv-scanner/actions/workflows/prerelease-check.yml)
 2. Click on `Run workflow`, fill the inputs and run the workflow
 3. Once done, if everything went well, a command will be printed in the action's output. Copy it and paste it on your terminal to launch the release

--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ The SBOM will be formatted using the CycloneDX 1.4 format.
 
 ## Releasing OSV-Scanner
 
-Releasing OSV-Scanner is a pretty simple task :
-
 1. Go to the [Prerelease-check GitHub action](https://github.com/DataDog/osv-scanner/actions/workflows/prerelease-check.yml)
 2. Click on `Run workflow`, fill the inputs and run the workflow
 3. Once done, if everything went well, a command will be printed in the action's output. Copy it and paste it on your terminal to launch the release

--- a/README.md
+++ b/README.md
@@ -80,32 +80,34 @@ inv -e generate-licenses
 
 ## Documentation
 
-### Run
+### Running OSV to export a SBOM
 
-1. Download the latest version of the scanner from the [release page](https://www.github.com/DataDog/osv-scanner/releases)
-2. Export few environment variables :
-   1. `REPOSITORY_URL` representing the URL of the repository you scan. Please note that if you run it through a GitHub action, you don't have to export it.
-   2. `DD_SITE` representing the region of your Datadog account. It defaults to `us1`
-   3. `DD_API_KEY` representing a Datadog API key
-3. Run the scanner using the following command :
+You can download the latest version of the scanner from the [release page](https://www.github.com/DataDog/osv-scanner/releases)
+
+Run the scanner using the following command to export the sbom in the file `result.json` :
    ```bash
    ./osv-scanner_<version>_<target>_<architecture> \
       --skip-git \
       --recursive \
-      --format=datadog-sbom \
+      --experimental-only-packages
+      --format=cyclonedx-1-4 \
+      --output=result.json
       <path to your repository root directory>
    ```
 
-**Note** : You may want to run the tool only to export the SBOM, in that case you can run the following command :
+The SBOM will be formatted using the CycloneDX 1.4 format.
 
-```bash
-./osv-scanner_<version>_<target>_<architecture> \
-    --skip-git \
-    --recursive \
-    --format=datadog-offline-sbom \
-    --output=result.json \
-    <path to your repository root directory>
-```
+**Note** : This format does not support file location reporting.
+
+## Releasing OSV-Scanner
+
+Releasing OSV-Scanner is a pretty simple task :
+1. Go to the [Prerelease-check GitHub action](https://github.com/DataDog/osv-scanner/actions/workflows/prerelease-check.yml)
+2. Click on `Run workflow`, fill the inputs and run the workflow
+3. Once done, if everything went well, a command will be printed in the action's output. Copy it and paste it on your terminal to launch the release
+4. In the [release section](https://github.com/DataDog/osv-scanner/releases), a new one with your given version has been created.
+   1. If you want to test it, check the pre-release box before publishing it
+   2. Otherwise, publish it normally and you're all set
 
 ## Contributing code
 

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -926,31 +926,6 @@ func TestRun_LocalDatabases(t *testing.T) {
 			`,
 			wantStderr: "",
 		},
-		// one specific supported sbom with vulns
-		{
-			name:         "",
-			args:         []string{"", "--experimental-local-db", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/sbom-insecure/postgres-stretch.cdx.xml"},
-			wantExitCode: 1,
-			wantStdout: `
-				Scanning dir ./fixtures/sbom-insecure/postgres-stretch.cdx.xml
-				Scanned <rootdir>/fixtures/sbom-insecure/postgres-stretch.cdx.xml as CycloneDX SBOM and found 136 packages
-				Loaded Debian local db from %%/osv-scanner/Debian/all.zip
-				Loaded Go local db from %%/osv-scanner/Go/all.zip
-				Loaded OSS-Fuzz local db from %%/osv-scanner/OSS-Fuzz/all.zip
-				+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-				| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE                        | VERSION                            | SOURCE                                          |
-				+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-				| https://osv.dev/GHSA-f3fp-gc8g-vw66 | 5.9  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-g2j6-57v7-gm8c | 6.1  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-m8cg-xc2p-r3fc | 2.5  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-v95c-p5hm-xq8f | 6    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-vpvm-3wq2-2wvm | 7    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-xr7r-f8xq-vfvv | 8.6  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-p782-xgp4-8hr8 | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				+-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
-			`,
-			wantStderr: "",
-		},
 		// one specific unsupported lockfile
 		{
 			name:         "",


### PR DESCRIPTION
## What does this PR do?

- Updates the README run section to use a command exporting the SBOM instead of sending it to Datadog's backend
- Adds a release section with the process to follow
- Removing a flaky test

## Additional information
The removed test was flaky due to an external dependency download (the osv db) which has no option to fix on a specific version in OSV command line. As it is not a priority for Datadog to support this feature (only exporting an SBOM with location is), deleting it seems ok.