### PR TITLE
♻️ expectPackage(s) without locations

### DIFF
--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/osv-scanner/pkg/models"
-
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
@@ -17,7 +15,7 @@ func TestParseNpmLock_v1_FileDoesNotExist(t *testing.T) {
 	packages, err := lockfile.ParseNpmLock("fixtures/npm/does-not-exist")
 
 	expectErrIs(t, err, fs.ErrNotExist)
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseNpmLock_v1_InvalidJson(t *testing.T) {
@@ -26,7 +24,7 @@ func TestParseNpmLock_v1_InvalidJson(t *testing.T) {
 	packages, err := lockfile.ParseNpmLock("fixtures/npm/not-json.txt")
 
 	expectErrContaining(t, err, "could not decode json from")
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseNpmLock_v1_NoPackages(t *testing.T) {
@@ -38,7 +36,7 @@ func TestParseNpmLock_v1_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseNpmLock_v1_OnePackage(t *testing.T) {
@@ -54,15 +52,10 @@ func TestParseNpmLock_v1_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "wrappy",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 9},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "wrappy",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -82,15 +75,10 @@ func TestParseNpmLock_v1_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "wrappy",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 10},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "wrappy",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev"},
@@ -111,26 +99,16 @@ func TestParseNpmLock_v1_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "wrappy",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 9},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "wrappy",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "supports-color",
-			Version: "5.5.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 17},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "supports-color",
+			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -150,26 +128,16 @@ func TestParseNpmLock_v1_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "wrappy",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 17},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "wrappy",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "@babel/code-frame",
-			Version: "7.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 12},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "@babel/code-frame",
+			Version:   "7.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -189,59 +157,34 @@ func TestParseNpmLock_v1_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "postcss",
-			Version: "6.0.23",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 14},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "postcss",
+			Version:   "6.0.23",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "postcss",
-			Version: "7.0.16",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 26, End: 35},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
+			Name:      "postcss",
+			Version:   "7.0.16",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "postcss-calc",
-			Version: "7.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 15, End: 45},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "postcss-calc",
+			Version:   "7.0.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "supports-color",
-			Version: "6.1.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 36, End: 43},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
+			Name:      "supports-color",
+			Version:   "6.1.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "supports-color",
-			Version: "5.5.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 46, End: 53},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "supports-color",
+			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -266,38 +209,23 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		t.Errorf("Expected to get 39 packages, but got %d", len(packages))
 	}
 
