### PR TITLE
✨Extracting name and version location for maven lock files

### DIFF
--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -1278,7 +1278,8 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										}
+										},
+										"file_name": null
 									}
 								},
 								"licenses": [
@@ -1298,7 +1299,8 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										}
+										},
+										"file_name": null
 									}
 								},
 								"licenses": [
@@ -1321,7 +1323,8 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										}
+										},
+										"file_name": null
 									}
 								},
 								"licenses": [
@@ -1422,7 +1425,8 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										}
+										},
+										"file_name": null
 									}
 								},
 								"licenses": [
@@ -1494,7 +1498,8 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										}
+										},
+										"file_name": null
 									}
 								},
 								"licenses": [
@@ -1514,7 +1519,8 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										}
+										},
+										"file_name": null
 									}
 								},
 								"licenses": [
@@ -1534,7 +1540,8 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										}
+										},
+										"file_name": null
 									}
 								},
 								"licenses": [
@@ -1636,7 +1643,8 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										}
+										},
+										"file_name": null
 									}
 								},
 								"licenses": [
@@ -1656,7 +1664,8 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										}
+										},
+										"file_name": null
 									}
 								},
 								"licenses": [
@@ -1676,7 +1685,8 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										}
+										},
+										"file_name": null
 									}
 								},
 								"licenses": [
@@ -1865,6 +1875,20 @@ func TestRun_WithCycloneDX15(t *testing.T) {
 						ColumnStart: 5,
 						ColumnEnd:   18,
 					},
+					Name: &models.PackageLocation{
+						Filename:    "/pom.xml",
+						LineStart:   27,
+						LineEnd:     27,
+						ColumnStart: 19,
+						ColumnEnd:   25,
+					},
+					Version: &models.PackageLocation{
+						Filename:    "/pom.xml",
+						LineStart:   19,
+						LineEnd:     19,
+						ColumnStart: 18,
+						ColumnEnd:   23,
+					},
 				}),
 			},
 			{
@@ -1923,6 +1947,20 @@ func TestRun_WithExplicitParsers(t *testing.T) {
 						LineEnd:     28,
 						ColumnStart: 5,
 						ColumnEnd:   18,
+					},
+					Name: &models.PackageLocation{
+						Filename:    "/pom.xml",
+						LineStart:   27,
+						LineEnd:     27,
+						ColumnStart: 19,
+						ColumnEnd:   25,
+					},
+					Version: &models.PackageLocation{
+						Filename:    "/pom.xml",
+						LineStart:   19,
+						LineEnd:     19,
+						ColumnStart: 18,
+						ColumnEnd:   23,
 					},
 				}),
 			},
