### PR TITLE
✨ Adding name location for go

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -236,7 +236,6 @@ func TestRun(t *testing.T) {
 				| https://osv.dev/GHSA-m8cg-xc2p-r3fc | 2.5  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 				| https://osv.dev/GHSA-vpvm-3wq2-2wvm | 7    | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 				| https://osv.dev/GHSA-xr7r-f8xq-vfvv | 8.6  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
-				| https://osv.dev/GHSA-c5pj-mqfh-rvc3 | 7.2  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 				| https://osv.dev/GHSA-p782-xgp4-8hr8 | 5.3  | Go        | golang.org/x/sys               | v0.0.0-20210817142637-7d9622a276b7 | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 				| https://osv.dev/GO-2022-0493        |      |           |                                |                                    |                                                 |
 				| https://osv.dev/DLA-3012-1          |      | Debian    | libxml2                        | 2.9.4+dfsg1-2.2+deb9u6             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -1998,6 +1997,13 @@ func TestRun_WithEncodedLockfile(t *testing.T) {
 						LineEnd:     5,
 						ColumnStart: 37,
 						ColumnEnd:   41,
+					},
+					Name: &models.PackageLocation{
+						Filename:    "go.mod",
+						LineStart:   5,
+						LineEnd:     5,
+						ColumnStart: 9,
+						ColumnEnd:   35,
 					},
 				}),
 			},

--- a/pkg/grouper/package_grouper.go
+++ b/pkg/grouper/package_grouper.go
@@ -67,15 +67,21 @@ func extractPackageLocations(pkgSource models.SourceInfo, pkgInfos models.Packag
 		},
 	}
 
-	if pkgInfos.VersionLocation != nil && isLocationExtractedSuccessfully(*pkgInfos.VersionLocation) {
-		locations.Version = &models.PackageLocation{
-			Filename:    pkgSource.Path,
-			LineStart:   pkgInfos.VersionLocation.Line.Start,
-			LineEnd:     pkgInfos.VersionLocation.Line.End,
-			ColumnStart: pkgInfos.VersionLocation.Column.Start,
-			ColumnEnd:   pkgInfos.VersionLocation.Column.End,
-		}
-	}
+	locations.Version = mapToPackageLocation(pkgSource.Path, pkgInfos.VersionLocation)
+	locations.Name = mapToPackageLocation(pkgSource.Path, pkgInfos.NameLocation)
 
 	return locations
+}
+
+func mapToPackageLocation(path string, location *models.FilePosition) *models.PackageLocation {
+	if location == nil || !isLocationExtractedSuccessfully(*location) {
+		return nil
+	}
+	return &models.PackageLocation{
+		Filename:    path,
+		LineStart:   location.Line.Start,
+		LineEnd:     location.Line.End,
+		ColumnStart: location.Column.Start,
+		ColumnEnd:   location.Column.End,
+	}
 }

--- a/pkg/grouper/package_grouper.go
+++ b/pkg/grouper/package_grouper.go
@@ -77,6 +77,7 @@ func mapToPackageLocation(path string, location *models.FilePosition) *models.Pa
 	if location == nil || !isLocationExtractedSuccessfully(*location) {
 		return nil
 	}
+
 	return &models.PackageLocation{
 		Filename:    path,
 		LineStart:   location.Line.Start,

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -94,6 +94,7 @@ func extractNamePosition(lines []string, name string, start modfile.Position, en
 		return nil
 	}
 	nameEndColumn := nameStartColumn + len(name)
+
 	return &models.FilePosition{
 		Line:   models.Position{Start: start.Line, End: end.Line},
 		Column: models.Position{Start: nameStartColumn, End: nameEndColumn},

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -82,6 +82,24 @@ func extractVersionPosition(lines []string, version string, start modfile.Positi
 	}
 }
 
+func extractNamePosition(lines []string, name string, start modfile.Position, end modfile.Position) *models.FilePosition {
+	if start.Line > len(lines) {
+		return nil
+	}
+
+	line := lines[start.Line-1]
+	nameStartColumn := strings.Index(line, name) + 1
+
+	if nameStartColumn == 0 {
+		return nil
+	}
+	nameEndColumn := nameStartColumn + len(name)
+	return &models.FilePosition{
+		Line:   models.Position{Start: start.Line, End: end.Line},
+		Column: models.Position{Start: nameStartColumn, End: nameEndColumn},
+	}
+}
+
 func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	var parsedLockfile *modfile.File
 
@@ -103,6 +121,7 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 		var end = require.Syntax.End
 		version := strings.TrimPrefix(require.Mod.Version, "v")
 		versionLocation := extractVersionPosition(lines, version, start, end)
+		nameLocation := extractNamePosition(lines, require.Mod.Path, start, end)
 
 		packages[require.Mod.Path+"@"+require.Mod.Version] = PackageDetails{
 			Name:      require.Mod.Path,
@@ -114,6 +133,7 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 				Column: models.Position{Start: start.LineRune, End: end.LineRune},
 			},
 			VersionLocation: versionLocation,
+			NameLocation:    nameLocation,
 		}
 	}
 
