### PR TITLE
✅ Add unit test to utility/fileposition

### DIFF
--- a/internal/utility/fileposition/column_test.go
+++ b/internal/utility/fileposition/column_test.go
@@ -1,0 +1,75 @@
+package fileposition
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFirstNonEmptyCharacterIndexInLine(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		line  string
+		index int
+	}{
+		{
+			line:  "no empty characters",
+			index: 1,
+		},
+		{
+			line:  " one empty character",
+			index: 2,
+		},
+		{
+			line:  "         multiple empty character",
+			index: 10,
+		},
+		{
+			line:  "			with tabs",
+			index: 4,
+		},
+		{
+			line:  "",
+			index: -1,
+		},
+	}
+
+	for _, tt := range testCases {
+		assert.Equal(t, tt.index, GetFirstNonEmptyCharacterIndexInLine(tt.line))
+	}
+}
+
+func TestGetLastNonEmptyCharacterIndexInLine(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		line  string
+		index int
+	}{
+		{
+			line:  "a",
+			index: 2,
+		},
+		{
+			line:  "abc",
+			index: 4,
+		},
+		{
+			line:  "abc  ",
+			index: 4,
+		},
+		{
+			line:  "  abc  ",
+			index: 6,
+		},
+		{
+			line:  "",
+			index: -1,
+		},
+	}
+
+	for _, tt := range testCases {
+		assert.Equal(t, tt.index, GetLastNonEmptyCharacterIndexInLine(tt.line))
+	}
+}