@@ -2108,6 +2146,20 @@ func TestRun_WithEncodedLockfile(t *testing.T) {
 						LineEnd:     28,
 						ColumnStart: 5,
 						ColumnEnd:   18,
+					},
+					Name: &models.PackageLocation{
+						Filename:    "pom.xml",
+						LineStart:   27,
+						LineEnd:     27,
+						ColumnStart: 19,
+						ColumnEnd:   25,
+					},
+					Version: &models.PackageLocation{
+						Filename:    "pom.xml",
+						LineStart:   19,
+						LineEnd:     19,
+						ColumnStart: 18,
+						ColumnEnd:   23,
 					},
 				}),
 			},

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -1278,8 +1278,7 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										},
-										"file_name": null
+										}
 									}
 								},
 								"licenses": [
@@ -1299,8 +1298,7 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										},
-										"file_name": null
+										}
 									}
 								},
 								"licenses": [
@@ -1323,8 +1321,7 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										},
-										"file_name": null
+										}
 									}
 								},
 								"licenses": [
@@ -1425,8 +1422,7 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										},
-										"file_name": null
+										}
 									}
 								},
 								"licenses": [
@@ -1498,8 +1494,7 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										},
-										"file_name": null
+										}
 									}
 								},
 								"licenses": [
@@ -1519,8 +1514,7 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										},
-										"file_name": null
+										}
 									}
 								},
 								"licenses": [
@@ -1540,8 +1534,7 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										},
-										"file_name": null
+										}
 									}
 								},
 								"licenses": [
@@ -1643,8 +1636,7 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										},
-										"file_name": null
+										}
 									}
 								},
 								"licenses": [
@@ -1664,8 +1656,7 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										},
-										"file_name": null
+										}
 									}
 								},
 								"licenses": [
@@ -1685,8 +1676,7 @@ Filtered 2 vulnerabilities from output
 										"column": {
 											"start": 5,
 											"end": 6
-										},
-										"file_name": null
+										}
 									}
 								},
 								"licenses": [

--- a/internal/cachedregexp/regex.go
+++ b/internal/cachedregexp/regex.go
@@ -15,3 +15,7 @@ func MustCompile(exp string) *regexp.Regexp {
 
 	return compiled.(*regexp.Regexp)
 }
+
+func QuoteMeta(s string) string {
+	return regexp.QuoteMeta(s)
+}

--- a/internal/utility/fileposition/string.go
+++ b/internal/utility/fileposition/string.go
@@ -3,8 +3,26 @@ package fileposition
 import (
 	"strings"
 
+	"github.com/google/osv-scanner/internal/cachedregexp"
+
 	"github.com/google/osv-scanner/pkg/models"
 )
+
+func BytesToLines(data []byte) []string {
+	str := string(data)
+	return strings.Split(str, "\n")
+}
+
+func extractPositionFromLine(blockStartLine int, i int, line string, str string) *models.FilePosition {
+	linePosition := blockStartLine + i
+	columnStart := strings.Index(line, str) + 1
+	columnEnd := columnStart + len(str)
+
+	return &models.FilePosition{
+		Line:   models.Position{Start: linePosition, End: linePosition},
+		Column: models.Position{Start: columnStart, End: columnEnd},
+	}
+}
 
 func ExtractStringPositionInBlock(block []string, str string, blockStartLine int) *models.FilePosition {
 	return ExtractDelimitedStringPositionInBlock(block, str, blockStartLine, "", "")
@@ -14,14 +32,29 @@ func ExtractDelimitedStringPositionInBlock(block []string, str string, blockStar
 	for i, line := range block {
 		search := prefix + str + suffix
 		if strings.Contains(line, search) {
-			linePosition := blockStartLine + i
-			columnStart := strings.Index(line, str) + 1
-			columnEnd := columnStart + len(str)
+			return extractPositionFromLine(blockStartLine, i, line, str)
+		}
+	}
 
-			return &models.FilePosition{
-				Line:   models.Position{Start: linePosition, End: linePosition},
-				Column: models.Position{Start: columnStart, End: columnEnd},
+	return nil
+}
+
+func ExtractRegexpPositionInBlock(block []string, str string, blockStartLine int) *models.FilePosition {
+	return ExtractDelimitedRegexpPositionInBlock(block, str, blockStartLine, "", "")
+}
+
+func ExtractDelimitedRegexpPositionInBlock(block []string, str string, blockStartLine int, prefix string, suffix string) *models.FilePosition {
+	// We expect 'str' to be a literal value or in case it is a regexp to be only one capturing group
+	regex := cachedregexp.MustCompile(cachedregexp.QuoteMeta(prefix) + str + cachedregexp.QuoteMeta(suffix))
+	for i, line := range block {
+		matches := regex.FindStringSubmatch(line)
+		if len(matches) > 0 {
+			// A group was captured -> Replace group regexp with captured value
+			if len(matches) == 2 {
+				str = matches[1]
 			}
+
+			return extractPositionFromLine(blockStartLine, i, line, str)
 		}
 	}
 

--- a/internal/utility/fileposition/string.go
+++ b/internal/utility/fileposition/string.go
@@ -13,8 +13,7 @@ func BytesToLines(data []byte) []string {
 	return strings.Split(str, "\n")
 }
 
-func extractPositionFromLine(blockStartLine int, i int, line string, str string) *models.FilePosition {
-	linePosition := blockStartLine + i
+func extractPositionFromLine(linePosition int, line string, str string) *models.FilePosition {
 	columnStart := strings.Index(line, str) + 1
 	columnEnd := columnStart + len(str)
 
@@ -32,7 +31,7 @@ func ExtractDelimitedStringPositionInBlock(block []string, str string, blockStar
 	for i, line := range block {
 		search := prefix + str + suffix
 		if strings.Contains(line, search) {
-			return extractPositionFromLine(blockStartLine, i, line, str)
+			return extractPositionFromLine(blockStartLine+i, line, str)
 		}
 	}
 
@@ -54,7 +53,7 @@ func ExtractDelimitedRegexpPositionInBlock(block []string, str string, blockStar
 				str = matches[1]
 			}
 
-			return extractPositionFromLine(blockStartLine, i, line, str)
+			return extractPositionFromLine(blockStartLine+i, line, str)
 		}
 	}
 

--- a/pkg/grouper/package_grouper.go
+++ b/pkg/grouper/package_grouper.go
@@ -78,8 +78,8 @@ func mapToPackageLocation(path string, location *models.FilePosition) *models.Pa
 		return nil
 	}
 
-	if location.FileName != nil {
-		path = *location.FileName
+	if location.Filename != nil {
+		path = *location.Filename
 	}
 
 	return &models.PackageLocation{

--- a/pkg/grouper/package_grouper.go
+++ b/pkg/grouper/package_grouper.go
@@ -78,6 +78,10 @@ func mapToPackageLocation(path string, location *models.FilePosition) *models.Pa
 		return nil
 	}
 
+	if location.FileName != nil {
+		path = *location.FileName
+	}
+
 	return &models.PackageLocation{
 		Filename:    path,
 		LineStart:   location.Line.Start,

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -55,15 +55,11 @@ func (e GoLockExtractor) ShouldExtract(path string) bool {
 	return filepath.Base(path) == "go.mod"
 }
 
-func splitLines(data []byte) []string {
-	str := string(data)
-	return strings.Split(str, "\n")
-}
 func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	var parsedLockfile *modfile.File
 
 	b, err := io.ReadAll(f)
-	lines := splitLines(b)
+	lines := fileposition.BytesToLines(b)
 
 	if err == nil {
 		parsedLockfile, err = modfile.Parse(f.Path(), b, defaultNonCanonicalVersions)

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -88,7 +88,7 @@ func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fi
 			}
 			position = fileposition.ExtractRegexpPositionInBlock(lockfile.Lines[projectPropertySourceFile], property, 1)
 			if projectPropertySourceFile != lockfile.MainSourceFile {
-				position.FileName = &projectPropertySourceFile
+				position.Filename = &projectPropertySourceFile
 			}
 		} else {
 			lockProperty, ok = lockfile.Properties.m[propName]
@@ -101,7 +101,7 @@ func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fi
 					// We should locate the property in its source file
 					position = fileposition.ExtractDelimitedRegexpPositionInBlock(lockfile.Lines[lockProperty.SourceFile], "(.*)", 1, propOpenTag, propCloseTag)
 					if lockProperty.SourceFile != lockfile.MainSourceFile {
-						position.FileName = &(lockProperty.SourceFile)
+						position.Filename = &(lockProperty.SourceFile)
 					}
 				}
 			}
@@ -431,7 +431,7 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 
 			pkgDetails.VersionLocation = versionPosition
 			if lockPackage.SourceFile != pkgDetails.SourceFile {
-				pkgDetails.VersionLocation.FileName = &(lockPackage.SourceFile)
+				pkgDetails.VersionLocation.Filename = &(lockPackage.SourceFile)
 			}
 		}
 		if strings.TrimSpace(lockPackage.Scope) != "" {

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -1,13 +1,18 @@
 package lockfile
 
 import (
+	"bytes"
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/osv-scanner/internal/utility/fileposition"
+	"golang.org/x/exp/maps"
 
 	"github.com/google/osv-scanner/internal/utility/filereader"
 
@@ -49,13 +54,21 @@ func buildProjectProperties(lockfile MavenLockFile) map[string]string {
 /*
 You can see the regex working here : https://regex101.com/r/inAPiN/2
 */
-func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fieldToResolve string) string {
+func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fieldToResolve string) (string, *models.FilePosition) {
+	var position *models.FilePosition
+	variablesCount := 0
+
 	interpolationReg := cachedregexp.MustCompile(`\${([^}]+)}`)
 	projectProperties := buildProjectProperties(lockfile)
 
 	result := interpolationReg.ReplaceAllFunc([]byte(fieldToResolve), func(bytes []byte) []byte {
+		variablesCount += 1
 		propStr := string(bytes)
 		propName := propStr[2 : len(propStr)-1]
+		propOpenTag := fmt.Sprintf("<%s>", propName)
+		propCloseTag := fmt.Sprintf("</%s>", propName)
+
+		var lockProperty MavenLockProperty
 		var property string
 		var ok bool
 
@@ -67,11 +80,30 @@ func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fi
 		// If the fieldToResolve is the internal version fieldToResolve, then lets use the one declared
 		if strings.HasPrefix(propName, "project.") {
 			property, ok = projectProperties[propName]
+			// The property is located in the main source file...
+			projectPropertySourceFile := lockfile.MainSourceFile
+			// Except if it is the version -> It could be located in some parent file
+			if strings.HasSuffix(propName, "version") {
+				projectPropertySourceFile = lockfile.ProjectVersionSourceFile
+			}
+			position = fileposition.ExtractRegexpPositionInBlock(lockfile.Lines[projectPropertySourceFile], property, 1)
+			if projectPropertySourceFile != lockfile.MainSourceFile {
+				position.FileName = &projectPropertySourceFile
+			}
 		} else {
-			property, ok = lockfile.Properties.m[propName]
-			if ok && interpolationReg.MatchString(property) {
-				// Property uses other properties
-				property = mld.resolvePropertiesValue(lockfile, property)
+			lockProperty, ok = lockfile.Properties.m[propName]
+			if ok {
+				property = lockProperty.Property
+				if interpolationReg.MatchString(property) {
+					// Property uses other properties
+					property, position = mld.resolvePropertiesValue(lockfile, property)
+				} else {
+					// We should locate the property in its source file
+					position = fileposition.ExtractDelimitedRegexpPositionInBlock(lockfile.Lines[lockProperty.SourceFile], "(.*)", 1, propOpenTag, propCloseTag)
+					if lockProperty.SourceFile != lockfile.MainSourceFile {
+						position.FileName = &(lockProperty.SourceFile)
+					}
+				}
 			}
 		}
 
@@ -90,49 +122,61 @@ func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fi
 		return []byte(property)
 	})
 
-	return string(result)
+	if variablesCount > 1 {
+		position = nil
+	}
+
+	return string(result), position
 }
 
-func (mld MavenLockDependency) ResolveVersion(lockfile MavenLockFile) string {
+func (mld MavenLockDependency) ResolveVersion(lockfile MavenLockFile) (string, *models.FilePosition) {
 	versionRequirementReg := cachedregexp.MustCompile(`[[(]?(.*?)(?:,|[)\]]|$)`)
-	version := mld.resolvePropertiesValue(lockfile, mld.Version)
+	version, position := mld.resolvePropertiesValue(lockfile, mld.Version)
 	results := versionRequirementReg.FindStringSubmatch(version)
 
 	if results == nil || results[1] == "" {
-		return "0"
+		return "0", nil
 	}
 
-	return results[1]
+	return results[1], position
 }
 
-func (mld MavenLockDependency) ResolveArtifactID(lockfile MavenLockFile) string {
+func (mld MavenLockDependency) ResolveArtifactID(lockfile MavenLockFile) (string, *models.FilePosition) {
 	return mld.resolvePropertiesValue(lockfile, mld.ArtifactID)
 }
 
-func (mld MavenLockDependency) ResolveGroupID(lockfile MavenLockFile) string {
+func (mld MavenLockDependency) ResolveGroupID(lockfile MavenLockFile) (string, *models.FilePosition) {
 	return mld.resolvePropertiesValue(lockfile, mld.GroupID)
 }
 
 type MavenLockFile struct {
-	XMLName             xml.Name                  `xml:"project"`
-	Parent              MavenLockParent           `xml:"parent"`
-	Version             string                    `xml:"version"`
-	ModelVersion        string                    `xml:"modelVersion"`
-	GroupID             string                    `xml:"groupId"`
-	ArtifactID          string                    `xml:"artifactId"`
-	Properties          MavenLockProperties       `xml:"properties"`
-	Dependencies        MavenLockDependencyHolder `xml:"dependencies"`
-	ManagedDependencies MavenLockDependencyHolder `xml:"dependencyManagement>dependencies"`
+	XMLName                  xml.Name                  `xml:"project"`
+	Parent                   MavenLockParent           `xml:"parent"`
+	Version                  string                    `xml:"version"`
+	ModelVersion             string                    `xml:"modelVersion"`
+	GroupID                  string                    `xml:"groupId"`
+	ArtifactID               string                    `xml:"artifactId"`
+	Properties               MavenLockProperties       `xml:"properties"`
+	Dependencies             MavenLockDependencyHolder `xml:"dependencies"`
+	ManagedDependencies      MavenLockDependencyHolder `xml:"dependencyManagement>dependencies"`
+	MainSourceFile           string
+	ProjectVersionSourceFile string
+	Lines                    map[string][]string
 }
 
 const MavenEcosystem Ecosystem = "Maven"
 
+type MavenLockProperty struct {
+	Property   string
+	SourceFile string
+}
+
 type MavenLockProperties struct {
-	m map[string]string
+	m map[string]MavenLockProperty
 }
 
 func (p *MavenLockProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	p.m = map[string]string{}
+	p.m = map[string]MavenLockProperty{}
 
 	for {
 		t, err := d.Token()
@@ -148,7 +192,9 @@ func (p *MavenLockProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElemen
 				return fmt.Errorf("%w", err)
 			}
 
-			p.m[tt.Name.Local] = s
+			p.m[tt.Name.Local] = MavenLockProperty{
+				Property: s,
+			}
 
 		case xml.EndElement:
 			if tt.Name == start.Name {
@@ -206,10 +252,17 @@ func (e MavenLockExtractor) mergeLockfiles(childLockfile *MavenLockFile, parentL
 	parentLockfile.GroupID = childLockfile.GroupID
 	parentLockfile.ModelVersion = childLockfile.ModelVersion
 
+	// Merge lock file lines
+	maps.Copy(parentLockfile.Lines, childLockfile.Lines)
+
 	// If child lockfile overrides the project version, let's use it instead
 	if len(childLockfile.Version) > 0 {
 		parentLockfile.Version = childLockfile.Version
+		parentLockfile.ProjectVersionSourceFile = parentLockfile.MainSourceFile
 	}
+
+	// Keep track of the main source file
+	parentLockfile.MainSourceFile = childLockfile.MainSourceFile
 
 	// Child properties take precedence over parent defined ones
 	for key, value := range childLockfile.Properties.m {
@@ -234,22 +287,46 @@ func (e MavenLockExtractor) enrichDependencies(f DepFile, dependencies []MavenLo
 	return MavenLockDependencyHolder{Dependencies: result}
 }
 
+func (e MavenLockExtractor) enrichProperties(f DepFile, properties map[string]MavenLockProperty) MavenLockProperties {
+	for key, property := range properties {
+		if len(property.SourceFile) == 0 {
+			property.SourceFile = f.Path()
+		}
+		properties[key] = property
+	}
+
+	return MavenLockProperties{m: properties}
+}
+
 func (e MavenLockExtractor) decodeMavenFile(f DepFile, depth int) (*MavenLockFile, error) {
 	var parsedLockfile *MavenLockFile
 	if depth >= maxParentDepth {
 		return nil, fmt.Errorf("maven file decoding reached the max depth (%d/%d), check for a circular dependency", depth, maxParentDepth)
 	}
 	// Decoding the original lockfile and enrich its dependencies
-	decoder := xml.NewDecoder(f)
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
+	}
+
+	decoder := xml.NewDecoder(bytes.NewReader(b))
 	decoder.CharsetReader = filereader.CharsetDecoder
-	err := decoder.Decode(&parsedLockfile)
+	err = decoder.Decode(&parsedLockfile)
 	if err != nil {
 		return nil, err
 	}
 
-	if parsedLockfile.Properties.m == nil {
-		parsedLockfile.Properties.m = map[string]string{}
+	if parsedLockfile.Lines == nil {
+		parsedLockfile.Lines = map[string][]string{}
 	}
+	parsedLockfile.Lines[f.Path()] = fileposition.BytesToLines(b)
+	parsedLockfile.MainSourceFile = f.Path()
+	parsedLockfile.ProjectVersionSourceFile = f.Path()
+
+	if parsedLockfile.Properties.m == nil {
+		parsedLockfile.Properties.m = map[string]MavenLockProperty{}
+	}
+	parsedLockfile.Properties = e.enrichProperties(f, parsedLockfile.Properties.m)
 	parsedLockfile.Dependencies = e.enrichDependencies(f, parsedLockfile.Dependencies.Dependencies)
 	parsedLockfile.ManagedDependencies = e.enrichDependencies(f, parsedLockfile.ManagedDependencies.Dependencies)
 	if parsedLockfile.Parent == (MavenLockParent{}) {
@@ -279,6 +356,7 @@ func (e MavenLockExtractor) decodeMavenFile(f DepFile, depth int) (*MavenLockFil
 	if parentErr != nil {
 		return nil, parentErr
 	}
+	parentLockfile.Properties = e.enrichProperties(f, parentLockfile.Properties.m)
 	parentLockfile.Dependencies = e.enrichDependencies(parentFile, parentLockfile.Dependencies.Dependencies)
 	parentLockfile.ManagedDependencies = e.enrichDependencies(parentFile, parentLockfile.ManagedDependencies.Dependencies)
 
@@ -295,20 +373,34 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	details := map[string]PackageDetails{}
 
 	for _, lockPackage := range parsedLockfile.Dependencies.Dependencies {
-		resolvedGroupID := lockPackage.ResolveGroupID(*parsedLockfile)
-		resolvedArtifactID := lockPackage.ResolveArtifactID(*parsedLockfile)
+		resolvedGroupID, _ := lockPackage.ResolveGroupID(*parsedLockfile)
+		resolvedArtifactID, artifactPosition := lockPackage.ResolveArtifactID(*parsedLockfile)
+		resolvedVersion, versionPosition := lockPackage.ResolveVersion(*parsedLockfile)
 		finalName := resolvedGroupID + ":" + resolvedArtifactID
 
+		blockLocation := models.FilePosition{
+			Line:   lockPackage.Line,
+			Column: lockPackage.Column,
+		}
+		block := parsedLockfile.Lines[lockPackage.SourceFile][lockPackage.Line.Start-1 : lockPackage.Line.End]
+
+		// A position is null after resolving the value in case the value is directly defined in the block
+		if artifactPosition == nil {
+			artifactPosition = fileposition.ExtractDelimitedRegexpPositionInBlock(block, "(.*)", lockPackage.Line.Start, "<artifactId>", "</artifactId>")
+		}
+		if versionPosition == nil {
+			versionPosition = fileposition.ExtractDelimitedRegexpPositionInBlock(block, "(.*)", lockPackage.Line.Start, "<version>", "</version>")
+		}
+
 		pkgDetails := PackageDetails{
-			Name:      finalName,
-			Version:   lockPackage.ResolveVersion(*parsedLockfile),
-			Ecosystem: MavenEcosystem,
-			CompareAs: MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:   lockPackage.Line,
-				Column: lockPackage.Column,
-			},
-			SourceFile: lockPackage.SourceFile,
+			Name:            finalName,
+			Version:         resolvedVersion,
+			Ecosystem:       MavenEcosystem,
+			CompareAs:       MavenEcosystem,
+			BlockLocation:   blockLocation,
+			NameLocation:    artifactPosition,
+			VersionLocation: versionPosition,
+			SourceFile:      lockPackage.SourceFile,
 		}
 		if strings.TrimSpace(lockPackage.Scope) != "" {
 			pkgDetails.DepGroups = append(pkgDetails.DepGroups, lockPackage.Scope)
@@ -318,16 +410,29 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 
 	// If a dependency is declared and have not specified its version, then use the one declared in the managed dependencies
 	for _, lockPackage := range parsedLockfile.ManagedDependencies.Dependencies {
-		resolvedGroupID := lockPackage.ResolveGroupID(*parsedLockfile)
-		resolvedArtifactID := lockPackage.ResolveArtifactID(*parsedLockfile)
+		resolvedGroupID, _ := lockPackage.ResolveGroupID(*parsedLockfile)
+		resolvedArtifactID, _ := lockPackage.ResolveArtifactID(*parsedLockfile)
 		finalName := resolvedGroupID + ":" + resolvedArtifactID
 		pkgDetails, pkgExists := details[finalName]
 		if !pkgExists {
 			continue
 		}
 
+		block := parsedLockfile.Lines[lockPackage.SourceFile][lockPackage.Line.Start-1 : lockPackage.Line.End]
+
 		if pkgDetails.IsVersionEmpty() {
-			pkgDetails.Version = lockPackage.ResolveVersion(*parsedLockfile)
+			resolvedVersion, versionPosition := lockPackage.ResolveVersion(*parsedLockfile)
+			pkgDetails.Version = resolvedVersion
+
+			// A position is null after resolving the value in case the value is directly defined in the block
+			if versionPosition == nil {
+				versionPosition = fileposition.ExtractDelimitedRegexpPositionInBlock(block, "(.*)", lockPackage.Line.Start, "<version>", "</version>")
+			}
+
+			pkgDetails.VersionLocation = versionPosition
+			if lockPackage.SourceFile != pkgDetails.SourceFile {
+				pkgDetails.VersionLocation.FileName = &(lockPackage.SourceFile)
+			}
 		}
 		if strings.TrimSpace(lockPackage.Scope) != "" {
 			pkgDetails.DepGroups = append(pkgDetails.DepGroups, lockPackage.Scope)

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -413,7 +413,7 @@ func TestMavenLock_WithParent(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 15, End: 15},
 				Column:   models.Position{Start: 18, End: 30},
-				FileName: &parentPath,
+				Filename: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -452,7 +452,7 @@ func TestMavenLock_WithParent(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 4, End: 4},
 				Column:   models.Position{Start: 23, End: 28},
-				FileName: &parentPath,
+				Filename: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -472,7 +472,7 @@ func TestMavenLock_WithParent(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 5, End: 5},
 				Column:   models.Position{Start: 25, End: 30},
-				FileName: &parentPath,
+				Filename: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -492,7 +492,7 @@ func TestMavenLock_WithParent(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 8, End: 8},
 				Column:   models.Position{Start: 12, End: 24},
-				FileName: &parentPath,
+				Filename: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -550,7 +550,7 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 14, End: 14},
 				Column:   models.Position{Start: 18, End: 30},
-				FileName: &parentPath,
+				Filename: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -589,7 +589,7 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 4, End: 4},
 				Column:   models.Position{Start: 23, End: 28},
-				FileName: &parentPath,
+				Filename: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -609,7 +609,7 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 5, End: 5},
 				Column:   models.Position{Start: 25, End: 30},
-				FileName: &parentPath,
+				Filename: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -667,7 +667,7 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 14, End: 14},
 				Column:   models.Position{Start: 18, End: 30},
-				FileName: &parentPath,
+				Filename: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -706,7 +706,7 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 4, End: 4},
 				Column:   models.Position{Start: 23, End: 28},
-				FileName: &parentPath,
+				Filename: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -726,7 +726,7 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 5, End: 5},
 				Column:   models.Position{Start: 25, End: 30},
-				FileName: &parentPath,
+				Filename: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -785,7 +785,7 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 15, End: 15},
 				Column:   models.Position{Start: 18, End: 30},
-				FileName: &rootPath,
+				Filename: &rootPath,
 			},
 			SourceFile: parentPath,
 		},
@@ -824,7 +824,7 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 4, End: 4},
 				Column:   models.Position{Start: 23, End: 28},
-				FileName: &rootPath,
+				Filename: &rootPath,
 			},
 			SourceFile: parentPath,
 		},
@@ -844,7 +844,7 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 6, End: 6},
 				Column:   models.Position{Start: 20, End: 42},
-				FileName: &rootPath,
+				Filename: &rootPath,
 			},
 			SourceFile: childPath,
 		},
@@ -864,7 +864,7 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			VersionLocation: &models.FilePosition{
 				Line:     models.Position{Start: 8, End: 8},
 				Column:   models.Position{Start: 12, End: 24},
-				FileName: &rootPath,
+				Filename: &rootPath,
 			},
 			SourceFile: parentPath,
 		},

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -129,6 +129,14 @@ func TestParseMavenLock_OnePackage(t *testing.T) {
 				Line:   models.Position{Start: 7, End: 11},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 9, End: 9},
+				Column: models.Position{Start: 19, End: 33},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 10, End: 10},
+				Column: models.Position{Start: 16, End: 21},
+			},
 			SourceFile: filepath.FromSlash(sourcePath),
 		},
 	})