@@ -159,6 +179,7 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 					Column: models.Position{Start: start.LineRune, End: end.LineRune},
 				},
 				VersionLocation: extractVersionPosition(lines, version, start, end),
+				NameLocation:    extractNamePosition(lines, replace.New.Path, start, end),
 			}
 		}
 	}

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -524,6 +524,10 @@ func TestParseGoLock_Replacements_NoVersion(t *testing.T) {
 				Line:   models.Position{Start: 7, End: 7},
 				Column: models.Position{Start: 47, End: 51},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 7, End: 7},
+				Column: models.Position{Start: 25, End: 45},
+			},
 		},
 	})
 }

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -114,6 +114,10 @@ func TestParseGoLock_WithPathMajor(t *testing.T) {
 				Line:   models.Position{Start: 2, End: 2},
 				Column: models.Position{Start: 46, End: 46},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 2, End: 2},
+				Column: models.Position{Start: 9, End: 47},
+			},
 		},
 		{
 			Name:      "stdlib",
@@ -146,6 +150,10 @@ func TestParseGoLock_WithoutSupportedVersioning(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 2, End: 2},
 				Column: models.Position{Start: 1, End: 51},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 2, End: 2},
+				Column: models.Position{Start: 9, End: 44},
 			},
 		},
 		{
@@ -184,6 +192,10 @@ func TestParseGoLock_OnePackage(t *testing.T) {
 				Line:   models.Position{Start: 4, End: 4},
 				Column: models.Position{Start: 30, End: 34},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 4, End: 4},
+				Column: models.Position{Start: 2, End: 28},
+			},
 		},
 	})
 }
@@ -211,6 +223,10 @@ func TestParseGoLock_TwoPackages(t *testing.T) {
 				Line:   models.Position{Start: 6, End: 6},
 				Column: models.Position{Start: 30, End: 34},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 6, End: 6},
+				Column: models.Position{Start: 2, End: 28},
+			},
 		},
 		{
 			Name:      "gopkg.in/yaml.v2",
@@ -224,6 +240,10 @@ func TestParseGoLock_TwoPackages(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},
 				Column: models.Position{Start: 20, End: 24},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 7, End: 7},
+				Column: models.Position{Start: 2, End: 18},
 			},
 		},
 		{
@@ -258,6 +278,10 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 				Line:   models.Position{Start: 6, End: 6},
 				Column: models.Position{Start: 30, End: 34},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 6, End: 6},
+				Column: models.Position{Start: 2, End: 28},
+			},
 		},
 		{
 			Name:      "gopkg.in/yaml.v2",
@@ -271,6 +295,10 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},
 				Column: models.Position{Start: 20, End: 24},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 7, End: 7},
+				Column: models.Position{Start: 2, End: 18},
 			},
 		},
 		{
@@ -286,6 +314,10 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 				Line:   models.Position{Start: 11, End: 11},
 				Column: models.Position{Start: 33, End: 37},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 11, End: 11},
+				Column: models.Position{Start: 2, End: 31},
+			},
 		},
 		{
 			Name:      "github.com/mattn/go-isatty",
@@ -300,6 +332,10 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 				Line:   models.Position{Start: 12, End: 12},
 				Column: models.Position{Start: 30, End: 35},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 12, End: 12},
+				Column: models.Position{Start: 2, End: 28},
+			},
 		},
 		{
 			Name:      "golang.org/x/sys",
@@ -313,6 +349,10 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 13, End: 13},
 				Column: models.Position{Start: 20, End: 52},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 13, End: 13},
+				Column: models.Position{Start: 2, End: 18},
 			},
 		},
 		{
@@ -347,6 +387,10 @@ func TestParseGoLock_Replacements_One(t *testing.T) {
 				Line:   models.Position{Start: 5, End: 5},
 				Column: models.Position{Start: 58, End: 62},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 5, End: 5},
+				Column: models.Position{Start: 36, End: 56},
+			},
 		},
 	})
 }
