### PR TITLE
:bug: deduplicate location object based on block locations

### DIFF
--- a/pkg/grouper/package_grouper_test.go
+++ b/pkg/grouper/package_grouper_test.go
@@ -29,6 +29,24 @@ func TestGroupPackageByPURL_ShouldUnifyPackages(t *testing.T) {
 				},
 				{
 					Package: models.PackageInfo{
+						Name:      "foo.bar:the-first-package",
+						Version:   "1.0.0",
+						Ecosystem: string(lockfile.MavenEcosystem),
+						Line:      models.Position{Start: 1, End: 2},
+						Column:    models.Position{Start: 10, End: 21},
+					},
+				},
+				{
+					Package: models.PackageInfo{
+						Name:      "foo.bar:the-first-package",
+						Version:   "1.0.0",
+						Ecosystem: string(lockfile.MavenEcosystem),
+						Line:      models.Position{Start: 1, End: 2},
+						Column:    models.Position{Start: 10, End: 21},
+					},
+				},
+				{
+					Package: models.PackageInfo{
 						Name:      "foo.bar:package-2",
 						Ecosystem: string(lockfile.MavenEcosystem),
 						Version:   "1.0.0",

--- a/pkg/models/location.go
+++ b/pkg/models/location.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 )
 
 type PackageDetails struct {
@@ -33,4 +35,14 @@ func (location PackageLocations) MarshalToJSONString() (string, error) {
 	}
 
 	return string(str), nil
+}
+
+func (location PackageLocation) Hash() string {
+	return strings.Join([]string{
+		location.Filename,
+		strconv.Itoa(location.LineStart),
+		strconv.Itoa(location.LineEnd),
+		strconv.Itoa(location.ColumnStart),
+		strconv.Itoa(location.ColumnEnd),
+	}, "#")
 }


### PR DESCRIPTION
## What does this PR do?

This PR deduplicates locations to avoid reporting the same one multiple times.

### Why is this happening ?

Some package managers have a parenting system (yes I'm looking at you maven), which means that for a given lockfile we will reports its dependencies and the ones from its parent. Each lockfile parsing being independant, the same package is then reported multiple times, which will turn in the package grouper (which role is to turn packages grouped by source file in packages grouped by PURL) in one package with a duplicated location object.
