### PR TITLE
:bug: Add type in cyclone dx component

### DIFF
--- a/pkg/reporter/cyclonedx.go
+++ b/pkg/reporter/cyclonedx.go
@@ -10,6 +10,7 @@ import (
 )
 
 const cycloneDx14Schema = "http://cyclonedx.org/schema/bom-1.4.schema.json"
+const componentType = "library"
 
 type CycloneDXReporter struct {
 	hasPrintedError bool
@@ -75,6 +76,7 @@ func toCycloneDX14Bom(packageSources []models.PackageSource) *cyclonedx.BOM {
 		component.Version = packageDetail.Version
 		component.BOMRef = packageURL
 		component.PackageURL = packageURL
+		component.Type = componentType
 		components = append(components, component)
 	}
 

--- a/pkg/reporter/cyclonedx_test.go
+++ b/pkg/reporter/cyclonedx_test.go
@@ -99,12 +99,14 @@ func TestEncoding_EncodeComponentsInValidCycloneDX1_4(t *testing.T) {
 				PackageURL: "pkg:maven/com.foo/the-greatest-package@1.0.0",
 				Name:       "com.foo:the-greatest-package",
 				Version:    "1.0.0",
+				Type:       "library",
 			},
 			{
 				BOMRef:     "pkg:npm/the-npm-package@1.1.0",
 				PackageURL: "pkg:npm/the-npm-package@1.1.0",
 				Name:       "the-npm-package",
 				Version:    "1.1.0",
+				Type:       "library",
 			},
 		},
 	}


### PR DESCRIPTION
## What does this PR do?

- Add the missing required component type to have a valid sbom