-	expectPackage(t, packages, lockfile.PackageDetails{
-		Name:    "supports-color",
-		Version: "6.1.0",
-		BlockLocation: models.FilePosition{
-			Line:     models.Position{Start: 21, End: 28},
-			Column:   models.Position{Start: 9, End: 10},
-			Filename: path,
-		},
+	expectPackageWithoutLocations(t, packages, lockfile.PackageDetails{
+		Name:      "supports-color",
+		Version:   "6.1.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
 	})
 
-	expectPackage(t, packages, lockfile.PackageDetails{
-		Name:    "supports-color",
-		Version: "5.5.0",
-		BlockLocation: models.FilePosition{
-			Line:     models.Position{Start: 759, End: 766},
-			Column:   models.Position{Start: 5, End: 6},
-			Filename: path,
-		},
+	expectPackageWithoutLocations(t, packages, lockfile.PackageDetails{
+		Name:      "supports-color",
+		Version:   "5.5.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
 	})
 
-	expectPackage(t, packages, lockfile.PackageDetails{
-		Name:    "supports-color",
-		Version: "2.0.0",
-		BlockLocation: models.FilePosition{
-			Line:     models.Position{Start: 64, End: 68},
-			Column:   models.Position{Start: 9, End: 10},
-			Filename: path,
-		},
+	expectPackageWithoutLocations(t, packages, lockfile.PackageDetails{
+		Name:      "supports-color",
+		Version:   "2.0.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
 	})
@@ -316,190 +244,115 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@segment/analytics.js-integration-facebook-pixel",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 18},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "@segment/analytics.js-integration-facebook-pixel",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "3b1bb80b302c2e552685dc8a029797ec832ea7c9",
 		},
 		{
-			Name:    "ansi-styles",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 19, End: 23},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "ansi-styles",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "babel-preset-php",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 24, End: 30},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "babel-preset-php",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
 		},
 		{
-			Name:    "is-number-1",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 31, End: 37},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-1",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-1",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 75, End: 81},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
+			Name:      "is-number-1",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-2",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 38, End: 41},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-2",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
 		},
 		{
-			Name:    "is-number-2",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 82, End: 85},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
+			Name:      "is-number-2",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82dcc8e914dabd9305ab9ae580709a7825e824f5",
 		},
 		{
-			Name:    "is-number-3",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 42, End: 46},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-3",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-3",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 86, End: 90},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
+			Name:      "is-number-3",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-4",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 47, End: 54},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-4",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-5",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 55, End: 62},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-5",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-6",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 63, End: 69},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-6",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "postcss-calc",
-			Version: "7.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 70, End: 92},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "postcss-calc",
+			Version:   "7.0.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "raven-js",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 93, End: 96},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "raven-js",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c2b377e7a254264fd4a1fe328e4e3cfc9e245570",
 		},
 		{
-			Name:    "slick-carousel",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 97, End: 101},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "slick-carousel",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "280b560161b751ba226d50c7db1e0a14a78c2de0",
@@ -521,27 +374,17 @@ func TestParseNpmLock_v1_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "lodash",
-			Version: "1.3.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 9},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "lodash",
+			Version:   "1.3.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "other_package",
-			Version: "0.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 15},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "other_package",
+			Version:   "0.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -562,37 +405,22 @@ func TestParseNpmLock_v1_Alias(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@babel/code-frame",
-			Version: "7.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 12},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "@babel/code-frame",
+			Version:   "7.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "string-width",
-			Version: "4.2.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 23, End: 32},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "string-width",
+			Version:   "4.2.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "string-width",
-			Version: "5.1.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 22},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "string-width",
+			Version:   "5.1.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -612,27 +440,17 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "wrappy",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 11},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "wrappy",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev", "optional"},
 		},
 		{
-			Name:    "supports-color",
-			Version: "5.5.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 20},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "supports-color",
+			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"optional"},

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/osv-scanner/pkg/models"
-
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
@@ -22,7 +20,7 @@ func TestParseNpmLock_v2_FileDoesNotExist(t *testing.T) {
 	packages, err := lockfile.ParseNpmLock(path)
 
 	expectErrIs(t, err, fs.ErrNotExist)
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseNpmLock_v2_InvalidJson(t *testing.T) {
@@ -36,7 +34,7 @@ func TestParseNpmLock_v2_InvalidJson(t *testing.T) {
 	packages, err := lockfile.ParseNpmLock(path)
 
 	expectErrContaining(t, err, "could not decode json from")
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseNpmLock_v2_NoPackages(t *testing.T) {
@@ -52,7 +50,7 @@ func TestParseNpmLock_v2_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseNpmLock_v2_OnePackage(t *testing.T) {
@@ -68,15 +66,10 @@ func TestParseNpmLock_v2_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "wrappy",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 14},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "wrappy",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -96,15 +89,10 @@ func TestParseNpmLock_v2_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "wrappy",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 15},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "wrappy",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev"},
@@ -125,15 +113,10 @@ func TestParseNpmLock_v2_LinkDependency(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "wrappy",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 15},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "wrappy",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev"},
@@ -154,26 +137,16 @@ func TestParseNpmLock_v2_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "wrappy",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 17},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "wrappy",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "supports-color",
-			Version: "5.5.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 18, End: 28},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "supports-color",
+			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -193,26 +166,16 @@ func TestParseNpmLock_v2_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "wrappy",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 18, End: 22},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "wrappy",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "@babel/code-frame",
-			Version: "7.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 17},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "@babel/code-frame",
+			Version:   "7.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -232,59 +195,34 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "postcss",
-			Version: "6.0.23",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 22},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "postcss",
+			Version:   "6.0.23",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "postcss",
-			Version: "7.0.16",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 34, End: 46},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "postcss",
+			Version:   "7.0.16",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "postcss-calc",
-			Version: "7.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 23, End: 33},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "postcss-calc",
+			Version:   "7.0.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "supports-color",
-			Version: "6.1.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 47, End: 57},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "supports-color",
+			Version:   "6.1.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "supports-color",
-			Version: "5.5.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 58, End: 68},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "supports-color",
+			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -304,26 +242,16 @@ func TestParseNpmLock_v2_NestedDependenciesDup(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "supports-color",
-			Version: "6.1.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 20},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "supports-color",
+			Version:   "6.1.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "supports-color",
-			Version: "2.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 32, End: 39},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "supports-color",
+			Version:   "2.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -343,104 +271,64 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@segment/analytics.js-integration-facebook-pixel",
-			Version: "2.4.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 26, End: 41},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "@segment/analytics.js-integration-facebook-pixel",
+			Version:   "2.4.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "3b1bb80b302c2e552685dc8a029797ec832ea7c9",
 		},
 		{
-			Name:    "ansi-styles",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 42, End: 49},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "ansi-styles",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "babel-preset-php",
-			Version: "1.1.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 50, End: 59},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "babel-preset-php",
+			Version:   "1.1.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-1",
-			Version: "3.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 60, End: 72},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-1",
+			Version:   "3.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-1",
-			Version: "3.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 130, End: 142},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-1",
+			Version:   "3.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-2",
-			Version: "2.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 73, End: 82},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-2",
+			Version:   "2.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-2",
-			Version: "2.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 143, End: 152},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-2",
+			Version:   "2.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82dcc8e914dabd9305ab9ae580709a7825e824f5",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-3",
-			Version: "2.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 83, End: 92},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-3",
+			Version:   "2.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
@@ -451,72 +339,42 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Version:   "3.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 153, End: 162},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-4",
-			Version: "3.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 93, End: 105},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-4",
+			Version:   "3.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "is-number-5",
-			Version: "3.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 106, End: 118},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "is-number-5",
+			Version:   "3.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "postcss-calc",
-			Version: "7.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 119, End: 129},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "postcss-calc",
+			Version:   "7.0.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "raven-js",
-			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 163, End: 165},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "raven-js",
+			Version:   "",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c2b377e7a254264fd4a1fe328e4e3cfc9e245570",
 		},
 		{
-			Name:    "slick-carousel",
-			Version: "1.7.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 166, End: 175},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "slick-carousel",
+			Version:   "1.7.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "280b560161b751ba226d50c7db1e0a14a78c2de0",
@@ -538,41 +396,26 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "etag",
-			Version: "1.8.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 16, End: 35},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "etag",
+			Version:   "1.8.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "abbrev",
-			Version: "1.0.9",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 36, End: 41},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "abbrev",
+			Version:   "1.0.9",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 			DepGroups: []string{"dev"},
 		},
 		{
-			Name:    "abbrev",
-			Version: "2.3.4",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 42, End: 47},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "abbrev",
+			Version:   "2.3.4",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -594,37 +437,22 @@ func TestParseNpmLock_v2_Alias(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@babel/code-frame",
-			Version: "7.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 21},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "@babel/code-frame",
+			Version:   "7.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "string-width",
-			Version: "4.2.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 32, End: 42},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "string-width",
+			Version:   "4.2.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
-			Name:    "string-width",
-			Version: "5.1.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 22, End: 31},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "string-width",
+			Version:   "5.1.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -644,27 +472,17 @@ func TestParseNpmLock_v2_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "wrappy",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 15},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			Name:      "wrappy",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"optional"},
 		},
 		{
-			Name:    "supports-color",
-			Version: "5.5.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 16, End: 27},
-				Column:   models.Position{Start: 6, End: 6},
-				Filename: path,
-			},
+			Name:      "supports-color",
+			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev", "optional"},

