### PR TITLE
🐛 Fix NPE in maven when version is defined in child and dependency in parent lockfile

### DIFF
--- a/pkg/lockfile/fixtures/maven/children/with-parent-child-project-version.xml
+++ b/pkg/lockfile/fixtures/maven/children/with-parent-child-project-version.xml
@@ -1,0 +1,15 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+  </properties>
+
+  <version>1.0-CHILD-SNAPSHOT</version>
+
+  <parent>
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1</version>
+    <relativePath>../parent-project-version.xml</relativePath>
+  </parent>
+
+</project>

--- a/pkg/lockfile/fixtures/maven/parent-project-version.xml
+++ b/pkg/lockfile/fixtures/maven/parent-project-version.xml
@@ -1,0 +1,17 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+    <mypackageVersion>1.0.0</mypackageVersion>
+    <my.package.version>2.3.4</my.package.version>
+    <version-range>[9.4.35.v20201120,9.5)</version-range>
+  </properties>
+  <version>1.0-PARENT-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -733,6 +733,45 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 	})
 }
 
+func TestMavenLock_WithParent_Child_Project(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	parentPath := filepath.FromSlash(filepath.Join(dir, "fixtures/maven/parent-project-version.xml"))
+	childPath := filepath.FromSlash(filepath.Join(dir, "fixtures/maven/children/with-parent-child-project-version.xml"))
+	packages, err := lockfile.ParseMavenLock(childPath)
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "com.google.code.findbugs:jsr305",
+			Version:   "1.0-CHILD-SNAPSHOT",
+			Ecosystem: lockfile.MavenEcosystem,
+			CompareAs: lockfile.MavenEcosystem,
+			BlockLocation: models.FilePosition{
+				Line:   models.Position{Start: 11, End: 15},
+				Column: models.Position{Start: 5, End: 18},
+			},
+			NameLocation: &models.FilePosition{
+				Line:   models.Position{Start: 13, End: 13},
+				Column: models.Position{Start: 19, End: 25},
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 6, End: 6},
+				Column:   models.Position{Start: 12, End: 30},
+				Filename: &childPath,
+			},
+			SourceFile: parentPath,
+		},
+	})
+}
+
 func TestMavenLock_WithMultipleParents(t *testing.T) {
 	t.Parallel()
 	dir, err := os.Getwd()


### PR DESCRIPTION
## What does this PR do?

- Fix NPE in maven when version is defined in child and dependency in parent lockfile