@@ -156,6 +164,14 @@ func TestParseMavenLock_OnePackageWithMultipleVersionVariable(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 9, End: 13},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 11, End: 11},
+				Column: models.Position{Start: 19, End: 33},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 12, End: 12},
+				Column: models.Position{Start: 16, End: 40},
 			},
 			SourceFile: filepath.FromSlash(sourcePath),
 		},
@@ -185,6 +201,14 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 				Line:   models.Position{Start: 7, End: 11},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 9, End: 9},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 10, End: 10},
+				Column: models.Position{Start: 16, End: 28},
+			},
 			SourceFile: filepath.FromSlash(sourcePath),
 		},
 		{
@@ -196,6 +220,14 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 				Line:   models.Position{Start: 12, End: 16},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 14, End: 14},
+				Column: models.Position{Start: 19, End: 32},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 15, End: 15},
+				Column: models.Position{Start: 16, End: 22},
+			},
 			SourceFile: filepath.FromSlash(sourcePath),
 		},
 	})
@@ -204,7 +236,7 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 	t.Parallel()
 	lockfileRelativePath := filepath.FromSlash("fixtures/maven/with-dependency-management.xml")
-	packages, err := lockfile.ParseMavenLock("fixtures/maven/with-dependency-management.xml")
+	packages, err := lockfile.ParseMavenLock(lockfileRelativePath)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
@@ -224,6 +256,14 @@ func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 				Line:   models.Position{Start: 7, End: 10},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 9, End: 9},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 23, End: 23},
+				Column: models.Position{Start: 18, End: 30},
+			},
 			SourceFile: filepath.FromSlash(sourcePath),
 		},
 		{
@@ -234,6 +274,14 @@ func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 11, End: 15},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 13, End: 13},
+				Column: models.Position{Start: 19, End: 32},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 14, End: 14},
+				Column: models.Position{Start: 16, End: 22},
 			},
 			SourceFile: filepath.FromSlash(sourcePath),
 		},
