### PR TITLE
Change the non-zero output to zero when the detection is empty

### DIFF
--- a/cmd/osv-reporter/main.go
+++ b/cmd/osv-reporter/main.go
@@ -179,8 +179,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		}
 
 		if errors.Is(err, osvscanner.NoPackagesFoundErr) {
-			tableReporter.PrintErrorf("No package sources found, --help for usage information.\n")
-			return 128
+			tableReporter.PrintWarnf("No package sources found, --help for usage information.\n")
+			return 0
 		}
 
 		tableReporter.PrintErrorf("%v\n", err)

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -237,7 +237,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 				},
 			}, r)
 
-			if err != nil && !errors.Is(err, osvscanner.VulnerabilitiesFoundErr) {
+			shouldIgnoreError := errors.Is(err, osvscanner.VulnerabilitiesFoundErr) || errors.Is(err, osvscanner.NoPackagesFoundErr)
+			if err != nil && !shouldIgnoreError {
 				return err
 			}
 

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -258,8 +258,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		case errors.Is(err, osvscanner.VulnerabilitiesFoundErr):
 			return 1
 		case errors.Is(err, osvscanner.NoPackagesFoundErr):
-			r.PrintErrorf("No package sources found, --help for usage information.\n")
-			return 128
+			r.PrintWarnf("No package sources found, --help for usage information.\n")
+			return 0
 		}
 		r.PrintErrorf("%v\n", err)
 	}

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -181,7 +181,7 @@ func TestRun(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{""},
-			wantExitCode: 128,
+			wantExitCode: 0,
 			wantStdout:   "",
 			wantStderr: `
         No package sources found, --help for usage information.
@@ -261,7 +261,7 @@ func TestRun(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{"", "./fixtures/locks-many/not-a-lockfile.toml"},
-			wantExitCode: 128,
+			wantExitCode: 0,
 			wantStdout: `
 				Scanning dir ./fixtures/locks-many/not-a-lockfile.toml
 			`,
@@ -641,7 +641,7 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 		{
 			name:         "one lockfile with local path",
 			args:         []string{"", "--lockfile=go.mod:./fixtures/locks-many/replace-local.mod"},
-			wantExitCode: 128,
+			wantExitCode: 0,
 			wantStdout: `
 				Scanned <rootdir>/fixtures/locks-many/replace-local.mod file as a go.mod and found 0 packages
 			`,
@@ -947,7 +947,7 @@ func TestRun_LocalDatabases(t *testing.T) {
 		{
 			name:         "",
 			args:         []string{"", "--experimental-local-db", "./fixtures/locks-many/not-a-lockfile.toml"},
-			wantExitCode: 128,
+			wantExitCode: 0,
 			wantStdout: `
 				Scanning dir ./fixtures/locks-many/not-a-lockfile.toml
 			`,

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -182,7 +182,7 @@ func TestRun(t *testing.T) {
 			name:         "",
 			args:         []string{""},
 			wantExitCode: 0,
-			wantStdout:   "",
+			wantStdout:   "No issues found",
 			wantStderr: `
         No package sources found, --help for usage information.
 			`,
@@ -264,6 +264,7 @@ func TestRun(t *testing.T) {
 			wantExitCode: 0,
 			wantStdout: `
 				Scanning dir ./fixtures/locks-many/not-a-lockfile.toml
+				No issues found
 			`,
 			wantStderr: `
 				No package sources found, --help for usage information.
@@ -644,6 +645,7 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 			wantExitCode: 0,
 			wantStdout: `
 				Scanned <rootdir>/fixtures/locks-many/replace-local.mod file as a go.mod and found 0 packages
+				No issues found
 			`,
 			wantStderr: "No package sources found, --help for usage information.",
 		},
@@ -950,6 +952,7 @@ func TestRun_LocalDatabases(t *testing.T) {
 			wantExitCode: 0,
 			wantStdout: `
 				Scanning dir ./fixtures/locks-many/not-a-lockfile.toml
+				No issues found
 			`,
 			wantStderr: `
 				No package sources found, --help for usage information.


### PR DESCRIPTION
## What does this PR do?

- Change the return code to 0 when no packages are detected, as empty repositories could want to start the scan right away without blocking everything

