### PR TITLE
✨ Extract version from the wheel package filename convention

### DIFF
--- a/pkg/lockfile/fixtures/pip/whl-url-packages.txt
+++ b/pkg/lockfile/fixtures/pip/whl-url-packages.txt
@@ -1,0 +1,1 @@
+pandas @ https://files.pythonhosted.org/packages/bc/57/8c61a6b2f9798349748701938dfed6d645bd329bfd96245ad98245238b6f/pandas-2.2.1-cp39-cp39-macosx_11_0_arm64.whl

--- a/pkg/lockfile/parse-requirements-txt.go
+++ b/pkg/lockfile/parse-requirements-txt.go
@@ -14,8 +14,6 @@ import (
 
 const PipEcosystem Ecosystem = "PyPI"
 
-var wheelPattern = cachedregexp.MustCompile("")
-
 // todo: expand this to support more things, e.g.
 //
 //	https://pip.pypa.io/en/stable/reference/requirements-file-format/#example
@@ -53,11 +51,11 @@ func parseLine(path string, line string, lineNumber int, lineOffset int, columnS
 			version, _, _ = strings.Cut(strings.TrimSpace(unprocessedVersion), " ")
 		}
 	} else if strings.Contains(line, "@") {
-		unprocessedName, unprocessedWheelUrl, _ := strings.Cut(line, "@")
+		unprocessedName, unprocessedFileLocation, _ := strings.Cut(line, "@")
 		name = strings.TrimSpace(unprocessedName)
-		wheelUrl := strings.TrimSpace(unprocessedWheelUrl)
-		if strings.HasSuffix(wheelUrl, ".whl") {
-			version = extractVersionFromWheelUrl(wheelUrl)
+		fileLocation := strings.TrimSpace(unprocessedFileLocation)
+		if strings.HasSuffix(fileLocation, ".whl") {
+			version = extractVersionFromWheelURL(fileLocation)
 		}
 	}
 
@@ -118,14 +116,17 @@ func isLineContinuation(line string) bool {
 	return re.MatchString(line)
 }
 
-func extractVersionFromWheelUrl(wheelUrl string) string {
-	paths := strings.Split(wheelUrl, "/")
+// Please note the whl filename has been standardized here :
+// https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention
+func extractVersionFromWheelURL(wheelURL string) string {
+	paths := strings.Split(wheelURL, "/")
 	filename := paths[len(paths)-1]
 	parts := strings.Split(filename, "-")
 
 	if len(parts) < 2 {
 		return "0.0.0"
 	}
+
 	return parts[1]
 }
 

--- a/pkg/lockfile/parse-requirements-txt.go
+++ b/pkg/lockfile/parse-requirements-txt.go
@@ -14,6 +14,8 @@ import (
 
 const PipEcosystem Ecosystem = "PyPI"
 
+var wheelPattern = cachedregexp.MustCompile("")
+
 // todo: expand this to support more things, e.g.
 //
 //	https://pip.pypa.io/en/stable/reference/requirements-file-format/#example
@@ -51,8 +53,12 @@ func parseLine(path string, line string, lineNumber int, lineOffset int, columnS
 			version, _, _ = strings.Cut(strings.TrimSpace(unprocessedVersion), " ")
 		}
 	} else if strings.Contains(line, "@") {
-		unprocessedName, _, _ := strings.Cut(line, "@")
+		unprocessedName, unprocessedWheelUrl, _ := strings.Cut(line, "@")
 		name = strings.TrimSpace(unprocessedName)
+		wheelUrl := strings.TrimSpace(unprocessedWheelUrl)
+		if strings.HasSuffix(wheelUrl, ".whl") {
+			version = extractVersionFromWheelUrl(wheelUrl)
+		}
 	}
 
 	return PackageDetails{
@@ -110,6 +116,17 @@ func isLineContinuation(line string) bool {
 	var re = cachedregexp.MustCompile(`([^\\]|^)(\\{2})*\\$`)
 
 	return re.MatchString(line)
+}
+
+func extractVersionFromWheelUrl(wheelUrl string) string {
+	paths := strings.Split(wheelUrl, "/")
+	filename := paths[len(paths)-1]
+	parts := strings.Split(filename, "-")
+
+	if len(parts) < 2 {
+		return "0.0.0"
+	}
+	return parts[1]
 }
 
 type RequirementsTxtExtractor struct{}

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -1072,7 +1072,7 @@ func TestParseRequirementsTxt_EnvironmentMarkers(t *testing.T) {
 	})
 }
 
-func TestParseRequirementsTxt_UrlPackages(t *testing.T) {
+func TestParseRequirementsTxt_GitUrlPackages(t *testing.T) {
 	t.Parallel()
 
 	lockfileRelativePath := filepath.FromSlash("fixtures/pip/url-packages.txt")
@@ -1101,6 +1101,39 @@ func TestParseRequirementsTxt_UrlPackages(t *testing.T) {
 			Commit:     "",
 			SourceFile: filepath.FromSlash(sourcePath),
 			DepGroups:  []string{"url-packages"},
+		},
+	})
+}
+
+func TestParseRequirementsTxt_WhlUrlPackages(t *testing.T) {
+	t.Parallel()
+
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/whl-url-packages.txt")
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	sourcePath := path.Join(dir, lockfileRelativePath)
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:       "pandas",
+			Version:    "2.2.1",
+			Ecosystem:  lockfile.PipEcosystem,
+			CompareAs:  lockfile.PipEcosystem,
+			Line:       models.Position{Start: 1, End: 1},
+			Column:     models.Position{Start: 1, End: 161},
+			Commit:     "",
+			SourceFile: filepath.FromSlash(sourcePath),
+			DepGroups:  []string{"whl-url-packages"},
 		},
 	})
 }


### PR DESCRIPTION
## What does this PR do?

- Extracting version from the wheel package filename convention

## Additional information
- Wheel package filename convention is described [here](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention)