### PR TITLE
:bug: Ignoring project 'dependencies' when scanning nuget's package.lock.json

### DIFF
--- a/pkg/lockfile/fixtures/nuget/one-framework-one-package.v1.json
+++ b/pkg/lockfile/fixtures/nuget/one-framework-one-package.v1.json
@@ -7,6 +7,9 @@
         "requested": "[6.0.5, )",
         "resolved": "6.0.5",
         "contentHash": "FwdQVtpj34xt8vKyFUUeNIS+obWlEnSrSW7y1ivRVts/ZsrUsKyOd0bZehgFhWdnB/NBsa9DCWvNFMTO0XDFcg=="
+      },
+      "project": {
+        "type": "Project"
       }
     }
   }

--- a/pkg/lockfile/fixtures/nuget/one-framework-two-packages.v1.json
+++ b/pkg/lockfile/fixtures/nuget/one-framework-two-packages.v1.json
@@ -16,6 +16,9 @@
         "dependencies": {
           "Test.Core": "6.0.0"
         }
+      },
+      "project": {
+        "type": "Project"
       }
     }
   }

--- a/pkg/lockfile/fixtures/nuget/two-frameworks-different-packages.v1.json
+++ b/pkg/lockfile/fixtures/nuget/two-frameworks-different-packages.v1.json
@@ -7,6 +7,9 @@
         "requested": "[6.0.5, )",
         "resolved": "6.0.5",
         "contentHash": "FwdQVtpj34xt8vKyFUUeNIS+obWlEnSrSW7y1ivRVts/ZsrUsKyOd0bZehgFhWdnB/NBsa9DCWvNFMTO0XDFcg=="
+      },
+      "project": {
+        "type": "Project"
       }
     },
     "net7.0": {
@@ -15,6 +18,9 @@
         "requested": "[0.13.0-beta4, )",
         "resolved": "0.13.0-beta4",
         "contentHash": "5r9yBPe7XOnb4zAQYzyvlt85dpuIJQkPJYEns5hpfv/JbC4uBHVqnrzqiPlTiaWEcXFgmDjjh0ihVB0vvChuCQ=="
+      },
+      "project": {
+        "type": "Project"
       }
     }
   }

--- a/pkg/lockfile/fixtures/nuget/two-frameworks-duplicate-packages.v1.json
+++ b/pkg/lockfile/fixtures/nuget/two-frameworks-duplicate-packages.v1.json
@@ -7,6 +7,9 @@
         "requested": "[6.0.5, )",
         "resolved": "6.0.5",
         "contentHash": "FwdQVtpj34xt8vKyFUUeNIS+obWlEnSrSW7y1ivRVts/ZsrUsKyOd0bZehgFhWdnB/NBsa9DCWvNFMTO0XDFcg=="
+      },
+      "project": {
+        "type": "Project"
       }
     },
     "net7.0": {
@@ -15,6 +18,9 @@
         "requested": "[6.0.5, )",
         "resolved": "6.0.5",
         "contentHash": "FwdQVtpj34xt8vKyFUUeNIS+obWlEnSrSW7y1ivRVts/ZsrUsKyOd0bZehgFhWdnB/NBsa9DCWvNFMTO0XDFcg=="
+      },
+      "project": {
+        "type": "Project"
       }
     }
   }

--- a/pkg/lockfile/fixtures/nuget/two-frameworks-mixed-packages.v1.json
+++ b/pkg/lockfile/fixtures/nuget/two-frameworks-mixed-packages.v1.json
@@ -32,6 +32,9 @@
         "contentHash": "t85dpuIJQkPJYEns5hpfv5r9yBPe7XOnb4zAQYzyvl/cXFgmDjjh0ihVB0vvChuCQJbC4uBHVqnrzqiPlTiaWE==",
         "dependencies": {
           "Test.Core": "6.0.0"
+        },
+        "project": {
+          "type": "Project"
         }
       }
     }

--- a/pkg/lockfile/parse-nuget-lock.go
+++ b/pkg/lockfile/parse-nuget-lock.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 type NuGetLockPackage struct {
 	Resolved string `json:"resolved"`
+	Type     string `json:"type"`
 }
 
 // NuGetLockfile contains the required dependency information as defined in
@@ -18,11 +20,15 @@ type NuGetLockfile struct {
 }
 
 const NuGetEcosystem Ecosystem = "NuGet"
+const projectDependencyType = "Project"
 
 func parseNuGetLockDependencies(dependencies map[string]NuGetLockPackage) map[string]PackageDetails {
 	details := map[string]PackageDetails{}
 
 	for name, dependency := range dependencies {
+		if strings.EqualFold(dependency.Type, projectDependencyType) {
+			continue
+		}
 		details[name+"@"+dependency.Resolved] = PackageDetails{
 			Name:      name,
 			Version:   dependency.Resolved,


### PR DESCRIPTION
## What does this PR do?

-  Ignoring project type 'dependencies' when scanning nuget's package.lock.json
