### PR TITLE
Remove trailing \n from location as JSON string

### DIFF
--- a/pkg/models/location.go
+++ b/pkg/models/location.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"strings"
 )
 
 type PackageDetails struct {
@@ -27,14 +26,11 @@ type PackageLocations struct {
 	Version   *PackageLocation `json:"version,omitempty"`
 }
 
-func (location PackageLocations) EncodeToJSONString() (string, error) {
-	buffer := strings.Builder{}
-	encoder := json.NewEncoder(&buffer)
-
-	err := encoder.Encode(location)
+func (location PackageLocations) MarshalToJSONString() (string, error) {
+	str, err := json.Marshal(location)
 	if err != nil {
 		return "", err
 	}
 
-	return buffer.String(), nil
+	return string(str), nil
 }

--- a/pkg/reporter/sbom/cyclonedx_1_5.go
+++ b/pkg/reporter/sbom/cyclonedx_1_5.go
@@ -25,7 +25,7 @@ func ToCycloneDX15Bom(stderr io.Writer, uniquePackages map[string]models.Package
 		component.Evidence = &cyclonedx.Evidence{Occurrences: &occurrences}
 
 		for index, packageLocations := range packageDetail.Locations {
-			jsonLocation, err := packageLocations.EncodeToJSONString()
+			jsonLocation, err := packageLocations.MarshalToJSONString()
 			if err != nil {
 				_, _ = fmt.Fprintf(stderr, "An error occurred when creating the jsonLocation structure : %v", err.Error())
 				continue


### PR DESCRIPTION
## What does this PR do?

- [json.Encoder](https://pkg.go.dev/encoding/json#NewEncoder) add a new line at the end of the string
- See this [Stackoverflow question](https://stackoverflow.com/questions/36319918/why-does-json-encoder-add-an-extra-line)
- The location represented as json should not have a new line, `json.Marshal` is used instead