### PR TITLE
✨ Adding a relative path flag to report location relative to the scanned directory

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -154,6 +154,10 @@ func run(args []string, stdout, stderr io.Writer) int {
 				Name:  "consider-scan-path-as-root",
 				Usage: "Transform package path root to be the scanning path, thus removing any information about the host",
 			},
+			&cli.BoolFlag{
+				Name:  "paths-relative-to-scan-dir",
+				Usage: "Same than --consider-scan-path-as-root but reports a path relative to the scan dir (removing the leading path separator)",
+			},
 		},
 		ArgsUsage: "[directory1 directory2...]",
 		Action: func(context *cli.Context) error {
@@ -216,6 +220,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 				DirectoryPaths:         context.Args().Slice(),
 				CallAnalysisStates:     callAnalysisStates,
 				ConsiderScanPathAsRoot: context.Bool("consider-scan-path-as-root"),
+				PathRelativeToScanDir:  context.Bool("paths-relative-to-scan-dir"),
 				ExperimentalScannerActions: osvscanner.ExperimentalScannerActions{
 					LocalDBPath:    context.String("experimental-local-db-path"),
 					CompareLocally: context.Bool("experimental-local-db"),

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -1752,6 +1752,21 @@ func TestRun_WithoutHostPathInformation(t *testing.T) {
 				filepath.FromSlash("/yarn.lock"),
 			},
 		},
+		{
+			name:          "one specific supported lockfile (relative path)",
+			args:          []string{"", "--experimental-only-packages", "--format=cyclonedx-1-5", "--paths-relative-to-scan-dir", "./fixtures/locks-many/yarn.lock"},
+			wantExitCode:  0,
+			wantFilePaths: []string{filepath.FromSlash("yarn.lock")},
+		},
+		{
+			name:         "Multiple lockfiles (relative path)",
+			args:         []string{"", "--experimental-only-packages", "--format=cyclonedx-1-5", "--paths-relative-to-scan-dir", "./fixtures/locks-many"},
+			wantExitCode: 0,
+			wantFilePaths: []string{
+				filepath.FromSlash("package-lock.json"),
+				filepath.FromSlash("yarn.lock"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -1741,30 +1741,30 @@ func TestRun_WithoutHostPathInformation(t *testing.T) {
 			name:          "one specific supported lockfile",
 			args:          []string{"", "--experimental-only-packages", "--format=cyclonedx-1-5", "--consider-scan-path-as-root", "./fixtures/locks-many/yarn.lock"},
 			wantExitCode:  0,
-			wantFilePaths: []string{filepath.FromSlash("/yarn.lock")},
+			wantFilePaths: []string{"/yarn.lock"},
 		},
 		{
 			name:         "Multiple lockfiles",
 			args:         []string{"", "--experimental-only-packages", "--format=cyclonedx-1-5", "--consider-scan-path-as-root", "./fixtures/locks-many"},
 			wantExitCode: 0,
 			wantFilePaths: []string{
-				filepath.FromSlash("/package-lock.json"),
-				filepath.FromSlash("/yarn.lock"),
+				"/package-lock.json",
+				"/yarn.lock",
 			},
 		},
 		{
 			name:          "one specific supported lockfile (relative path)",
 			args:          []string{"", "--experimental-only-packages", "--format=cyclonedx-1-5", "--paths-relative-to-scan-dir", "./fixtures/locks-many/yarn.lock"},
 			wantExitCode:  0,
-			wantFilePaths: []string{filepath.FromSlash("yarn.lock")},
+			wantFilePaths: []string{"yarn.lock"},
 		},
 		{
 			name:         "Multiple lockfiles (relative path)",
 			args:         []string{"", "--experimental-only-packages", "--format=cyclonedx-1-5", "--paths-relative-to-scan-dir", "./fixtures/locks-many"},
 			wantExitCode: 0,
 			wantFilePaths: []string{
-				filepath.FromSlash("package-lock.json"),
-				filepath.FromSlash("yarn.lock"),
+				"package-lock.json",
+				"yarn.lock",
 			},
 		},
 	}
@@ -1832,7 +1832,7 @@ func TestRun_WithCycloneDX15(t *testing.T) {
 				Version:    "3.0.2",
 				Evidence: buildLocationEvidence(t, models.PackageLocations{
 					Block: models.PackageLocation{
-						Filename:    filepath.FromSlash("/pom.xml"),
+						Filename:    "/pom.xml",
 						LineStart:   25,
 						LineEnd:     28,
 						ColumnStart: 5,


### PR DESCRIPTION
## What does this PR do?

- adds the flag `--paths-relative-to-scan-dir` doing the same thing than `--consider-scan-path-as-root` but removes the leading path separator
