### PR TITLE
✨ Matcher (from lockfile to sourcefile) general logic

### DIFF
--- a/pkg/lockfile/match-package-json.go
+++ b/pkg/lockfile/match-package-json.go
@@ -1,0 +1,13 @@
+package lockfile
+
+type PackageJsonMatcher struct{}
+
+func (m PackageJsonMatcher) GetSourceFile(lockfile DepFile) (DepFile, error) {
+	return lockfile.Open("package.json")
+}
+
+func (m PackageJsonMatcher) Match(_ DepFile, _ []PackageDetails) error {
+	return nil
+}
+
+var _ Matcher = PackageJsonMatcher{}

--- a/pkg/lockfile/match-package-json.go
+++ b/pkg/lockfile/match-package-json.go
@@ -1,13 +1,13 @@
 package lockfile
 
-type PackageJsonMatcher struct{}
+type PackageJSONMatcher struct{}
 
-func (m PackageJsonMatcher) GetSourceFile(lockfile DepFile) (DepFile, error) {
+func (m PackageJSONMatcher) GetSourceFile(lockfile DepFile) (DepFile, error) {
 	return lockfile.Open("package.json")
 }
 
-func (m PackageJsonMatcher) Match(_ DepFile, _ []PackageDetails) error {
+func (m PackageJSONMatcher) Match(_ DepFile, _ []PackageDetails) error {
 	return nil
 }
 
-var _ Matcher = PackageJsonMatcher{}
+var _ Matcher = PackageJSONMatcher{}

--- a/pkg/lockfile/matcher-helpers_test.go
+++ b/pkg/lockfile/matcher-helpers_test.go
@@ -1,0 +1,42 @@
+package lockfile_test
+
+import (
+	"github.com/google/osv-scanner/pkg/lockfile"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	MockAllMatchers()
+	os.Exit(m.Run())
+}
+
+func MockAllMatchers() {
+	lockfile.YarnExtractor.Matcher = SuccessfulMatcher{}
+}
+
+type SuccessfulMatcher struct{}
+
+func (m SuccessfulMatcher) GetSourceFile(_ lockfile.DepFile) (lockfile.DepFile, error) {
+	return nil, nil
+}
+
+func (m SuccessfulMatcher) Match(_ lockfile.DepFile, _ []lockfile.PackageDetails) error {
+	return nil
+}
+
+var _ lockfile.Matcher = SuccessfulMatcher{}
+
+type FailingMatcher struct {
+	Error error
+}
+
+func (m FailingMatcher) GetSourceFile(_ lockfile.DepFile) (lockfile.DepFile, error) {
+	return nil, nil
+}
+
+func (m FailingMatcher) Match(_ lockfile.DepFile, _ []lockfile.PackageDetails) error {
+	return m.Error
+}
+
+var _ lockfile.Matcher = FailingMatcher{}

--- a/pkg/lockfile/matcher-helpers_test.go
+++ b/pkg/lockfile/matcher-helpers_test.go
@@ -12,7 +12,8 @@ func TestMain(m *testing.M) {
 }
 
 func MockAllMatchers() {
-	lockfile.YarnExtractor.Matcher = SuccessfulMatcher{}
+	// TODO: Mock extractors with matcher to use SuccessfulMatcher by default in all tests
+	// lockfile.YarnExtractor.Matcher = SuccessfulMatcher{}
 }
 
 type SuccessfulMatcher struct{}

--- a/pkg/lockfile/matcher-helpers_test.go
+++ b/pkg/lockfile/matcher-helpers_test.go
@@ -1,9 +1,10 @@
 package lockfile_test
 
 import (
-	"github.com/google/osv-scanner/pkg/lockfile"
 	"os"
 	"testing"
+
+	"github.com/google/osv-scanner/pkg/lockfile"
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/lockfile/matcher.go
+++ b/pkg/lockfile/matcher.go
@@ -1,0 +1,16 @@
+package lockfile
+
+type Matcher interface {
+	GetSourceFile(lockfile DepFile) (DepFile, error)
+	Match(sourceFile DepFile, packages []PackageDetails) error
+}
+
+func matchWithFile(lockfile DepFile, packages []PackageDetails, matcher Matcher) error {
+	sourceFile, err := matcher.GetSourceFile(lockfile)
+
+	if err != nil {
+		return err
+	}
+
+	return matcher.Match(sourceFile, packages)
+}


### PR DESCRIPTION
## What does this PR do?
Base code for matching lock files with source files
- Matching is perform automatically in `extractFromFile` (i.e. for all extractors) when the extractor "has a `Matcher`"
  - This means that it'll be really easy to enrich the package details extracted from a lockfile with the positions in the source file, by just implementing the interface `ExtractorWithMatcher` in the original `Extractor``
- To isolate the unit testing of the extractors from the unit testing of the matchers, there is an override of all the matchers of the extractors with matcher in the main entry point of the `lockfile_test`module (in `matcher-helpers_test`)
  - By default, the matching will success (`SuccessfulMatcher{}`)
  - In case we want to test matching failing for the extractor, we may use `FailingMatcher{Error: <some_error>}` (there will be an example in the following PR)
  
## Additional notes
- Ideally, matchers should be in a different module, like `sourcefile` (not `lockfile`), but, as there is a circular dependency between matchers and extractors, it will require to refactor and extract the `types` in `lockfile` to a separated module 