### PR TITLE
:bug: Resolving bugs in npm lockfile parser

### DIFF
--- a/pkg/lockfile/fixtures/npm/link-dependency.v2.json
+++ b/pkg/lockfile/fixtures/npm/link-dependency.v2.json
@@ -1,0 +1,21 @@
+{
+  "name": "my-library",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {},
+      "devDependencies": { "wrappy": "^1.0.0" }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "wrappy": {
+      "link": true
+    }
+  },
+  "dependencies": {}
+}

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -412,7 +412,7 @@ func TestParseNpmLock_v1_Files(t *testing.T) {
 		},
 		{
 			Name:      "other_package",
-			Version:   "",
+			Version:   "0.0.0",
 			Line:      models.Position{Start: 10, End: 15},
 			Column:    models.Position{Start: 5, End: 6},
 			Ecosystem: lockfile.NpmEcosystem,

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -82,6 +82,28 @@ func TestParseNpmLock_v2_OnePackageDev(t *testing.T) {
 	})
 }
 
+func TestParseNpmLock_v2_LinkDependency(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseNpmLock("fixtures/npm/link-dependency.v2.json")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "wrappy",
+			Version:   "1.0.2",
+			Line:      models.Position{Start: 10, End: 15},
+			Column:    models.Position{Start: 5, End: 6},
+			Ecosystem: lockfile.NpmEcosystem,
+			CompareAs: lockfile.NpmEcosystem,
+			DepGroups: []string{"dev"},
+		},
+	})
+}
+
 func TestParseNpmLock_v2_TwoPackages(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -41,6 +41,7 @@ type NpmLockPackage struct {
 	Version      string            `json:"version"`
 	Resolved     string            `json:"resolved"`
 	Dependencies map[string]string `json:"dependencies"`
+	Link         bool              `json:"link,omitempty"`
 
 	Dev         bool `json:"dev,omitempty"`
 	DevOptional bool `json:"devOptional,omitempty"`
@@ -209,7 +210,8 @@ func parseNpmLockPackages(packages map[string]*NpmLockPackage) map[string]Packag
 			finalVersion = commit
 		}
 
-		if _, ok := details[finalName+"@"+finalVersion]; !ok {
+		_, exists := details[finalName+"@"+finalVersion]
+		if !exists && !detail.Link {
 			details[finalName+"@"+finalVersion] = PackageDetails{
 				Name:      finalName,
 				Version:   detail.Version,

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -127,7 +127,8 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency) map[st
 
 		// we can't resolve a version from a "file:" dependency
 		if strings.HasPrefix(detail.Version, "file:") {
-			finalVersion = ""
+			finalVersion = "0.0.0"
+			version = "0.0.0"
 		} else {
 			commit = tryExtractCommit(detail.Version)
 

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -210,6 +210,12 @@ func parseNpmLockPackages(packages map[string]*NpmLockPackage) map[string]Packag
 			finalVersion = commit
 		}
 
+		if finalVersion == "" {
+			// If version and commit are not set in the lockfile, it means the package is defined locally
+			// with its own package.json, without any version defined for it, lets default on 0.0.0
+			detail.Version = "0.0.0"
+		}
+
 		_, exists := details[finalName+"@"+finalVersion]
 		if !exists && !detail.Link {
 			details[finalName+"@"+finalVersion] = PackageDetails{


### PR DESCRIPTION
## What does this PR do?

- Filtering dependencies flagged as "link" as it means they are defined elsewhere in the lockfile, they will be scanned at this moment
- Default version to 0.0.0 instead of skipping the entire package when it is not defined
- Default version to 0.0.0 instead of skipping the entire package when the dependency is defined as a local file

## Additional Notes

packages block specification : https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json#packages
specifically :
> link: A flag to indicate that this is a symbolic link. If this is present, no other fields are specified, since the link target will also be included in the lockfile.