### PR TITLE
:bug: Fixing bugs in PNPM lockfile parser

### DIFF
--- a/pkg/lockfile/fixtures/pnpm/scoped-packages-v6-lockfile.yaml
+++ b/pkg/lockfile/fixtures/pnpm/scoped-packages-v6-lockfile.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: 6.0-flavoured
 
 dependencies:
   '@typescript-eslint/types':

--- a/pkg/lockfile/parse-pnpm-lock.go
+++ b/pkg/lockfile/parse-pnpm-lock.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/google/osv-scanner/pkg/models"
@@ -32,32 +31,8 @@ type PnpmLockPackage struct {
 type PnpmLockPackages map[string]PnpmLockPackage
 
 type PnpmLockfile struct {
-	Version  float64          `yaml:"lockfileVersion"`
-	Packages PnpmLockPackages `yaml:"packages,omitempty"`
-}
-
-type PnpmLockfileV6 struct {
 	Version  string           `yaml:"lockfileVersion"`
 	Packages PnpmLockPackages `yaml:"packages,omitempty"`
-}
-
-func (l *PnpmLockfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var lockfileV6 PnpmLockfileV6
-
-	if err := unmarshal(&lockfileV6); err != nil {
-		return err
-	}
-
-	parsedVersion, err := strconv.ParseFloat(lockfileV6.Version, 64)
-
-	if err != nil {
-		return err
-	}
-
-	l.Version = parsedVersion
-	l.Packages = lockfileV6.Packages
-
-	return nil
 }
 
 func (pnpmLockPackages *PnpmLockPackages) UnmarshalYAML(value *yaml.Node) error {


### PR DESCRIPTION
## What does this PR do?

- Pnpm lockfiles version are not necessarily float64, handling them as string

## Additional Notes
