### PR TITLE
✨ Adding a flag to explicitly enable lockfiles

### DIFF
--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -221,6 +221,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 				CallAnalysisStates:     callAnalysisStates,
 				ConsiderScanPathAsRoot: context.Bool("consider-scan-path-as-root"),
 				PathRelativeToScanDir:  context.Bool("paths-relative-to-scan-dir"),
+				EnableParsers:          context.StringSlice("enable-parsers"),
 				ExperimentalScannerActions: osvscanner.ExperimentalScannerActions{
 					LocalDBPath:    context.String("experimental-local-db-path"),
 					CompareLocally: context.Bool("experimental-local-db"),

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/google/osv-scanner/pkg/lockfile"
 	"io"
 	"os"
 	"slices"
@@ -157,6 +158,10 @@ func run(args []string, stdout, stderr io.Writer) int {
 			&cli.BoolFlag{
 				Name:  "paths-relative-to-scan-dir",
 				Usage: "Same than --consider-scan-path-as-root but reports a path relative to the scan dir (removing the leading path separator)",
+			},
+			&cli.StringSliceFlag{
+				Name:  "enable-parsers",
+				Usage: fmt.Sprintf("Explicitly define which lockfile to parse. If set, any non-set parsers will be ignored. (Available parsers: %v)", lockfile.ListExtractors()),
 			},
 		},
 		ArgsUsage: "[directory1 directory2...]",

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/google/osv-scanner/pkg/lockfile"
 	"io"
 	"os"
 	"slices"
 	"strings"
+
+	"github.com/google/osv-scanner/pkg/lockfile"
 
 	"github.com/google/osv-scanner/internal/version"
 	"github.com/google/osv-scanner/pkg/osv"

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -1852,6 +1852,58 @@ func TestRun_WithCycloneDX15(t *testing.T) {
 	sbom_test.AssertBomEqual(t, expectedBom, bom, true)
 }
 
+func TestRun_WithExplicitParsers(t *testing.T) {
+	t.Parallel()
+	args := []string{
+		"",
+		"-r",
+		"--experimental-only-packages",
+		"--format=cyclonedx-1-5",
+		"--consider-scan-path-as-root",
+		"--enable-parsers=pom.xml",
+		"./fixtures/integration-test-locks",
+	}
+	stdoutBuffer := &bytes.Buffer{}
+	stderrBuffer := &bytes.Buffer{}
+
+	ec := run(args, stdoutBuffer, stderrBuffer)
+
+	if ec != 0 {
+		require.Failf(t, "The run did not finish successfully", "Error code = %v ; Error = %v", ec, stderrBuffer.String())
+	}
+
+	stdout := stdoutBuffer.String()
+	bom := cyclonedx.BOM{}
+	err := json.NewDecoder(strings.NewReader(stdout)).Decode(&bom)
+	require.NoError(t, err)
+
+	expectedBom := cyclonedx.BOM{
+		JSONSchema:  "http://cyclonedx.org/schema/bom-1.5.schema.json",
+		BOMFormat:   cyclonedx.BOMFormat,
+		SpecVersion: cyclonedx.SpecVersion1_5,
+		Version:     1,
+		Components: &[]cyclonedx.Component{
+			{
+				BOMRef:     "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+				PackageURL: "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+				Type:       "library",
+				Name:       "com.google.code.findbugs:jsr305",
+				Version:    "3.0.2",
+				Evidence: buildLocationEvidence(t, models.PackageLocations{
+					Block: models.PackageLocation{
+						Filename:    "/pom.xml",
+						LineStart:   25,
+						LineEnd:     28,
+						ColumnStart: 5,
+						ColumnEnd:   18,
+					},
+				}),
+			},
+		},
+	}
+	sbom_test.AssertBomEqual(t, expectedBom, bom, true)
+}
+
 func buildLocationEvidence(t *testing.T, packageLocations models.PackageLocations) *cyclonedx.Evidence {
 	t.Helper()
 	jsonLocation := strings.Builder{}

--- a/pkg/lockfile/extract_test.go
+++ b/pkg/lockfile/extract_test.go
@@ -52,9 +52,10 @@ func TestFindExtractor(t *testing.T) {
 		"requirements.txt":            "requirements.txt",
 		"yarn.lock":                   "yarn.lock",
 	}
-
+	enabledParsers := make(map[string]bool)
 	for file, extractAs := range lockfiles {
-		extractor, extractedAs := lockfile.FindExtractor("/path/to/my/"+file, "")
+		enabledParsers[extractAs] = true
+		extractor, extractedAs := lockfile.FindExtractor("/path/to/my/"+file, "", enabledParsers)
 
 		if extractor == nil {
 			t.Errorf("Expected a extractor to be found for %s but did not", file)
@@ -69,7 +70,10 @@ func TestFindExtractor(t *testing.T) {
 func TestFindExtractor_ExplicitExtractAs(t *testing.T) {
 	t.Parallel()
 
-	extractor, extractedAs := lockfile.FindExtractor("/path/to/my/package-lock.json", "composer.lock")
+	enabledParsers := map[string]bool{
+		"composer.lock": true,
+	}
+	extractor, extractedAs := lockfile.FindExtractor("/path/to/my/package-lock.json", "composer.lock", enabledParsers)
 
 	if extractor == nil {
 		t.Errorf("Expected a extractor to be found for package-lock.json (overridden as composer.lock) but did not")
@@ -103,11 +107,15 @@ func TestExtractDeps_FindsExpectedExtractor(t *testing.T) {
 		"requirements.txt",
 		"yarn.lock",
 	}
-
+	enabledParsers := make(map[string]bool)
+	for _, name := range lockfiles {
+		enabledParsers[name] = true
+	}
+	delete(enabledParsers, "buildscript-gradle.lockfile") // This extractor does not exists, it uses the gradle one
 	count := 0
 
 	for _, file := range lockfiles {
-		_, err := lockfile.ExtractDeps(openTestDepFile("/path/to/my/"+file), "")
+		_, err := lockfile.ExtractDeps(openTestDepFile("/path/to/my/"+file), "", enabledParsers)
 
 		if errors.Is(err, lockfile.ErrExtractorNotFound) {
 			t.Errorf("No extractor was found for %s", file)
@@ -125,7 +133,7 @@ func TestExtractDeps_FindsExpectedExtractor(t *testing.T) {
 func TestExtractDeps_ExtractorNotFound(t *testing.T) {
 	t.Parallel()
 
-	_, err := lockfile.ExtractDeps(openTestDepFile("/path/to/my/"), "")
+	_, err := lockfile.ExtractDeps(openTestDepFile("/path/to/my/"), "", map[string]bool{})
 
 	if err == nil {
 		t.Errorf("Expected to get an error but did not")
@@ -139,7 +147,7 @@ func TestExtractDeps_ExtractorNotFound(t *testing.T) {
 func TestExtractDeps_ExtractorNotFound_WithExplicitExtractAs(t *testing.T) {
 	t.Parallel()
 
-	_, err := lockfile.ExtractDeps(openTestDepFile("/path/to/my/"), "unsupported")
+	_, err := lockfile.ExtractDeps(openTestDepFile("/path/to/my/"), "unsupported", map[string]bool{})
 
 	if err == nil {
 		t.Errorf("Expected to get an error but did not")

--- a/pkg/lockfile/extract_test.go
+++ b/pkg/lockfile/extract_test.go
@@ -175,3 +175,13 @@ func TestListExtractors(t *testing.T) {
 		t.Errorf("Expected last element to be %s, but got %s", lastExpected, last)
 	}
 }
+
+func TestDisabledExtractor(t *testing.T) {
+	t.Parallel()
+
+	extractor, extractedAs := lockfile.FindExtractor("/path/to/my/composer.lock", "", map[string]bool{})
+
+	if extractor != nil {
+		t.Errorf("Expected no extractor to be found but one has been found (%s)", extractedAs)
+	}
+}

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -714,7 +714,7 @@ func initializeEnabledParsers(enabledParsers []string) map[string]bool {
 
 	if len(enabledParsers) == 0 {
 		// If the list is empty, it means the flag is not set on the CLI, everything should be enabled
-		for _, parser := range lockfile.ListParsers() {
+		for _, parser := range lockfile.ListExtractors() {
 			result[parser] = true
 		}
 	} else {

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -43,6 +43,7 @@ type ScannerActions struct {
 	CallAnalysisStates     map[string]bool
 	ConsiderScanPathAsRoot bool
 	PathRelativeToScanDir  bool
+	EnableParsers          []string
 
 	ExperimentalScannerActions
 }
@@ -101,7 +102,7 @@ const (
 //   - Any lockfiles with scanLockfile
 //   - Any SBOM files with scanSBOMFile
 //   - Any git repositories with scanGit
-func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useGitIgnore bool, compareOffline bool) ([]scannedPackage, error) {
+func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useGitIgnore bool, compareOffline bool, enabledParsers map[string]bool) ([]scannedPackage, error) {
 	var ignoreMatcher *gitIgnoreMatcher
 	if useGitIgnore {
 		var err error
@@ -157,8 +158,8 @@ func scanDir(r reporter.Reporter, dir string, skipGit bool, recursive bool, useG
 		}
 
 		if !info.IsDir() {
-			if extractor, _ := lockfile.FindExtractor(path, ""); extractor != nil {
-				pkgs, err := scanLockfile(r, path, "")
+			if extractor, _ := lockfile.FindExtractor(path, "", enabledParsers); extractor != nil {
+				pkgs, err := scanLockfile(r, path, "", enabledParsers)
 				if err != nil {
 					r.PrintWarnf("Attempted to scan lockfile but failed: %s (%v)\n", path, err.Error())
 				}
@@ -335,7 +336,7 @@ func (m *gitIgnoreMatcher) match(absPath string, isDir bool) (bool, error) {
 
 // scanLockfile will load, identify, and parse the lockfile path passed in, and add the dependencies specified
 // within to `query`
-func scanLockfile(r reporter.Reporter, path string, parseAs string) ([]scannedPackage, error) {
+func scanLockfile(r reporter.Reporter, path string, parseAs string, enabledParsers map[string]bool) ([]scannedPackage, error) {
 	var err error
 	var parsedLockfile lockfile.Lockfile
 
@@ -353,7 +354,7 @@ func scanLockfile(r reporter.Reporter, path string, parseAs string) ([]scannedPa
 		case "osv-scanner":
 			parsedLockfile, err = lockfile.FromOSVScannerResults(path)
 		default:
-			parsedLockfile, err = lockfile.ExtractDeps(f, parseAs)
+			parsedLockfile, err = lockfile.ExtractDeps(f, parseAs, enabledParsers)
 		}
 	}
 
@@ -708,8 +709,27 @@ type scannedPackage struct {
 	DepGroups []string
 }
 
+func initializeEnabledParsers(enabledParsers []string) map[string]bool {
+	result := make(map[string]bool)
+
+	if len(enabledParsers) == 0 {
+		// If the list is empty, it means the flag is not set on the CLI, everything should be enabled
+		for _, parser := range lockfile.ListParsers() {
+			result[parser] = true
+		}
+	} else {
+		for _, parser := range enabledParsers {
+			result[parser] = true
+		}
+	}
+
+	return result
+}
+
 // Perform osv scanner action, with optional reporter to output information
 func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityResults, error) {
+	enabledParsers := initializeEnabledParsers(actions.EnableParsers)
+
 	if r == nil {
 		r = &reporter.VoidReporter{}
 	}
@@ -760,7 +780,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 			r.PrintErrorf("Failed to resolved path with error %s\n", err)
 			return models.VulnerabilityResults{}, err
 		}
-		pkgs, err := scanLockfile(r, lockfilePath, parseAs)
+		pkgs, err := scanLockfile(r, lockfilePath, parseAs, enabledParsers)
 		if err != nil {
 			return models.VulnerabilityResults{}, err
 		}
@@ -785,7 +805,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 
 	for _, dir := range actions.DirectoryPaths {
 		r.PrintTextf("Scanning dir %s\n", dir)
-		pkgs, err := scanDir(r, dir, actions.SkipGit, actions.Recursive, !actions.NoIgnore, actions.CompareOffline)
+		pkgs, err := scanDir(r, dir, actions.SkipGit, actions.Recursive, !actions.NoIgnore, actions.CompareOffline, enabledParsers)
 		if err != nil {
 			return models.VulnerabilityResults{}, err
 		}


### PR DESCRIPTION
## What does this PR do?

This PR adds the possibility to explicitly choose the parsers in action when scanning the repository. For example, if you only want to reports from java maven and python requirements.txt you can set `--enable-parsers pom.xml --enable-parsers requirements.txt`. 

You can get the full list by running `osv-scanner --help`