--- a/pkg/lockfile/parse-pnpm-lock_test.go
+++ b/pkg/lockfile/parse-pnpm-lock_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/osv-scanner/pkg/models"
-
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
@@ -69,7 +67,7 @@ func TestParsePnpmLock_FileDoesNotExist(t *testing.T) {
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/does-not-exist")
 
 	expectErrIs(t, err, fs.ErrNotExist)
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParsePnpmLock_InvalidYaml(t *testing.T) {
@@ -78,7 +76,7 @@ func TestParsePnpmLock_InvalidYaml(t *testing.T) {
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/not-yaml.txt")
 
 	expectErrContaining(t, err, "could not extract from")
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParsePnpmLock_Empty(t *testing.T) {
@@ -90,7 +88,7 @@ func TestParsePnpmLock_Empty(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParsePnpmLock_NoPackages(t *testing.T) {
@@ -102,7 +100,7 @@ func TestParsePnpmLock_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParsePnpmLock_OnePackage(t *testing.T) {
@@ -118,15 +116,10 @@ func TestParsePnpmLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "acorn",
-			Version: "8.7.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 11, End: 15},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "acorn",
+			Version:   "8.7.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
@@ -146,15 +139,10 @@ func TestParsePnpmLock_OnePackageV6Lockfile(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "acorn",
-			Version: "8.7.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 14},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "acorn",
+			Version:   "8.7.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
@@ -174,15 +162,10 @@ func TestParsePnpmLock_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "acorn",
-			Version: "8.7.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 11, End: 15},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "acorn",
+			Version:   "8.7.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
@@ -202,15 +185,10 @@ func TestParsePnpmLock_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@typescript-eslint/types",
-			Version: "5.13.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 11, End: 14},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "@typescript-eslint/types",
+			Version:   "5.13.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
@@ -230,15 +208,10 @@ func TestParsePnpmLock_ScopedPackagesV6Lockfile(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@typescript-eslint/types",
-			Version: "5.57.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 13},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "@typescript-eslint/types",
+			Version:   "5.57.1",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
@@ -258,26 +231,16 @@ func TestParsePnpmLock_PeerDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "acorn-jsx",
-			Version: "5.3.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 19},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "acorn-jsx",
+			Version:   "5.3.2",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "acorn",
-			Version: "8.7.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 21, End: 25},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "acorn",
+			Version:   "8.7.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
@@ -297,103 +260,58 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@typescript-eslint/eslint-plugin",
-			Version: "5.13.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 17, End: 42},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "@typescript-eslint/eslint-plugin",
+			Version:   "5.13.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "@typescript-eslint/parser",
-			Version: "5.13.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 44, End: 62},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "@typescript-eslint/parser",
+			Version:   "5.13.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "@typescript-eslint/type-utils",
-			Version: "5.13.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 64, End: 81},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "@typescript-eslint/type-utils",
+			Version:   "5.13.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "@typescript-eslint/types",
-			Version: "5.13.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 83, End: 86},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "@typescript-eslint/types",
+			Version:   "5.13.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "@typescript-eslint/typescript-estree",
-			Version: "5.13.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 88, End: 107},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "@typescript-eslint/typescript-estree",
+			Version:   "5.13.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "@typescript-eslint/utils",
-			Version: "5.13.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 109, End: 125},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "@typescript-eslint/utils",
+			Version:   "5.13.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "eslint-utils",
-			Version: "3.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 127, End: 135},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "eslint-utils",
+			Version:   "3.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "eslint",
-			Version: "8.10.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 137, End: 179},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "eslint",
+			Version:   "8.10.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "tsutils",
-			Version: "3.21.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 181, End: 189},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "tsutils",
+			Version:   "3.21.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
@@ -413,158 +331,88 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "aws-sdk",
-			Version: "2.1087.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 11, End: 24},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "aws-sdk",
+			Version:   "2.1087.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "base64-js",
-			Version: "1.5.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 26, End: 28},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "base64-js",
+			Version:   "1.5.1",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "buffer",
-			Version: "4.9.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 30, End: 36},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "buffer",
+			Version:   "4.9.2",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "events",
-			Version: "1.1.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 38, End: 41},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "events",
+			Version:   "1.1.1",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "ieee754",
-			Version: "1.1.13",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 43, End: 45},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "ieee754",
+			Version:   "1.1.13",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "isarray",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 47, End: 49},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "isarray",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "jmespath",
-			Version: "0.16.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 51, End: 54},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "jmespath",
+			Version:   "0.16.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "punycode",
-			Version: "1.3.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 56, End: 58},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "punycode",
+			Version:   "1.3.2",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "querystring",
-			Version: "0.2.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 60, End: 64},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "querystring",
+			Version:   "0.2.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "sax",
-			Version: "1.2.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 66, End: 68},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "sax",
+			Version:   "1.2.1",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "url",
-			Version: "0.10.3",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 70, End: 75},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "url",
+			Version:   "0.10.3",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "uuid",
-			Version: "3.3.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 77, End: 81},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "uuid",
+			Version:   "3.3.2",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "xml2js",
-			Version: "0.4.19",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 83, End: 88},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "xml2js",
+			Version:   "0.4.19",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "xmlbuilder",
-			Version: "9.0.7",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 90, End: 93},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "xmlbuilder",
+			Version:   "9.0.7",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
@@ -584,37 +432,22 @@ func TestParsePnpmLock_MultipleVersions(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "uuid",
-			Version: "3.3.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 17},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "uuid",
+			Version:   "3.3.2",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "uuid",
-			Version: "8.3.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 19, End: 22},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "uuid",
+			Version:   "8.3.2",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "xmlbuilder",
-			Version: "9.0.7",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 24, End: 27},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "xmlbuilder",
+			Version:   "9.0.7",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
@@ -634,15 +467,10 @@ func TestParsePnpmLock_Tarball(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@my-org/my-package",
-			Version: "3.2.3",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 14},
-				Column:   models.Position{Start: 3, End: 14},
-				Filename: path,
-			},
+			Name:      "@my-org/my-package",
+			Version:   "3.2.3",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 			Commit:    "",
@@ -664,81 +492,46 @@ func TestParsePnpmLock_Exotic(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "foo",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 10},
-				Column:   models.Position{Start: 3, End: 14},
-				Filename: path,
-			},
+			Name:      "foo",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "@foo/bar",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 11, End: 11},
-				Column:   models.Position{Start: 3, End: 19},
-				Filename: path,
-			},
+			Name:      "@foo/bar",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "foo",
-			Version: "1.1.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 3, End: 32},
-				Filename: path,
-			},
+			Name:      "foo",
+			Version:   "1.1.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "@foo/bar",
-			Version: "1.1.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 3, End: 37},
-				Filename: path,
-			},
+			Name:      "@foo/bar",
+			Version:   "1.1.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "foo",
-			Version: "1.2.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 15, End: 15},
-				Column:   models.Position{Start: 3, End: 25},
-				Filename: path,
-			},
+			Name:      "foo",
+			Version:   "1.2.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "foo",
-			Version: "1.3.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 16, End: 16},
-				Column:   models.Position{Start: 3, End: 35},
-				Filename: path,
-			},
+			Name:      "foo",
+			Version:   "1.3.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
 		{
-			Name:    "foo",
-			Version: "1.4.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 17, End: 17},
-				Column:   models.Position{Start: 3, End: 40},
-				Filename: path,
-			},
+			Name:      "foo",
+			Version:   "1.4.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 		},
@@ -758,63 +551,38 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "my-bitbucket-package",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 14, End: 18},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "my-bitbucket-package",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 			Commit:    "6104ae42cd32c3d724036d3964678f197b2c9cdb",
 		},
 		{
-			Name:    "@my-scope/my-package",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 20, End: 26},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "@my-scope/my-package",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 			Commit:    "267087851ad5fac92a184749c27cd539e2fc862e",
 		},
 		{
-			Name:    "@my-scope/my-other-package",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 28, End: 32},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "@my-scope/my-other-package",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 			Commit:    "fbfc962ab51eb1d754749b68c064460221fbd689",
 		},
 		{
-			Name:    "faker-parser",
-			Version: "0.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 34, End: 40},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "faker-parser",
+			Version:   "0.0.1",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 			Commit:    "d2dc42a9351d4d89ec48c525e34f612b6d77993f",
 		},
 		{
-			Name:    "mocks",
-			Version: "20.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 42, End: 48},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "mocks",
+			Version:   "20.0.1",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 			Commit:    "590f321b4eb3f692bb211bd74e22947639a6f79d",
@@ -835,63 +603,38 @@ func TestParsePnpmLock_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "my-file-package",
-			Version: "0.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 14},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "my-file-package",
+			Version:   "0.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "a-local-package",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 16, End: 20},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "a-local-package",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "a-nested-local-package",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 22, End: 26},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "a-nested-local-package",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "one-up",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 28, End: 32},
-				Column:   models.Position{Start: 3, End: 15},
-				Filename: path,
-			},
+			Name:      "one-up",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "one-up-with-peer",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 34, End: 40},
-				Column:   models.Position{Start: 3, End: 25},
-				Filename: path,
-			},
+			Name:      "one-up-with-peer",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",

