### PR TITLE
♻️ ExtractStringPositionInBlock utility 

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -1996,7 +1996,7 @@ func TestRun_WithEncodedLockfile(t *testing.T) {
 						LineStart:   5,
 						LineEnd:     5,
 						ColumnStart: 37,
-						ColumnEnd:   41,
+						ColumnEnd:   42,
 					},
 					Name: &models.PackageLocation{
 						Filename:    "go.mod",

--- a/internal/utility/fileposition/string.go
+++ b/internal/utility/fileposition/string.go
@@ -7,8 +7,13 @@ import (
 )
 
 func ExtractStringPositionInBlock(block []string, str string, blockStartLine int) *models.FilePosition {
+	return ExtractDelimitedStringPositionInBlock(block, str, blockStartLine, "", "")
+}
+
+func ExtractDelimitedStringPositionInBlock(block []string, str string, blockStartLine int, prefix string, suffix string) *models.FilePosition {
 	for i, line := range block {
-		if strings.Contains(line, str) {
+		search := prefix + str + suffix
+		if strings.Contains(line, search) {
 			linePosition := blockStartLine + i
 			columnStart := strings.Index(line, str) + 1
 			columnEnd := columnStart + len(str)

--- a/internal/utility/fileposition/string.go
+++ b/internal/utility/fileposition/string.go
@@ -1,8 +1,9 @@
 package fileposition
 
 import (
-	"github.com/google/osv-scanner/pkg/models"
 	"strings"
+
+	"github.com/google/osv-scanner/pkg/models"
 )
 
 func ExtractStringPositionInBlock(block []string, str string, blockStartLine int) *models.FilePosition {
@@ -18,5 +19,6 @@ func ExtractStringPositionInBlock(block []string, str string, blockStartLine int
 			}
 		}
 	}
+
 	return nil
 }

--- a/internal/utility/fileposition/string.go
+++ b/internal/utility/fileposition/string.go
@@ -1,0 +1,22 @@
+package fileposition
+
+import (
+	"github.com/google/osv-scanner/pkg/models"
+	"strings"
+)
+
+func ExtractStringPositionInBlock(block []string, str string, blockStartLine int) *models.FilePosition {
+	for i, line := range block {
+		if strings.Contains(line, str) {
+			linePosition := blockStartLine + i
+			columnStart := strings.Index(line, str) + 1
+			columnEnd := columnStart + len(str)
+
+			return &models.FilePosition{
+				Line:   models.Position{Start: linePosition, End: linePosition},
+				Column: models.Position{Start: columnStart, End: columnEnd},
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -2,11 +2,12 @@ package lockfile
 
 import (
 	"fmt"
-	"github.com/google/osv-scanner/internal/utility/fileposition"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/osv-scanner/internal/utility/fileposition"
 
 	"golang.org/x/mod/module"
 

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -2,6 +2,7 @@ package lockfile
 
 import (
 	"fmt"
+	"github.com/google/osv-scanner/internal/utility/fileposition"
 	"io"
 	"os"
 	"path/filepath"
@@ -57,50 +58,6 @@ func splitLines(data []byte) []string {
 	str := string(data)
 	return strings.Split(str, "\n")
 }
-
-func extractVersionPosition(lines []string, version string, start modfile.Position, end modfile.Position) *models.FilePosition {
-	if start.Line > len(lines) {
-		return nil
-	}
-
-	line := lines[start.Line-1]
-	versionStartColumn := strings.LastIndex(line, version) + 1 // column start is 1-based
-
-	if versionStartColumn == 0 {
-		// It may happen if the version is not defined in the gomod file
-		// e.g. `require github.com/elastic/go-elasticsearch master`
-		// In this case the reported version is v0.0.0 (see func `defaultNonCanonicalVersions`).
-		return nil
-	}
-
-	// versionStartColumn is the first character of the version, we should not count it to calculate the end
-	versionEndColumn := versionStartColumn + len(version) - 1
-
-	return &models.FilePosition{
-		Line:   models.Position{Start: start.Line, End: end.Line},
-		Column: models.Position{Start: versionStartColumn, End: versionEndColumn},
-	}
-}
-
-func extractNamePosition(lines []string, name string, start modfile.Position, end modfile.Position) *models.FilePosition {
-	if start.Line > len(lines) {
-		return nil
-	}
-
-	line := lines[start.Line-1]
-	nameStartColumn := strings.Index(line, name) + 1
-
-	if nameStartColumn == 0 {
-		return nil
-	}
-	nameEndColumn := nameStartColumn + len(name)
-
-	return &models.FilePosition{
-		Line:   models.Position{Start: start.Line, End: end.Line},
-		Column: models.Position{Start: nameStartColumn, End: nameEndColumn},
-	}
-}
-
 func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	var parsedLockfile *modfile.File
 
@@ -120,12 +77,12 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	for _, require := range parsedLockfile.Require {
 		var start = require.Syntax.Start
 		var end = require.Syntax.End
+		block := lines[start.Line-1 : end.Line]
 		version := strings.TrimPrefix(require.Mod.Version, "v")
-		versionLocation := extractVersionPosition(lines, version, start, end)
-		nameLocation := extractNamePosition(lines, require.Mod.Path, start, end)
+		name := require.Mod.Path
 
 		packages[require.Mod.Path+"@"+require.Mod.Version] = PackageDetails{
-			Name:      require.Mod.Path,
+			Name:      name,
 			Version:   version,
 			Ecosystem: GoEcosystem,
 			CompareAs: GoEcosystem,
@@ -133,14 +90,15 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 				Line:   models.Position{Start: start.Line, End: end.Line},
 				Column: models.Position{Start: start.LineRune, End: end.LineRune},
 			},
-			VersionLocation: versionLocation,
-			NameLocation:    nameLocation,
+			VersionLocation: fileposition.ExtractStringPositionInBlock(block, version, start.Line),
+			NameLocation:    fileposition.ExtractStringPositionInBlock(block, name, start.Line),
 		}
 	}
 
 	for _, replace := range parsedLockfile.Replace {
 		var start = replace.Syntax.Start
 		var end = replace.Syntax.End
+		block := lines[start.Line-1 : end.Line]
 		var replacements []string
 
 		if replace.Old.Version == "" {
@@ -163,6 +121,7 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 
 		for _, replacement := range replacements {
 			version := strings.TrimPrefix(replace.New.Version, "v")
+			name := replace.New.Path
 
 			if len(version) == 0 {
 				// There is no version specified on the replacement, it means the artifact is directly accessible
@@ -171,7 +130,7 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 				continue
 			}
 			packages[replacement] = PackageDetails{
-				Name:      replace.New.Path,
+				Name:      name,
 				Version:   version,
 				Ecosystem: GoEcosystem,
 				CompareAs: GoEcosystem,
@@ -179,8 +138,8 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 					Line:   models.Position{Start: start.Line, End: end.Line},
 					Column: models.Position{Start: start.LineRune, End: end.LineRune},
 				},
-				VersionLocation: extractVersionPosition(lines, version, start, end),
-				NameLocation:    extractNamePosition(lines, replace.New.Path, start, end),
+				VersionLocation: fileposition.ExtractStringPositionInBlock(block, version, start.Line),
+				NameLocation:    fileposition.ExtractStringPositionInBlock(block, name, start.Line),
 			}
 		}
 	}

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -1,7 +1,6 @@
 package lockfile_test
 
 import (
-	"fmt"
 	"io/fs"
 	"testing"
 
@@ -101,10 +100,6 @@ func TestParseGoLock_WithPathMajor(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	for _, p := range packages {
-		fmt.Println(p.VersionLocation)
-		fmt.Println(p.NameLocation)
-	}
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "github.com/elastic/go-elasticsearch/v8",

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -1,6 +1,7 @@
 package lockfile_test
 
 import (
+	"fmt"
 	"io/fs"
 	"testing"
 
@@ -100,6 +101,10 @@ func TestParseGoLock_WithPathMajor(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
+	for _, p := range packages {
+		fmt.Println(p.VersionLocation)
+		fmt.Println(p.NameLocation)
+	}
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "github.com/elastic/go-elasticsearch/v8",
@@ -112,7 +117,7 @@ func TestParseGoLock_WithPathMajor(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 2, End: 2},
-				Column: models.Position{Start: 46, End: 46},
+				Column: models.Position{Start: 46, End: 47},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 2, End: 2},
@@ -190,7 +195,7 @@ func TestParseGoLock_OnePackage(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 4, End: 4},
-				Column: models.Position{Start: 30, End: 34},
+				Column: models.Position{Start: 30, End: 35},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 4, End: 4},
@@ -221,7 +226,7 @@ func TestParseGoLock_TwoPackages(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 6, End: 6},
-				Column: models.Position{Start: 30, End: 34},
+				Column: models.Position{Start: 30, End: 35},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 6, End: 6},
@@ -239,7 +244,7 @@ func TestParseGoLock_TwoPackages(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},
-				Column: models.Position{Start: 20, End: 24},
+				Column: models.Position{Start: 20, End: 25},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},
@@ -276,7 +281,7 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 6, End: 6},
-				Column: models.Position{Start: 30, End: 34},
+				Column: models.Position{Start: 30, End: 35},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 6, End: 6},
@@ -294,7 +299,7 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},
-				Column: models.Position{Start: 20, End: 24},
+				Column: models.Position{Start: 20, End: 25},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},
@@ -312,7 +317,7 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 11, End: 11},
-				Column: models.Position{Start: 33, End: 37},
+				Column: models.Position{Start: 33, End: 38},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 11, End: 11},
@@ -330,7 +335,7 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 12, End: 12},
-				Column: models.Position{Start: 30, End: 35},
+				Column: models.Position{Start: 30, End: 36},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 12, End: 12},
@@ -348,7 +353,7 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 13, End: 13},
-				Column: models.Position{Start: 20, End: 52},
+				Column: models.Position{Start: 20, End: 53},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 13, End: 13},
@@ -385,7 +390,7 @@ func TestParseGoLock_Replacements_One(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 5, End: 5},
-				Column: models.Position{Start: 58, End: 62},
+				Column: models.Position{Start: 58, End: 63},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 5, End: 5},
@@ -416,7 +421,7 @@ func TestParseGoLock_Replacements_Mixed(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},
-				Column: models.Position{Start: 54, End: 58},
+				Column: models.Position{Start: 54, End: 59},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},
@@ -434,7 +439,7 @@ func TestParseGoLock_Replacements_Mixed(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 3, End: 3},
-				Column: models.Position{Start: 23, End: 27},
+				Column: models.Position{Start: 23, End: 28},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 3, End: 3},
@@ -465,7 +470,7 @@ func TestParseGoLock_Replacements_Local(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 3, End: 3},
-				Column: models.Position{Start: 33, End: 37},
+				Column: models.Position{Start: 33, End: 38},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 3, End: 3},
@@ -496,7 +501,7 @@ func TestParseGoLock_Replacements_Different(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},
-				Column: models.Position{Start: 54, End: 58},
+				Column: models.Position{Start: 54, End: 59},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},
@@ -514,7 +519,7 @@ func TestParseGoLock_Replacements_Different(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 8, End: 8},
-				Column: models.Position{Start: 54, End: 58},
+				Column: models.Position{Start: 54, End: 59},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 8, End: 8},
@@ -545,7 +550,7 @@ func TestParseGoLock_Replacements_NotRequired(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 2, End: 2},
-				Column: models.Position{Start: 23, End: 27},
+				Column: models.Position{Start: 23, End: 28},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 2, End: 2},
@@ -563,7 +568,7 @@ func TestParseGoLock_Replacements_NotRequired(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 3, End: 3},
-				Column: models.Position{Start: 33, End: 37},
+				Column: models.Position{Start: 33, End: 38},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 3, End: 3},
@@ -594,7 +599,7 @@ func TestParseGoLock_Replacements_NoVersion(t *testing.T) {
 			},
 			VersionLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},
-				Column: models.Position{Start: 47, End: 51},
+				Column: models.Position{Start: 47, End: 52},
 			},
 			NameLocation: &models.FilePosition{
 				Line:   models.Position{Start: 7, End: 7},


### PR DESCRIPTION
We realized that the logic to find any substring in an already located block could be abstracted to ease the following work on extracting the name and version in the different package managers.

This PR adds the generic function `ExtractStringPositionInBlock` and refactor the go lockfile parser to use it.