@@ -263,6 +311,14 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 				Line:   models.Position{Start: 18, End: 22},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 20, End: 20},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 12, End: 12},
+				Column: models.Position{Start: 23, End: 28},
+			},
 			SourceFile: filepath.FromSlash(sourcePath),
 		},
 		{
@@ -274,6 +330,14 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 				Line:   models.Position{Start: 24, End: 28},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 26, End: 26},
+				Column: models.Position{Start: 19, End: 29},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 13, End: 13},
+				Column: models.Position{Start: 25, End: 30},
+			},
 			SourceFile: filepath.FromSlash(sourcePath),
 		},
 		{
@@ -284,6 +348,14 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 30, End: 33},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 32, End: 32},
+				Column: models.Position{Start: 19, End: 33},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 14, End: 14},
+				Column: models.Position{Start: 20, End: 42},
 			},
 			SourceFile: filepath.FromSlash(sourcePath),
 		},
@@ -315,6 +387,14 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Line:   models.Position{Start: 26, End: 29},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 28, End: 28},
+				Column: models.Position{Start: 19, End: 25},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 20, End: 20},
+				Column: models.Position{Start: 18, End: 23},
+			},
 			SourceFile: parentPath,
 		},
 		{
@@ -325,6 +405,15 @@ func TestMavenLock_WithParent(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 14, End: 17},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 16, End: 16},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 15, End: 15},
+				Column:   models.Position{Start: 18, End: 30},
+				FileName: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -337,6 +426,14 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Line:   models.Position{Start: 18, End: 22},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 20, End: 20},
+				Column: models.Position{Start: 19, End: 32},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 21, End: 21},
+				Column: models.Position{Start: 16, End: 22},
+			},
 			SourceFile: childPath,
 		},
 		{
@@ -347,6 +444,15 @@ func TestMavenLock_WithParent(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 23, End: 27},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 25, End: 25},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 4, End: 4},
+				Column:   models.Position{Start: 23, End: 28},
+				FileName: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -359,6 +465,15 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Line:   models.Position{Start: 28, End: 32},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 30, End: 30},
+				Column: models.Position{Start: 19, End: 29},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 5, End: 5},
+				Column:   models.Position{Start: 25, End: 30},
+				FileName: &parentPath,
+			},
 			SourceFile: childPath,
 		},
 		{
@@ -369,6 +484,15 @@ func TestMavenLock_WithParent(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 33, End: 37},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 35, End: 35},
+				Column: models.Position{Start: 19, End: 22},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 8, End: 8},
+				Column:   models.Position{Start: 12, End: 24},
+				FileName: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -400,6 +524,14 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 				Line:   models.Position{Start: 25, End: 28},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 27, End: 27},
+				Column: models.Position{Start: 19, End: 25},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 19, End: 19},
+				Column: models.Position{Start: 18, End: 23},
+			},
 			SourceFile: parentPath,
 		},
 		{
@@ -410,6 +542,15 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 14, End: 17},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 16, End: 16},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 14, End: 14},
+				Column:   models.Position{Start: 18, End: 30},
+				FileName: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -422,6 +563,14 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 				Line:   models.Position{Start: 18, End: 22},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 20, End: 20},
+				Column: models.Position{Start: 19, End: 32},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 21, End: 21},
+				Column: models.Position{Start: 16, End: 22},
+			},
 			SourceFile: childPath,
 		},
 		{
@@ -433,6 +582,15 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 				Line:   models.Position{Start: 23, End: 27},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 25, End: 25},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 4, End: 4},
+				Column:   models.Position{Start: 23, End: 28},
+				FileName: &parentPath,
+			},
 			SourceFile: childPath,
 		},
 		{
@@ -443,6 +601,15 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 28, End: 32},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 30, End: 30},
+				Column: models.Position{Start: 19, End: 29},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 5, End: 5},
+				Column:   models.Position{Start: 25, End: 30},
+				FileName: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -474,6 +641,14 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 				Line:   models.Position{Start: 25, End: 28},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 27, End: 27},
+				Column: models.Position{Start: 19, End: 25},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 19, End: 19},
+				Column: models.Position{Start: 18, End: 23},
+			},
 			SourceFile: parentPath,
 		},
 		{
@@ -484,6 +659,15 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 13, End: 16},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 15, End: 15},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 14, End: 14},
+				Column:   models.Position{Start: 18, End: 30},
+				FileName: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -496,6 +680,14 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 				Line:   models.Position{Start: 17, End: 21},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 19, End: 19},
+				Column: models.Position{Start: 19, End: 32},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 20, End: 20},
+				Column: models.Position{Start: 16, End: 22},
+			},
 			SourceFile: childPath,
 		},
 		{
@@ -507,6 +699,15 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 				Line:   models.Position{Start: 22, End: 26},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 24, End: 24},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 4, End: 4},
+				Column:   models.Position{Start: 23, End: 28},
+				FileName: &parentPath,
+			},
 			SourceFile: childPath,
 		},
 		{
@@ -517,6 +718,15 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 27, End: 31},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 29, End: 29},
+				Column: models.Position{Start: 19, End: 29},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 5, End: 5},
+				Column:   models.Position{Start: 25, End: 30},
+				FileName: &parentPath,
 			},
 			SourceFile: childPath,
 		},