--- a/pkg/lockfile/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v1_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/osv-scanner/pkg/models"
-
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
@@ -17,7 +15,7 @@ func TestParseYarnLock_v1_FileDoesNotExist(t *testing.T) {
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/does-not-exist")
 
 	expectErrIs(t, err, fs.ErrNotExist)
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseYarnLock_v1_NoPackages(t *testing.T) {
@@ -29,7 +27,7 @@ func TestParseYarnLock_v1_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseYarnLock_v1_OnePackage(t *testing.T) {
@@ -45,15 +43,10 @@ func TestParseYarnLock_v1_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "balanced-match",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 8},
-				Column:   models.Position{Start: 1, End: 108},
-				Filename: path,
-			},
+			Name:      "balanced-match",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -73,26 +66,16 @@ func TestParseYarnLock_v1_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "concat-stream",
-			Version: "1.6.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 18},
-				Column:   models.Position{Start: 1, End: 24},
-				Filename: path,
-			},
+			Name:      "concat-stream",
+			Version:   "1.6.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "concat-map",
-			Version: "0.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 8},
-				Column:   models.Position{Start: 1, End: 46},
-				Filename: path,
-			},
+			Name:      "concat-map",
+			Version:   "0.0.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -112,26 +95,16 @@ func TestParseYarnLock_v1_WithQuotes(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "concat-stream",
-			Version: "1.6.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 18},
-				Column:   models.Position{Start: 1, End: 26},
-				Filename: path,
-			},
+			Name:      "concat-stream",
+			Version:   "1.6.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "concat-map",
-			Version: "0.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 8},
-				Column:   models.Position{Start: 1, End: 48},
-				Filename: path,
-			},
+			Name:      "concat-map",
+			Version:   "0.0.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -151,48 +124,28 @@ func TestParseYarnLock_v1_MultipleVersions(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "define-properties",
-			Version: "1.1.3",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 10},
-				Column:   models.Position{Start: 1, End: 26},
-				Filename: path,
-			},
+			Name:      "define-properties",
+			Version:   "1.1.3",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "define-property",
-			Version: "0.2.5",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 17},
-				Column:   models.Position{Start: 1, End: 27},
-				Filename: path,
-			},
+			Name:      "define-property",
+			Version:   "0.2.5",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "define-property",
-			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 19, End: 24},
-				Column:   models.Position{Start: 1, End: 27},
-				Filename: path,
-			},
+			Name:      "define-property",
+			Version:   "1.0.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "define-property",
-			Version: "2.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 26, End: 32},
-				Column:   models.Position{Start: 1, End: 22},
-				Filename: path,
-			},
+			Name:      "define-property",
+			Version:   "2.0.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -212,26 +165,16 @@ func TestParseYarnLock_v1_MultipleConstraints(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@babel/code-frame",
-			Version: "7.12.13",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 15},
-				Column:   models.Position{Start: 1, End: 34},
-				Filename: path,
-			},
+			Name:      "@babel/code-frame",
+			Version:   "7.12.13",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "domelementtype",
-			Version: "1.3.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 8},
-				Column:   models.Position{Start: 1, End: 108},
-				Filename: path,
-			},
+			Name:      "domelementtype",
+			Version:   "1.3.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -251,26 +194,16 @@ func TestParseYarnLock_v1_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@babel/code-frame",
-			Version: "7.12.11",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 10},
-				Column:   models.Position{Start: 1, End: 33},
-				Filename: path,
-			},
+			Name:      "@babel/code-frame",
+			Version:   "7.12.11",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "@babel/compat-data",
-			Version: "7.14.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 15},
-				Column:   models.Position{Start: 1, End: 108},
-				Filename: path,
-			},
+			Name:      "@babel/compat-data",
+			Version:   "7.14.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -290,59 +223,34 @@ func TestParseYarnLock_v1_WithPrerelease(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "css-tree",
-			Version: "1.0.0-alpha.37",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 11},
-				Column:   models.Position{Start: 1, End: 24},
-				Filename: path,
-			},
+			Name:      "css-tree",
+			Version:   "1.0.0-alpha.37",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "gensync",
-			Version: "1.0.0-beta.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 16},
-				Column:   models.Position{Start: 1, End: 108},
-				Filename: path,
-			},
+			Name:      "gensync",
+			Version:   "1.0.0-beta.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "node-fetch",
-			Version: "3.0.0-beta.9",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 18, End: 24},
-				Column:   models.Position{Start: 1, End: 24},
-				Filename: path,
-			},
+			Name:      "node-fetch",
+			Version:   "3.0.0-beta.9",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "resolve",
-			Version: "1.20.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 26, End: 32},
-				Column:   models.Position{Start: 1, End: 24},
-				Filename: path,
-			},
+			Name:      "resolve",
+			Version:   "1.20.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "resolve",
-			Version: "2.0.0-next.3",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 34, End: 40},
-				Column:   models.Position{Start: 1, End: 24},
-				Filename: path,
-			},
+			Name:      "resolve",
+			Version:   "2.0.0-next.3",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -362,26 +270,16 @@ func TestParseYarnLock_v1_WithBuildString(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "domino",
-			Version: "2.1.6+git",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 8},
-				Column:   models.Position{Start: 1, End: 108},
-				Filename: path,
-			},
+			Name:      "domino",
+			Version:   "2.1.6+git",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "tslib",
-			Version: "2.6.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 13},
-				Column:   models.Position{Start: 1, End: 108},
-				Filename: path,
-			},
+			Name:      "tslib",
+			Version:   "2.6.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -401,51 +299,31 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "mine1",
 			Version:   "1.0.0-alpha.37",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 9},
