### PR TITLE
:bug:  Resolving bugs in maven pom file parser

### DIFF
--- a/pkg/lockfile/fixtures/maven/with-project-version-property.xml
+++ b/pkg/lockfile/fixtures/maven/with-project-version-property.xml
@@ -10,5 +10,10 @@
       <artifactId>bar</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>dev.bar</groupId>
+      <artifactId>foo</artifactId>
+      <version>${pom.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -57,6 +57,11 @@ func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fi
 		var property string
 		var ok bool
 
+		if strings.HasPrefix(propName, "pom.") {
+			// the pom. prefix is the legacy value of project. prefix even if it is deprecated, it is still supported
+			propName = "project" + strings.TrimPrefix(propName, "pom")
+		}
+
 		// If the fieldToResolve is the internal version fieldToResolve, then lets use the one declared
 		if strings.HasPrefix(propName, "project.") {
 			property, ok = projectProperties[propName]

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -242,6 +242,10 @@ func (e MavenLockExtractor) decodeMavenFile(f DepFile, depth int) (*MavenLockFil
 	if err != nil {
 		return nil, err
 	}
+
+	if parsedLockfile.Properties.m == nil {
+		parsedLockfile.Properties.m = map[string]string{}
+	}
 	parsedLockfile.Dependencies = e.enrichDependencies(f, parsedLockfile.Dependencies.Dependencies)
 	parsedLockfile.ManagedDependencies = e.enrichDependencies(f, parsedLockfile.ManagedDependencies.Dependencies)
 	if parsedLockfile.Parent == (MavenLockParent{}) {

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -264,6 +264,7 @@ func (e MavenLockExtractor) decodeMavenFile(f DepFile, depth int) (*MavenLockFil
 	parentPath := filepath.FromSlash(filepath.Join(filepath.Dir(f.Path()), parentRelativePath))
 	if _, err := os.Stat(parentPath); errors.Is(err, os.ErrNotExist) {
 		// If the parent pom does not exist, it still can be in an external repository, but it is unreachable from the parser
+		_, _ = fmt.Fprintf(os.Stderr, "Maven lockfile parser couldn't reach the parent because it is not locally defined\n")
 		return parsedLockfile, nil
 	}
 	parentFile, err := OpenLocalDepFile(parentPath)

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -742,6 +742,17 @@ func TestParseMavenLock_WithProjectVersionProperty(t *testing.T) {
 			Column:     models.Position{Start: 5, End: 18},
 			DepGroups:  nil,
 		},
+		{
+			Name:       "dev.bar:foo",
+			Version:    "1.0-SNAPSHOT",
+			Ecosystem:  lockfile.MavenEcosystem,
+			CompareAs:  lockfile.MavenEcosystem,
+			Commit:     "",
+			SourceFile: lockfilePath,
+			Line:       models.Position{Start: 13, End: 17},
+			Column:     models.Position{Start: 5, End: 18},
+			DepGroups:  nil,
+		},
 	})
 }
 


### PR DESCRIPTION
## What does this PR do?

- Fixing unexisting pom files instead of failing because parents can be located in an external registry
- Include all deserialized project direct properties
- Handling the now deprecated "pom" prefixed properties (replaced by "project" suffix but still in use)

## Additional Notes

- The POM file reference : https://maven.apache.org/pom.html