@@ -549,6 +759,14 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Line:   models.Position{Start: 26, End: 29},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 28, End: 28},
+				Column: models.Position{Start: 19, End: 25},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 20, End: 20},
+				Column: models.Position{Start: 18, End: 23},
+			},
 			SourceFile: rootPath,
 		},
 		{
@@ -559,6 +777,15 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 14, End: 17},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 16, End: 16},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 15, End: 15},
+				Column:   models.Position{Start: 18, End: 30},
+				FileName: &rootPath,
 			},
 			SourceFile: parentPath,
 		},
@@ -571,6 +798,14 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Line:   models.Position{Start: 18, End: 22},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 20, End: 20},
+				Column: models.Position{Start: 19, End: 32},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 21, End: 21},
+				Column: models.Position{Start: 16, End: 22},
+			},
 			SourceFile: parentPath,
 		},
 		{
@@ -581,6 +816,15 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 23, End: 27},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 25, End: 25},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 4, End: 4},
+				Column:   models.Position{Start: 23, End: 28},
+				FileName: &rootPath,
 			},
 			SourceFile: parentPath,
 		},
@@ -593,6 +837,15 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Line:   models.Position{Start: 14, End: 18},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 16, End: 16},
+				Column: models.Position{Start: 19, End: 29},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 6, End: 6},
+				Column:   models.Position{Start: 20, End: 42},
+				FileName: &rootPath,
+			},
 			SourceFile: childPath,
 		},
 		{
@@ -603,6 +856,15 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 33, End: 37},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 35, End: 35},
+				Column: models.Position{Start: 19, End: 22},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 8, End: 8},
+				Column:   models.Position{Start: 12, End: 24},
+				FileName: &rootPath,
 			},
 			SourceFile: parentPath,
 		},