-				Column:   models.Position{Start: 1, End: 31},
-				Filename: path,
-			},
-			Commit: "0a2d2506c1fe299691fc5db53a2097db3bd615bc",
+			Commit:    "0a2d2506c1fe299691fc5db53a2097db3bd615bc",
 		},
 		{
 			Name:      "mine2",
 			Version:   "0.0.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 11, End: 15},
-				Column:   models.Position{Start: 1, End: 31},
-				Filename: path,
-			},
-			Commit: "0a2d2506c1fe299691fc5db53a2097db3bd615bc",
+			Commit:    "0a2d2506c1fe299691fc5db53a2097db3bd615bc",
 		},
 		{
 			Name:      "mine3",
 			Version:   "1.2.3",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 17, End: 19},
-				Column:   models.Position{Start: 1, End: 111},
-				Filename: path,
-			},
-			Commit: "094e581aaf927d010e4b61d706ba584551dac502",
+			Commit:    "094e581aaf927d010e4b61d706ba584551dac502",
 		},
 		{
-			Name:    "mine4",
-			Version: "0.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 21, End: 23},
-				Column:   models.Position{Start: 1, End: 101},
-				Filename: path,
-			},
+			Name:      "mine4",
+			Version:   "0.0.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 			Commit:    "aa3bdfcb1d845c79f14abb66f60d35b8a3ee5998",
@@ -455,165 +333,95 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Version:   "0.0.4",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 25, End: 27},
-				Column:   models.Position{Start: 1, End: 111},
-				Filename: path,
-			},
-			Commit: "aa3bdfcb1d845c79f14abb66f60d35b8a3ee5998",
+			Commit:    "aa3bdfcb1d845c79f14abb66f60d35b8a3ee5998",
 		},
 		{
 			Name:      "my-package",
 			Version:   "1.8.3",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 29, End: 31},
