### PR TITLE
:loud_sound: Adding a warn mechanism to avoid blocking execution when a single lockfile/package is failing to entirely resolve

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -293,11 +293,12 @@ func TestRun(t *testing.T) {
 		{
 			name:         "all supported lockfiles in the directory should be checked",
 			args:         []string{"", "./fixtures/locks-many-with-invalid"},
-			wantExitCode: 127,
+			wantExitCode: 0,
 			wantStdout: `
 				Scanning dir ./fixtures/locks-many-with-invalid
 				Scanned <rootdir>/fixtures/locks-many-with-invalid/Gemfile.lock file and found 1 package
 				Scanned <rootdir>/fixtures/locks-many-with-invalid/yarn.lock file and found 1 package
+				No issues found
 			`,
 			wantStderr: `
 				Attempted to scan lockfile but failed: <rootdir>/fixtures/locks-many-with-invalid/composer.lock
@@ -983,13 +984,14 @@ func TestRun_LocalDatabases(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{"", "--experimental-local-db", "./fixtures/locks-many-with-invalid"},
-			wantExitCode: 127,
+			wantExitCode: 0,
 			wantStdout: `
 				Scanning dir ./fixtures/locks-many-with-invalid
 				Scanned <rootdir>/fixtures/locks-many-with-invalid/Gemfile.lock file and found 1 package
 				Scanned <rootdir>/fixtures/locks-many-with-invalid/yarn.lock file and found 1 package
 				Loaded RubyGems local db from %%/osv-scanner/RubyGems/all.zip
 				Loaded npm local db from %%/osv-scanner/npm/all.zip
+				No issues found
 			`,
 			wantStderr: `
 				Attempted to scan lockfile but failed: <rootdir>/fixtures/locks-many-with-invalid/composer.lock

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -301,7 +301,7 @@ func TestRun(t *testing.T) {
 				No issues found
 			`,
 			wantStderr: `
-				Attempted to scan lockfile but failed: <rootdir>/fixtures/locks-many-with-invalid/composer.lock
+				Attempted to scan lockfile but failed: <rootdir>/fixtures/locks-many-with-invalid/composer.lock (could not extract from <rootdir>/fixtures/locks-many-with-invalid/composer.lock: invalid character ',' looking for beginning of object key string)
 			`,
 		},
 		// only the files in the given directories are checked by default (no recursion)
@@ -994,7 +994,7 @@ func TestRun_LocalDatabases(t *testing.T) {
 				No issues found
 			`,
 			wantStderr: `
-				Attempted to scan lockfile but failed: <rootdir>/fixtures/locks-many-with-invalid/composer.lock
+				Attempted to scan lockfile but failed: <rootdir>/fixtures/locks-many-with-invalid/composer.lock (could not extract from <rootdir>/fixtures/locks-many-with-invalid/composer.lock: invalid character ',' looking for beginning of object key string)
 			`,
 		},
 		// only the files in the given directories are checked by default (no recursion)

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -159,7 +159,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 			if extractor, _ := lockfile.FindExtractor(path, ""); extractor != nil {
 				pkgs, err := scanLockfile(r, path, "")
 				if err != nil {
-					r.PrintWarnf("Attempted to scan lockfile but failed: %s\n", path)
+					r.PrintWarnf("Attempted to scan lockfile but failed: %s (%v)\n", path, err.Error())
 				}
 				scannedPackages = append(scannedPackages, pkgs...)
 			}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -159,7 +159,7 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 			if extractor, _ := lockfile.FindExtractor(path, ""); extractor != nil {
 				pkgs, err := scanLockfile(r, path, "")
 				if err != nil {
-					r.PrintErrorf("Attempted to scan lockfile but failed: %s\n", path)
+					r.PrintWarnf("Attempted to scan lockfile but failed: %s\n", path)
 				}
 				scannedPackages = append(scannedPackages, pkgs...)
 			}

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -140,7 +140,7 @@ func groupBySource(r reporter.Reporter, packages []scannedPackage) models.Vulner
 			}
 			pkg.Package.Line = p.Line
 		default:
-			r.PrintErrorf("package %v does not have a commit, PURL or ecosystem/name/version identifier", p)
+			r.PrintWarnf("package %v does not have a commit, PURL or ecosystem/name/version identifier", p)
 			continue
 		}
 