@@ -689,7 +951,7 @@ func TestMavenLockDependency_ResolveVersion(t *testing.T) {
 			mld := lockfile.MavenLockDependency{
 				Version: tt.fields.Version,
 			}
-			if got := mld.ResolveVersion(tt.args.lockfile); got != tt.want {
+			if got, _ := mld.ResolveVersion(tt.args.lockfile); got != tt.want {
 				t.Errorf("ResolveVersion() = %v, want %v", got, tt.want)
 			}
 		})
@@ -719,6 +981,14 @@ func TestParseMavenLock_WithScope(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 3, End: 8},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 5, End: 5},
+				Column: models.Position{Start: 19, End: 24},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 6, End: 6},
+				Column: models.Position{Start: 16, End: 20},
 			},
 			DepGroups: []string{"test"},
 		},
@@ -750,6 +1020,14 @@ func TestParseMavenLock_WithUnusedDependencyManagementDependencies(t *testing.T)
 				Line:   models.Position{Start: 17, End: 21},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 19, End: 19},
+				Column: models.Position{Start: 19, End: 28},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 20, End: 20},
+				Column: models.Position{Start: 16, End: 28},
+			},
 			DepGroups: nil,
 		},
 	})
@@ -779,6 +1057,14 @@ func TestParseMavenLock_WithOverriddenDependencyVersions(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 14, End: 18},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 16, End: 16},
+				Column: models.Position{Start: 19, End: 24},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 17, End: 17},
+				Column: models.Position{Start: 16, End: 20},
 			},
 			DepGroups: nil,
 		},