-				Column:   models.Position{Start: 1, End: 103},
-				Filename: path,
-			},
-			Commit: "b3bd3f1b3dad036e671251f5258beaae398f983a",
+			Commit:    "b3bd3f1b3dad036e671251f5258beaae398f983a",
 		},
 		{
 			Name:      "@bower_components/angular-animate",
 			Version:   "1.4.14",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 33, End: 35},
-				Column:   models.Position{Start: 1, End: 105},
-				Filename: path,
-			},
-			Commit: "e7f778fc054a086ba3326d898a00fa1bc78650a8",
+			Commit:    "e7f778fc054a086ba3326d898a00fa1bc78650a8",
 		},
 		{
 			Name:      "@bower_components/alertify",
 			Version:   "0.0.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 37, End: 39},
-				Column:   models.Position{Start: 1, End: 115},
-				Filename: path,
-			},
-			Commit: "e7b6c46d76604d297c389d830817b611c9a8f17c",
+			Commit:    "e7b6c46d76604d297c389d830817b611c9a8f17c",
 		},
 		{
 			Name:      "minimist",
 			Version:   "0.0.8",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 41, End: 43},
-				Column:   models.Position{Start: 1, End: 93},
-				Filename: path,
-			},
-			Commit: "3754568bfd43a841d2d72d7fb54598635aea8fa4",
+			Commit:    "3754568bfd43a841d2d72d7fb54598635aea8fa4",
 		},
 		{
 			Name:      "bats-assert",
 			Version:   "2.0.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 45, End: 47},
-				Column:   models.Position{Start: 1, End: 95},
-				Filename: path,
-			},
-			Commit: "4bdd58d3fbcdce3209033d44d884e87add1d8405",
+			Commit:    "4bdd58d3fbcdce3209033d44d884e87add1d8405",
 		},
 		{
 			Name:      "bats-support",
 			Version:   "0.3.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 49, End: 51},
-				Column:   models.Position{Start: 1, End: 96},
-				Filename: path,
-			},
-			Commit: "d140a65044b2d6810381935ae7f0c94c7023c8c3",
+			Commit:    "d140a65044b2d6810381935ae7f0c94c7023c8c3",
 		},
 		{
 			Name:      "bats",
 			Version:   "1.5.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 53, End: 55},
-				Column:   models.Position{Start: 1, End: 93},
-				Filename: path,
-			},
-			Commit: "172580d2ce19ee33780b5f1df817bbddced43789",
+			Commit:    "172580d2ce19ee33780b5f1df817bbddced43789",
 		},
 		{
 			Name:      "vue",
 			Version:   "2.6.12",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 57, End: 59},
