### PR TITLE
:bug: Resolving bugs in python requirements.txt parser

### DIFF
--- a/pkg/lockfile/fixtures/pip/with-url-r-option.txt
+++ b/pkg/lockfile/fixtures/pip/with-url-r-option.txt
@@ -1,0 +1,3 @@
+requests==1.2.3
+
+-r https://static.pyregistry.com/foopkg/requirements.txt

--- a/pkg/lockfile/parse-requirements-txt.go
+++ b/pkg/lockfile/parse-requirements-txt.go
@@ -179,6 +179,10 @@ func parseRequirementsTxt(f DepFile, requiredAlready map[string]struct{}) ([]Pac
 
 		line = removeComments(line)
 		if ar := strings.TrimPrefix(line, "-r "); ar != line {
+			if strings.HasPrefix(ar, "http://") || strings.HasPrefix(ar, "https://") {
+				// If the linked requirement file is not locally stored, we skip it
+				continue
+			}
 			err := func() error {
 				af, err := f.Open(ar)
 

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"github.com/stretchr/testify/require"
 	"io/fs"
 	"os"
 	"path"
@@ -737,6 +738,37 @@ func TestParseRequirementsTxt_WithBadROption(t *testing.T) {
 
 	expectErrIs(t, err, fs.ErrNotExist)
 	expectPackages(t, packages, []lockfile.PackageDetails{})
+}
+
+func TestParseRequirementsTxt_WithURLROption(t *testing.T) {
+	t.Parallel()
+	lockfileRelativePath := filepath.FromSlash("fixtures/pip/with-url-r-option.txt")
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	basePath := filepath.Join(dir, lockfileRelativePath)
+
+	packages, err := lockfile.ParseRequirementsTxt(lockfileRelativePath)
+	require.NoError(t, err)
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "requests",
+			Version:   "1.2.3",
+			Commit:    "",
+			Ecosystem: lockfile.PipEcosystem,
+			CompareAs: lockfile.PipEcosystem,
+			Line: models.Position{
+				Start: 1,
+				End:   1,
+			},
+			Column: models.Position{
+				Start: 1,
+				End:   16,
+			},
+			SourceFile: basePath,
+			DepGroups:  []string{"with-url-r-option"},
+		},
+	})
 }
 
 func TestParseRequirementsTxt_DuplicateROptions(t *testing.T) {

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -1,12 +1,13 @@
 package lockfile_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/google/osv-scanner/pkg/models"
 


### PR DESCRIPTION
## What does this PR do?

- Skipping -r with URL when parsing requirements.txt instead of skipping the whole file with an error

## Additional Notes
