### PR TITLE
:bug: Resolve bugs in go lockfile parser

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -641,13 +641,11 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 		{
 			name:         "one lockfile with local path",
 			args:         []string{"", "--lockfile=go.mod:./fixtures/locks-many/replace-local.mod"},
-			wantExitCode: 0,
+			wantExitCode: 128,
 			wantStdout: `
-				Scanned <rootdir>/fixtures/locks-many/replace-local.mod file as a go.mod and found 1 package
-				Filtered 1 local package/s from the scan.
-				No issues found
+				Scanned <rootdir>/fixtures/locks-many/replace-local.mod file as a go.mod and found 0 packages
 			`,
-			wantStderr: "",
+			wantStderr: "No package sources found, --help for usage information.",
 		},
 		// when an explicit parse-as is given, it's applied to that file
 		{

--- a/pkg/lockfile/fixtures/go/with-path-major.mod
+++ b/pkg/lockfile/fixtures/go/with-path-major.mod
@@ -1,0 +1,2 @@
+go 1.11
+require github.com/elastic/go-elasticsearch/v8 master

--- a/pkg/lockfile/fixtures/go/without-supported-versioning.mod
+++ b/pkg/lockfile/fixtures/go/without-supported-versioning.mod
@@ -1,0 +1,2 @@
+go 1.11
+require github.com/elastic/go-elasticsearch master

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -82,9 +82,17 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 		}
 
 		for _, replacement := range replacements {
+			version := strings.TrimPrefix(replace.New.Version, "v")
+
+			if len(version) == 0 {
+				// There is no version specified on the replacement, it means the artifact is directly accessible
+				// the package itself will then be scanned so there is no need to keep it
+				delete(packages, replacement)
+				continue
+			}
 			packages[replacement] = PackageDetails{
 				Name:      replace.New.Path,
-				Version:   strings.TrimPrefix(replace.New.Version, "v"),
+				Version:   version,
 				Ecosystem: GoEcosystem,
 				CompareAs: GoEcosystem,
 				Line:      models.Position{Start: start.Line, End: end.Line},

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -41,7 +41,7 @@ func defaultNonCanonicalVersions(path, version string) (string, error) {
 
 	if resolvedVersion == "" {
 		// If it is still not resolved, we default on 0.0.0 as we do with other package managers
-		_, _ = fmt.Fprintf(os.Stderr, "%s@%s is not a canonical path, defaulting to v0.0.0", path, resolvedVersion)
+		_, _ = fmt.Fprintf(os.Stderr, "%s@%s is not a canonical path, defaulting to v0.0.0\n", path, resolvedVersion)
 		return "v0.0.0", nil
 	}
 

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -2,11 +2,12 @@ package lockfile
 
 import (
 	"fmt"
-	"golang.org/x/mod/module"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/mod/module"
 
 	"github.com/google/osv-scanner/pkg/models"
 

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -91,6 +91,35 @@ func TestParseGoLock_NoPackages(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
+func TestParseGoLock_WithPathMajor(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseGoLock("fixtures/go/with-path-major.mod")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "github.com/elastic/go-elasticsearch/v8",
+			Version:   "8",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+			Line:      models.Position{Start: 2, End: 2},
+			Column:    models.Position{Start: 1, End: 54},
+		},
+		{
+			Name:      "stdlib",
+			Version:   "1.11.0",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+			Line:      models.Position{Start: 0, End: 0},
+			Column:    models.Position{Start: 0, End: 0},
+		},
+	})
+}
+
 func TestParseGoLock_OnePackage(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -120,6 +120,35 @@ func TestParseGoLock_WithPathMajor(t *testing.T) {
 	})
 }
 
+func TestParseGoLock_WithoutSupportedVersioning(t *testing.T) {
+	t.Parallel()
+
+	packages, err := lockfile.ParseGoLock("fixtures/go/without-supported-versioning.mod")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "github.com/elastic/go-elasticsearch",
+			Version:   "0.0.0",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+			Line:      models.Position{Start: 2, End: 2},
+			Column:    models.Position{Start: 1, End: 51},
+		},
+		{
+			Name:      "stdlib",
+			Version:   "1.11.0",
+			Ecosystem: lockfile.GoEcosystem,
+			CompareAs: lockfile.GoEcosystem,
+			Line:      models.Position{Start: 0, End: 0},
+			Column:    models.Position{Start: 0, End: 0},
+		},
+	})
+}
+
 func TestParseGoLock_OnePackage(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -267,14 +267,6 @@ func TestParseGoLock_Replacements_Local(t *testing.T) {
 
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
-			Name:      "./fork/net",
-			Version:   "",
-			Ecosystem: lockfile.GoEcosystem,
-			CompareAs: lockfile.GoEcosystem,
-			Line:      models.Position{Start: 7, End: 7},
-			Column:    models.Position{Start: 5, End: 42},
-		},
-		{
 			Name:      "github.com/BurntSushi/toml",
 			Version:   "1.0.0",
 			Ecosystem: lockfile.GoEcosystem,

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -140,7 +140,7 @@ func groupBySource(r reporter.Reporter, packages []scannedPackage) models.Vulner
 			}
 			pkg.Package.Line = p.Line
 		default:
-			r.PrintWarnf("package %v does not have a commit, PURL or ecosystem/name/version identifier", p)
+			r.PrintWarnf("package %v does not have a commit, PURL or ecosystem/name/version identifier\n", p)
 			continue
 		}
 


### PR DESCRIPTION
## What does this PR do?

- Filtering out packages which are replaced by local directories as they will be scanned later in the OSV process
- Handle non-canonical versions in dependency declarations instead of failing the entire go.mod

## Additional Notes

go module major version documentation : https://go.dev/doc/modules/major-version
specifically the example on major version in path :
> In the new version’s go.mod file, append new major version number to the module path, as in the following example:
> Existing version: example.com/mymodule
> New version: example.com/mymodule/v2