-				Column:   models.Position{Start: 1, End: 87},
-				Filename: path,
-			},
-			Commit: "bb253db0b3e17124b6d1fe93fbf2db35470a1347",
+			Commit:    "bb253db0b3e17124b6d1fe93fbf2db35470a1347",
 		},
 		{
 			Name:      "kit",
 			Version:   "1.0.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 61, End: 66},
-				Column:   models.Position{Start: 1, End: 32},
-				Filename: path,
-			},
-			Commit: "5b6830c0252eb73c6024d40a8ff5106d3023a2a6",
+			Commit:    "5b6830c0252eb73c6024d40a8ff5106d3023a2a6",
 		},
 		{
 			Name:      "casadistance",
 			Version:   "1.0.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 68, End: 70},
-				Column:   models.Position{Start: 1, End: 110},
-				Filename: path,
-			},
-			Commit: "f0308391f0c50104182bfb2332a53e4e523a4603",
+			Commit:    "f0308391f0c50104182bfb2332a53e4e523a4603",
 		},
 		{
 			Name:      "babel-preset-php",
 			Version:   "1.1.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 72, End: 76},
-				Column:   models.Position{Start: 1, End: 24},
-				Filename: path,
-			},
-			Commit: "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
+			Commit:    "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
 		},
 		{
 			Name:      "is-number",
 			Version:   "2.0.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 78, End: 80},
-				Column:   models.Position{Start: 1, End: 113},
-				Filename: path,
-			},
-			Commit: "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
+			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
 		},
 		{
-			Name:    "is-number",
-			Version: "5.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 82, End: 84},
-				Column:   models.Position{Start: 1, End: 113},
-				Filename: path,
-			},
+			Name:      "is-number",
+			Version:   "5.0.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -634,75 +442,45 @@ func TestParseYarnLock_v1_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "etag",
-			Version: "1.8.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 7},
-				Column:   models.Position{Start: 1, End: 105},
-				Filename: path,
-			},
+			Name:      "etag",
+			Version:   "1.8.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "filedep",
-			Version: "1.2.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 9, End: 10},
-				Column:   models.Position{Start: 1, End: 18},
-				Filename: path,
-			},
+			Name:      "filedep",
+			Version:   "1.2.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "lodash",
-			Version: "1.3.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 14},
-				Column:   models.Position{Start: 1, End: 109},
-				Filename: path,
-			},
+			Name:      "lodash",
+			Version:   "1.3.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "other_package",
-			Version: "0.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 16, End: 22},
-				Column:   models.Position{Start: 1, End: 18},
-				Filename: path,
-			},
+			Name:      "other_package",
+			Version:   "0.0.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "sprintf-js",
-			Version: "0.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 24, End: 25},
-				Column:   models.Position{Start: 1, End: 18},
-				Filename: path,
-			},
+			Name:      "sprintf-js",
+			Version:   "0.0.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 			Commit:    "",
 		},
 		{
-			Name:    "etag",
-			Version: "1.8.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 27, End: 28},
-				Column:   models.Position{Start: 1, End: 18},
-				Filename: path,
-			},
+			Name:      "etag",
+			Version:   "1.8.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 			Commit:    "",
@@ -723,37 +501,22 @@ func TestParseYarnLock_v1_WithAliases(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@babel/helper-validator-identifier",
-			Version: "7.22.20",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 15, End: 18},
-				Column:   models.Position{Start: 1, End: 108},
-				Filename: path,
-			},
+			Name:      "@babel/helper-validator-identifier",
+			Version:   "7.22.20",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "ansi-regex",
-			Version: "6.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 13},
-				Column:   models.Position{Start: 1, End: 108},
-				Filename: path,
-			},
+			Name:      "ansi-regex",
+			Version:   "6.0.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "ansi-regex",
-			Version: "5.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 8},
-				Column:   models.Position{Start: 1, End: 108},
-				Filename: path,
-			},
+			Name:      "ansi-regex",
+			Version:   "5.0.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},

--- a/pkg/lockfile/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v2_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/osv-scanner/pkg/models"
-
 	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