@@ -810,6 +1096,14 @@ func TestParseMavenLock_WithProjectVersionProperty(t *testing.T) {
 				Line:   models.Position{Start: 8, End: 12},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 10, End: 10},
+				Column: models.Position{Start: 19, End: 22},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 5, End: 5},
+				Column: models.Position{Start: 12, End: 24},
+			},
 			DepGroups: nil,
 		},
 		{
@@ -822,6 +1116,14 @@ func TestParseMavenLock_WithProjectVersionProperty(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 13, End: 17},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 15, End: 15},
+				Column: models.Position{Start: 19, End: 22},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 5, End: 5},
+				Column: models.Position{Start: 12, End: 24},
 			},
 			DepGroups: nil,
 		},
@@ -849,6 +1151,14 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 				Line:   models.Position{Start: 27, End: 30},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 6, End: 6},
+				Column: models.Position{Start: 21, End: 30},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 4, End: 4},
+				Column: models.Position{Start: 20, End: 32},
+			},
 			DepGroups: nil,
 		},
 		{
@@ -862,6 +1172,14 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 				Line:   models.Position{Start: 31, End: 35},
 				Column: models.Position{Start: 5, End: 18},
 			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 8, End: 8},
+				Column: models.Position{Start: 24, End: 30},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 3, End: 3},
+				Column: models.Position{Start: 20, End: 42},
+			},
 			DepGroups: nil,
 		},
 		{
@@ -874,6 +1192,14 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 			BlockLocation: models.FilePosition{
 				Line:   models.Position{Start: 36, End: 40},
 				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 38, End: 38},
+				Column: models.Position{Start: 19, End: 35},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:   models.Position{Start: 3, End: 3},
+				Column: models.Position{Start: 20, End: 42},
 			},
 			DepGroups: nil,
 		},

--- a/pkg/models/file_position.go
+++ b/pkg/models/file_position.go
@@ -6,8 +6,9 @@ type Position struct {
 }
 
 type FilePosition struct {
-	Line   Position `json:"line"`
-	Column Position `json:"column"`
+	Line     Position `json:"line"`
+	Column   Position `json:"column"`
+	FileName *string  `json:"file_name"`
 }
 
 type IFilePosition interface {

--- a/pkg/models/file_position.go
+++ b/pkg/models/file_position.go
@@ -8,7 +8,7 @@ type Position struct {
 type FilePosition struct {
 	Line     Position `json:"line"`
 	Column   Position `json:"column"`
-	FileName *string  `json:"file_name"`
+	Filename *string  `json:"file_name,omitempty"`
 }
 
 type IFilePosition interface {


### PR DESCRIPTION
## What does this PR do?
- Extract name and version location from maven lockfiles

## Notes
- The changes have been made to try to keep the already existing logic in the maven parser
- As in maven the name and version can be in a different file than the block, thus the model has been updated
- When name or version is composed by one variable, the location is where the variable value is defined
- When name or version is composed by MORE than one variable, the location is where those variables are used (the model cannot handle reporting multiple locations)