--- a/pkg/reporter/cyclonedx.go
+++ b/pkg/reporter/cyclonedx.go
@@ -35,6 +35,10 @@ func (r *CycloneDXReporter) PrintErrorf(msg string, a ...any) {
 	r.hasPrintedError = true
 }
 
+func (r *CycloneDXReporter) PrintWarnf(msg string, a ...any) {
+	fmt.Fprintf(r.stderr, msg, a...)
+}
+
 func (r *CycloneDXReporter) HasPrintedError() bool {
 	return r.hasPrintedError
 }

--- a/pkg/reporter/gh-annotations_reporter.go
+++ b/pkg/reporter/gh-annotations_reporter.go
@@ -26,6 +26,10 @@ func (r *GHAnnotationsReporter) PrintError(msg string) {
 	r.PrintErrorf(msg)
 }
 
+func (r *GHAnnotationsReporter) PrintWarnf(msg string, a ...any) {
+	fmt.Fprintf(r.stderr, msg, a...)
+}
+
 func (r *GHAnnotationsReporter) PrintErrorf(msg string, a ...any) {
 	fmt.Fprintf(r.stderr, msg, a...)
 	r.hasPrintedError = true

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -31,6 +31,10 @@ func (r *JSONReporter) PrintErrorf(msg string, a ...any) {
 	r.hasPrintedError = true
 }
 
+func (r *JSONReporter) PrintWarnf(msg string, a ...any) {
+	fmt.Fprintf(r.stderr, msg, a...)
+}
+
 func (r *JSONReporter) HasPrintedError() bool {
 	return r.hasPrintedError
 }

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -21,6 +21,10 @@ type Reporter interface {
 	// Where the error is actually printed (if at all) is entirely up to the actual
 	// reporter, though generally it will be to stderr.
 	PrintErrorf(msg string, a ...any)
+	// PrintWarnf does the same thing than PrintErrorf but does not consider it as an error
+	// The direct result of it is the result code which will still be a success if the error outputs only have
+	// warnings.
+	PrintWarnf(msg string, a ...any)
 	// HasPrintedError returns true if there have been any calls to PrintError or
 	// PrintErrorf.
 	//

--- a/pkg/reporter/sarif_reporter.go
+++ b/pkg/reporter/sarif_reporter.go
@@ -26,6 +26,10 @@ func (r *SARIFReporter) PrintError(msg string) {
 	r.PrintErrorf(msg)
 }
 
+func (r *SARIFReporter) PrintWarnf(msg string, a ...any) {
+	fmt.Fprintf(r.stderr, msg, a...)
+}
+
 func (r *SARIFReporter) PrintErrorf(msg string, a ...any) {
 	fmt.Fprintf(r.stderr, msg, a...)
 	r.hasPrintedError = true

--- a/pkg/reporter/table_reporter.go
+++ b/pkg/reporter/table_reporter.go
@@ -36,6 +36,10 @@ func (r *TableReporter) PrintErrorf(msg string, a ...any) {
 	r.hasPrintedError = true
 }
 
+func (r *TableReporter) PrintWarnf(msg string, a ...any) {
+	fmt.Fprintf(r.stderr, msg, a...)
+}
+
 func (r *TableReporter) HasPrintedError() bool {
 	return r.hasPrintedError
 }

--- a/pkg/reporter/void_reporter.go
+++ b/pkg/reporter/void_reporter.go
@@ -16,6 +16,8 @@ func (r *VoidReporter) PrintErrorf(msg string, a ...any) {
 	r.hasPrintedError = true
 }
 
+func (r *VoidReporter) PrintWarnf(msg string, a ...any) {}
+
 func (r *VoidReporter) HasPrintedError() bool {
 	return r.hasPrintedError
 }


### PR DESCRIPTION
## What does this PR do?

- Add a warn mechanism in reporters with the same behaviour than Error but without considering the execution as a failure
- Demote some logs to a warn to avoid automated execution like CIs to fail because of a single package or lockfile failing to resolve