@@ -17,7 +15,7 @@ func TestParseYarnLock_v2_FileDoesNotExist(t *testing.T) {
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/does-not-exist")
 
 	expectErrIs(t, err, fs.ErrNotExist)
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseYarnLock_v2_NoPackages(t *testing.T) {
@@ -29,7 +27,7 @@ func TestParseYarnLock_v2_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{})
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseYarnLock_v2_OnePackage(t *testing.T) {
@@ -45,15 +43,10 @@ func TestParseYarnLock_v2_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "balanced-match",
-			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 13},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "balanced-match",
+			Version:   "1.0.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -73,26 +66,16 @@ func TestParseYarnLock_v2_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "compare-func",
-			Version: "2.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 16},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "compare-func",
+			Version:   "2.0.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "concat-map",
-			Version: "0.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 18, End: 23},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "concat-map",
+			Version:   "0.0.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -112,26 +95,16 @@ func TestParseYarnLock_v2_WithQuotes(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "compare-func",
-			Version: "2.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 16},
-				Column:   models.Position{Start: 1, End: 19},
-				Filename: path,
-			},
+			Name:      "compare-func",
+			Version:   "2.0.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "concat-map",
-			Version: "0.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 18, End: 23},
-				Column:   models.Position{Start: 1, End: 19},
-				Filename: path,
-			},
+			Name:      "concat-map",
+			Version:   "0.0.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -151,37 +124,22 @@ func TestParseYarnLock_v2_MultipleVersions(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "debug",
-			Version: "4.3.3",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 18},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "debug",
+			Version:   "4.3.3",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "debug",
-			Version: "2.6.9",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 20, End: 27},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "debug",
+			Version:   "2.6.9",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "debug",
-			Version: "3.2.7",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 29, End: 36},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "debug",
+			Version:   "3.2.7",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -201,37 +159,22 @@ func TestParseYarnLock_v2_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@babel/cli",
-			Version: "7.16.8",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 33},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "@babel/cli",
+			Version:   "7.16.8",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "@babel/code-frame",
-			Version: "7.16.7",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 35, End: 42},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "@babel/code-frame",
+			Version:   "7.16.7",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "@babel/compat-data",
-			Version: "7.16.8",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 44, End: 49},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "@babel/compat-data",
+			Version:   "7.16.8",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -251,37 +194,22 @@ func TestParseYarnLock_v2_WithPrerelease(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@nicolo-ribaudo/chokidar-2",
-			Version: "2.1.8-no-fsevents.3",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 13},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "@nicolo-ribaudo/chokidar-2",
+			Version:   "2.1.8-no-fsevents.3",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "gensync",
-			Version: "1.0.0-beta.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 15, End: 20},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "gensync",
+			Version:   "1.0.0-beta.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "eslint-plugin-jest",
-			Version: "0.0.0-use.local",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 22, End: 76},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "eslint-plugin-jest",
+			Version:   "0.0.0-use.local",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -301,38 +229,23 @@ func TestParseYarnLock_v2_WithBuildString(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "domino",
-			Version: "2.1.6+git",
-			Commit:  "f2435fe1f9f7c91ade0bd472c4723e5eacd7d19a",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 13},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "domino",
+			Version:   "2.1.6+git",
+			Commit:    "f2435fe1f9f7c91ade0bd472c4723e5eacd7d19a",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "tslib",
-			Version: "2.6.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 15, End: 20},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "tslib",
+			Version:   "2.6.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "zone.js",
-			Version: "0.0.0-use.local",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 22, End: 29},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "zone.js",
+			Version:   "0.0.0-use.local",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
@@ -352,90 +265,55 @@ func TestParseYarnLock_v2_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "@my-scope/my-first-package",
 			Version:   "0.0.6",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 10},
-				Column:   models.Position{Start: 1, End: 138},
-				Filename: path,
-			},
-			Commit: "0b824c650d3a03444dbcf2b27a5f3566f6e41358",
+			Commit:    "0b824c650d3a03444dbcf2b27a5f3566f6e41358",
 		},
 		{
 			Name:      "my-second-package",
 			Version:   "0.2.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 19},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
-			Commit: "59e2127b9f9d4fda5f928c4204213b3502cd5bb0",
+			Commit:    "59e2127b9f9d4fda5f928c4204213b3502cd5bb0",
 		},
 		{
 			Name:      "@typegoose/typegoose",
 			Version:   "7.2.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 21, End: 35},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
-			Commit: "3ed06e5097ab929f69755676fee419318aaec73a",
+			Commit:    "3ed06e5097ab929f69755676fee419318aaec73a",
 		},
 		{
 			Name:      "vuejs",
 			Version:   "2.5.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 37, End: 42},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
-			Commit: "0948d999f2fddf9f90991956493f976273c5da1f",
+			Commit:    "0948d999f2fddf9f90991956493f976273c5da1f",
 		},
 		{
 			Name:      "my-third-package",
 			Version:   "0.16.1-dev",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 45, End: 47},
-				Column:   models.Position{Start: 1, End: 128},
-				Filename: path,
-			},
-			Commit: "5675a0aed98e067ff6ecccc5ac674fe8995960e0",
+			Commit:    "5675a0aed98e067ff6ecccc5ac674fe8995960e0",
 		},
 		{
 			Name:      "my-node-sdk",
 			Version:   "1.1.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 50, End: 55},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
-			Commit: "053dea9e0b8af442d8f867c8e690d2fb0ceb1bf5",
+			Commit:    "053dea9e0b8af442d8f867c8e690d2fb0ceb1bf5",
 		},
 		{
 			Name:      "is-really-great",
 			Version:   "1.0.0",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 58, End: 63},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
-			Commit: "191eeef50c584714e1fb8927d17ee72b3b8c97c4",
+			Commit:    "191eeef50c584714e1fb8927d17ee72b3b8c97c4",
 		},
 	})
 }
@@ -453,15 +331,10 @@ func TestParseYarnLock_v2_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "my-package",
-			Version: "0.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 13},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "my-package",
+			Version:   "0.0.2",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 			Commit:    "",
@@ -482,48 +355,28 @@ func TestParseYarnLock_v2_WithAliases(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackages(t, packages, []lockfile.PackageDetails{
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
 		{
-			Name:    "@babel/helper-validator-identifier",
-			Version: "7.22.20",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 22, End: 27},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "@babel/helper-validator-identifier",
+			Version:   "7.22.20",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "ansi-regex",
-			Version: "6.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 15, End: 20},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "ansi-regex",
+			Version:   "6.0.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "ansi-regex",
-			Version: "5.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 13},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "ansi-regex",
+			Version:   "5.0.1",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},
 		{
-			Name:    "mine",
-			Version: "0.0.0-use.local",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 29, End: 37},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
+			Name:      "mine",
+			Version:   "0.0.0-use.local",
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 		},


### PR DESCRIPTION
## What does this PR do?
For those cases where the location will refer to the source file and not the lock file, we don't want to check the locations on the package details struct (unit tests). 
To achieve this, the test helpers have been updated to allow it.