--- a/internal/utility/fileposition/json_test.go
+++ b/internal/utility/fileposition/json_test.go
@@ -1,0 +1,153 @@
+package fileposition
+
+import (
+	"testing"
+
+	"github.com/google/osv-scanner/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+type Dependency struct {
+	Dependencies map[string]*Dependency
+	models.FilePosition
+}
+
+func (d *Dependency) GetNestedDependencies() map[string]*models.FilePosition {
+	result := make(map[string]*models.FilePosition)
+	for key, value := range d.Dependencies {
+		result[key] = &value.FilePosition
+	}
+
+	return result
+}
+
+func TestInJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		groupKey     string
+		dependencies map[string]*Dependency
+		lines        []string
+		offset       int
+		expected     map[string]*Dependency
+	}{
+		{
+			groupKey: "groupKey",
+			dependencies: map[string]*Dependency{
+				"dep-1": {},
+			},
+			lines: []string{
+				`{`,
+				` "groupKey": {`,
+				`  "dep-1": {`,
+				`   "some-key": "some-value"`,
+				`  }`,
+				` }`,
+				`}`,
+			},
+			offset: 0,
+			expected: map[string]*Dependency{
+				"dep-1": {
+					FilePosition: models.FilePosition{
+						Line:   models.Position{Start: 3, End: 5},
+						Column: models.Position{Start: 3, End: 4},
+					},
+				},
+			},
+		},
+		{
+			groupKey: "groupKey",
+			dependencies: map[string]*Dependency{
+				"dep-1": {
+					Dependencies: map[string]*Dependency{
+						"nested-dep": {},
+					},
+				},
+			},
+			lines: []string{
+				`{`,
+				` "groupKey": {`,
+				`  "dep-1": {`,
+				`   "some-key": "some-value"`,
+				`   "nested-dep": {`,
+				`    "some-nested-key": "some-nested-value"`,
+				`   }`,
+				`  }`,
+				` }`,
+				`}`,
+			},
+			offset: 0,
+			expected: map[string]*Dependency{
+				"dep-1": {
+					FilePosition: models.FilePosition{
+						Line:   models.Position{Start: 3, End: 8},
+						Column: models.Position{Start: 3, End: 4},
+					},
+				},
+				"nested-dep": {
+					FilePosition: models.FilePosition{
+						Line:   models.Position{Start: 5, End: 7},
+						Column: models.Position{Start: 3, End: 4},
+					},
+				},
+			},
+		},
+		{
+			groupKey: "groupKey",
+			dependencies: map[string]*Dependency{
+				"dep-1": {
+					Dependencies: map[string]*Dependency{
+						"nested-dep": {
+							Dependencies: map[string]*Dependency{
+								"very-nested-dep": {},
+							},
+						},
+					},
+				},
+			},
+			lines: []string{
+				`{`,
+				` "groupKey": {`,
+				`  "dep-1": {`,
+				`   "some-key": "some-value"`,
+				`   "nested-dep": {`,
+				`    "some-nested-key": "some-nested-value"`,
+				`    "very-nested-dep": {`,
+				`     "some-very-nested-key": "some-very-nested-value"`,
+				`    }`,
+				`   }`,
+				`  }`,
+				` }`,
+				`}`,
+			},
+			offset: 0,
+			expected: map[string]*Dependency{
+				"dep-1": {
+					FilePosition: models.FilePosition{
+						Line:   models.Position{Start: 3, End: 11},
+						Column: models.Position{Start: 3, End: 4},
+					},
+				},
+				"nested-dep": {
+					FilePosition: models.FilePosition{
+						Line:   models.Position{Start: 5, End: 10},
+						Column: models.Position{Start: 3, End: 4},
+					},
+				},
+				"very-nested-dep": {
+					FilePosition: models.FilePosition{
+						Line:   models.Position{Start: 7, End: 9},
+						Column: models.Position{Start: 3, End: 4},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		InJSON(tt.groupKey, tt.dependencies, tt.lines, tt.offset)
+		for key, dep := range tt.dependencies {
+			assert.Equal(t, dep.FilePosition, tt.expected[key].FilePosition)
+		}
+	}
+}

--- a/internal/utility/fileposition/path_test.go
+++ b/internal/utility/fileposition/path_test.go
@@ -1,0 +1,52 @@
+package fileposition
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveHostPath(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	scanPath := "."
+	packagePath := filepath.FromSlash(filepath.Join(dir, "path_test.go"))
+
+	testCases := []struct {
+		considerScanPathAsRoot bool
+		pathRelativeToScanDir  bool
+		path                   string
+	}{
+		{
+			considerScanPathAsRoot: false,
+			pathRelativeToScanDir:  false,
+			path:                   packagePath,
+		},
+		{
+			considerScanPathAsRoot: false,
+			pathRelativeToScanDir:  true,
+			path:                   "path_test.go",
+		},
+		{
+			considerScanPathAsRoot: true,
+			pathRelativeToScanDir:  false,
+			path:                   "/path_test.go",
+		},
+		{
+			considerScanPathAsRoot: true,
+			pathRelativeToScanDir:  true,
+			path:                   "path_test.go",
+		},
+	}
+
+	for _, tt := range testCases {
+		assert.Equal(t, tt.path, RemoveHostPath(scanPath, packagePath, tt.considerScanPathAsRoot, tt.pathRelativeToScanDir))
+	}
+}

--- a/internal/utility/fileposition/string.go
+++ b/internal/utility/fileposition/string.go
@@ -49,10 +49,8 @@ func ExtractDelimitedRegexpPositionInBlock(block []string, str string, blockStar
 	for i, line := range block {
 		matches := regex.FindStringSubmatch(line)
 		if len(matches) > 0 {
-			// The group was captured -> Replace group regexp with captured value
-			if len(matches) == 2 {
-				str = matches[1]
-			}
+			// Replace regexp with captured value
+			str = matches[1]
 
 			return extractPositionFromLine(blockStartLine+i, line, str)
 		}

--- a/internal/utility/fileposition/string.go
+++ b/internal/utility/fileposition/string.go
@@ -1,6 +1,7 @@
 package fileposition
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/google/osv-scanner/internal/cachedregexp"
@@ -43,12 +44,12 @@ func ExtractRegexpPositionInBlock(block []string, str string, blockStartLine int
 }
 
 func ExtractDelimitedRegexpPositionInBlock(block []string, str string, blockStartLine int, prefix string, suffix string) *models.FilePosition {
-	// We expect 'str' to be a literal value or in case it is a regexp to be only one capturing group
-	regex := cachedregexp.MustCompile(cachedregexp.QuoteMeta(prefix) + str + cachedregexp.QuoteMeta(suffix))
+	group := fmt.Sprintf("(%s)", str)
+	regex := cachedregexp.MustCompile(cachedregexp.QuoteMeta(prefix) + group + cachedregexp.QuoteMeta(suffix))
 	for i, line := range block {
 		matches := regex.FindStringSubmatch(line)
 		if len(matches) > 0 {
-			// A group was captured -> Replace group regexp with captured value
+			// The group was captured -> Replace group regexp with captured value
 			if len(matches) == 2 {
 				str = matches[1]
 			}

--- a/internal/utility/fileposition/string_test.go
+++ b/internal/utility/fileposition/string_test.go
@@ -103,6 +103,15 @@ func TestExtractDelimitedRegexpPositionInBlock(t *testing.T) {
 		},
 		{
 			block:          []string{"abcdef", "ghijkl", "mnopqr"},
+			str:            "(h.*)l",
+			blockStartLine: 1,
+			position: &models.FilePosition{
+				Line:   models.Position{Start: 2, End: 2},
+				Column: models.Position{Start: 2, End: 7},
+			},
+		},
+		{
+			block:          []string{"abcdef", "ghijkl", "mnopqr"},
 			str:            "a+kl",
 			blockStartLine: 1,
 			position:       nil,

--- a/internal/utility/fileposition/string_test.go
+++ b/internal/utility/fileposition/string_test.go
@@ -1,0 +1,134 @@
+package fileposition
+
+import (
+	"testing"
+
+	"github.com/google/osv-scanner/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBytesToLines(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		data  []byte
+		lines []string
+	}{
+		{
+			data:  []byte(""),
+			lines: []string{""},
+		},
+		{
+			data:  []byte("1\n2\n3"),
+			lines: []string{"1", "2", "3"},
+		},
+	}
+
+	for _, tt := range testCases {
+		assert.Equal(t, tt.lines, BytesToLines(tt.data))
+	}
+}
+
+func TestExtractDelimitedStringPositionInBlock(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		block          []string
+		str            string
+		blockStartLine int
+		prefix         string
+		suffix         string
+		position       *models.FilePosition
+	}{
+		{
+			block:          []string{"abcdef", "ghijkl", "mnopqr"},
+			str:            "jk",
+			blockStartLine: 1,
+			position: &models.FilePosition{
+				Line:   models.Position{Start: 2, End: 2},
+				Column: models.Position{Start: 4, End: 6},
+			},
+		},
+		{
+			block:          []string{"abcdef", "ghijkl", "mnopqr"},
+			str:            "af",
+			blockStartLine: 1,
+			position:       nil,
+		},
+		{
+			block:          []string{"abcdef", "ghijkl", "mnopqr"},
+			str:            "jk",
+			blockStartLine: 1,
+			prefix:         "ghi",
+			suffix:         "l",
+			position: &models.FilePosition{
+				Line:   models.Position{Start: 2, End: 2},
+				Column: models.Position{Start: 4, End: 6},
+			},
+		},
+		{
+			block:          []string{"abcdef", "ghijkl", "mnopqr"},
+			str:            "jk",
+			blockStartLine: 1,
+			prefix:         "ab",
+			suffix:         "l",
+			position:       nil,
+		},
+	}
+
+	for _, tt := range testCases {
+		assert.Equal(t, tt.position, ExtractDelimitedStringPositionInBlock(tt.block, tt.str, tt.blockStartLine, tt.prefix, tt.suffix))
+	}
+}
+
+func TestExtractDelimitedRegexpPositionInBlock(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		block          []string
+		str            string
+		blockStartLine int
+		prefix         string
+		suffix         string
+		position       *models.FilePosition
+	}{
+		{
+			block:          []string{"abcdef", "ghijkl", "mnopqr"},
+			str:            "h.*l",
+			blockStartLine: 1,
+			position: &models.FilePosition{
+				Line:   models.Position{Start: 2, End: 2},
+				Column: models.Position{Start: 2, End: 7},
+			},
+		},
+		{
+			block:          []string{"abcdef", "ghijkl", "mnopqr"},
+			str:            "a+kl",
+			blockStartLine: 1,
+			position:       nil,
+		},
+		{
+			block:          []string{"abcdef", "ghijkl", "mnopqr"},
+			str:            "i+j",
+			blockStartLine: 1,
+			prefix:         "gh",
+			suffix:         "kl",
+			position: &models.FilePosition{
+				Line:   models.Position{Start: 2, End: 2},
+				Column: models.Position{Start: 3, End: 5},
+			},
+		},
+		{
+			block:          []string{"abcdef", "ghijkl", "mnopqr"},
+			str:            "i?k",
+			blockStartLine: 1,
+			prefix:         "ab",
+			suffix:         "l",
+			position:       nil,
+		},
+	}
+
+	for _, tt := range testCases {
+		assert.Equal(t, tt.position, ExtractDelimitedRegexpPositionInBlock(tt.block, tt.str, tt.blockStartLine, tt.prefix, tt.suffix))
+	}
+}

--- a/internal/utility/fileposition/toml_test.go
+++ b/internal/utility/fileposition/toml_test.go
@@ -1,0 +1,89 @@
+package fileposition
+
+import (
+	"testing"
+
+	"github.com/google/osv-scanner/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInTOML(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		groupKey     string
+		otherKey     string
+		dependencies []*models.FilePosition
+		lines        []string
+		expected     []*models.FilePosition
+	}{
+		{
+			groupKey: "[pkg]",
+			otherKey: "[other-section]",
+			dependencies: []*models.FilePosition{
+				{},
+			},
+			lines: []string{
+				`[pkg]`,
+				`name = "pkg-1"`,
+				``,
+				`[other-section]`,
+				`version = "1.1"`,
+			},
+			expected: []*models.FilePosition{
+				{
+					Line:   models.Position{Start: 1, End: 2},
+					Column: models.Position{Start: 1, End: 15},
+				},
+			},
+		},
+		{
+			groupKey: "[pkg]",
+			otherKey: "[other-section]",
+			dependencies: []*models.FilePosition{
+				{},
+			},
+			lines: []string{
+				`[pkg]`,
+				`name = "pkg-1"`,
+			},
+			expected: []*models.FilePosition{
+				{
+					Line:   models.Position{Start: 1, End: 2},
+					Column: models.Position{Start: 1, End: 15},
+				},
+			},
+		},
+		{
+			groupKey: "[pkg]",
+			otherKey: "[other-section]",
+			dependencies: []*models.FilePosition{
+				{},
+				{},
+			},
+			lines: []string{
+				`[pkg]`,
+				`name = "pkg-1"`,
+				`[pkg]`,
+				`name = "pkg-2"`,
+			},
+			expected: []*models.FilePosition{
+				{
+					Line:   models.Position{Start: 1, End: 2},
+					Column: models.Position{Start: 1, End: 15},
+				},
+				{
+					Line:   models.Position{Start: 3, End: 4},
+					Column: models.Position{Start: 1, End: 15},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		InTOML(tt.groupKey, tt.otherKey, tt.dependencies, tt.lines)
+		for index, dep := range tt.dependencies {
+			assert.Equal(t, dep, tt.expected[index])
+		}
+	}
+}

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -86,7 +86,7 @@ func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fi
 			if strings.HasSuffix(propName, "version") {
 				projectPropertySourceFile = lockfile.ProjectVersionSourceFile
 			}
-			position = fileposition.ExtractRegexpPositionInBlock(lockfile.Lines[projectPropertySourceFile], property, 1)
+			position = fileposition.ExtractStringPositionInBlock(lockfile.Lines[projectPropertySourceFile], property, 1)
 			position.Filename = projectPropertySourceFile
 		} else {
 			lockProperty, ok = lockfile.Properties.m[propName]
@@ -97,7 +97,7 @@ func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fi
 					property, position = mld.resolvePropertiesValue(lockfile, property)
 				} else {
 					// We should locate the property in its source file
-					position = fileposition.ExtractDelimitedRegexpPositionInBlock(lockfile.Lines[lockProperty.SourceFile], "(.*)", 1, propOpenTag, propCloseTag)
+					position = fileposition.ExtractDelimitedRegexpPositionInBlock(lockfile.Lines[lockProperty.SourceFile], ".*", 1, propOpenTag, propCloseTag)
 					position.Filename = lockProperty.SourceFile
 				}
 			}
@@ -383,11 +383,11 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 
 		// A position is null after resolving the value in case the value is directly defined in the block
 		if artifactPosition == nil {
-			artifactPosition = fileposition.ExtractDelimitedRegexpPositionInBlock(block, "(.*)", lockPackage.Line.Start, "<artifactId>", "</artifactId>")
+			artifactPosition = fileposition.ExtractDelimitedRegexpPositionInBlock(block, ".*", lockPackage.Line.Start, "<artifactId>", "</artifactId>")
 			artifactPosition.Filename = lockPackage.SourceFile
 		}
 		if versionPosition == nil {
-			versionPosition = fileposition.ExtractDelimitedRegexpPositionInBlock(block, "(.*)", lockPackage.Line.Start, "<version>", "</version>")
+			versionPosition = fileposition.ExtractDelimitedRegexpPositionInBlock(block, ".*", lockPackage.Line.Start, "<version>", "</version>")
 			if versionPosition != nil {
 				versionPosition.Filename = lockPackage.SourceFile
 			}
@@ -425,7 +425,7 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 
 			// A position is null after resolving the value in case the value is directly defined in the block
 			if versionPosition == nil {
-				versionPosition = fileposition.ExtractDelimitedRegexpPositionInBlock(block, "(.*)", lockPackage.Line.Start, "<version>", "</version>")
+				versionPosition = fileposition.ExtractDelimitedRegexpPositionInBlock(block, ".*", lockPackage.Line.Start, "<version>", "</version>")
 				versionPosition.Filename = lockPackage.SourceFile
 			}
 


### PR DESCRIPTION
- Add unit test to utility/fileposition
- Update a little bit the logic for `ExtractDelimitedRegexpPositionInBlock`:
  - Now, `str` is just a regexp: from `(.*)` to `.*`
  - To make sure there is only one capturing group, it is set in the function