@@ -374,6 +418,10 @@ func TestParseGoLock_Replacements_Mixed(t *testing.T) {
 				Line:   models.Position{Start: 7, End: 7},
 				Column: models.Position{Start: 54, End: 58},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 7, End: 7},
+				Column: models.Position{Start: 32, End: 52},
+			},
 		},
 		{
 			Name:      "golang.org/x/net",
@@ -387,6 +435,10 @@ func TestParseGoLock_Replacements_Mixed(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 3, End: 3},
 				Column: models.Position{Start: 23, End: 27},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 3, End: 3},
+				Column: models.Position{Start: 5, End: 21},
 			},
 		},
 	})
@@ -415,6 +467,10 @@ func TestParseGoLock_Replacements_Local(t *testing.T) {
 				Line:   models.Position{Start: 3, End: 3},
 				Column: models.Position{Start: 33, End: 37},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 3, End: 3},
+				Column: models.Position{Start: 5, End: 31},
+			},
 		},
 	})
 }
@@ -442,6 +498,10 @@ func TestParseGoLock_Replacements_Different(t *testing.T) {
 				Line:   models.Position{Start: 7, End: 7},
 				Column: models.Position{Start: 54, End: 58},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 7, End: 7},
+				Column: models.Position{Start: 32, End: 52},
+			},
 		},
 		{
 			Name:      "example.com/fork/foe",
@@ -455,6 +515,10 @@ func TestParseGoLock_Replacements_Different(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 8, End: 8},
 				Column: models.Position{Start: 54, End: 58},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 8, End: 8},
+				Column: models.Position{Start: 32, End: 52},
 			},
 		},
 	})
@@ -483,6 +547,10 @@ func TestParseGoLock_Replacements_NotRequired(t *testing.T) {
 				Line:   models.Position{Start: 2, End: 2},
 				Column: models.Position{Start: 23, End: 27},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 2, End: 2},
+				Column: models.Position{Start: 5, End: 21},
+			},
 		},
 		{
 			Name:      "github.com/BurntSushi/toml",
@@ -496,6 +564,10 @@ func TestParseGoLock_Replacements_NotRequired(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 3, End: 3},
 				Column: models.Position{Start: 33, End: 37},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 3, End: 3},
+				Column: models.Position{Start: 5, End: 31},
 			},
 		},
 	})

--- a/pkg/lockfile/types.go
+++ b/pkg/lockfile/types.go
@@ -12,6 +12,7 @@ type PackageDetails struct {
 	DepGroups       []string             `json:"-"`
 	BlockLocation   models.FilePosition  `json:"blockLocation,omitempty"`
 	VersionLocation *models.FilePosition `json:"versionLocation,omitempty"`
+	NameLocation    *models.FilePosition `json:"nameLocation,omitempty"`
 }
 
 type Ecosystem string

--- a/pkg/models/results.go
+++ b/pkg/models/results.go
@@ -172,4 +172,5 @@ type PackageInfo struct {
 	Commit          string        `json:"commit,omitempty"`
 	BlockLocation   FilePosition  `json:"blockLocation,omitempty"`
 	VersionLocation *FilePosition `json:"versionLocation,omitempty"`
+	NameLocation    *FilePosition `json:"nameLocation,omitempty"`
 }

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -396,6 +396,7 @@ func scanLockfile(r reporter.Reporter, path string, parseAs string, enabledParse
 			},
 			BlockLocation:   pkgDetail.BlockLocation,
 			VersionLocation: pkgDetail.VersionLocation,
+			NameLocation:    pkgDetail.NameLocation,
 		}
 	}
 
@@ -707,6 +708,7 @@ type scannedPackage struct {
 	DepGroups       []string
 	BlockLocation   models.FilePosition
 	VersionLocation *models.FilePosition
+	NameLocation    *models.FilePosition
 }
 
 func initializeEnabledParsers(enabledParsers []string) map[string]bool {

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -145,6 +145,7 @@ func groupBySource(r reporter.Reporter, packages []scannedPackage) models.Vulner
 		pkg.Groups = nil
 		pkg.Package.BlockLocation = p.BlockLocation
 		pkg.Package.VersionLocation = p.VersionLocation
+		pkg.Package.NameLocation = p.NameLocation
 		groupedBySource[p.Source] = append(groupedBySource[p.Source], pkg)
 	}
 


### PR DESCRIPTION
## What does this PR do?

- Extracting name location the same way we did for version (go only)
- Wiring name location extraction up to the grouper to be taken into account in the reporter
