### PR TITLE
🐛 Stop reporting a default version when not extracted properly

### DIFF
--- a/pkg/lockfile/fixtures/maven/no-version.xml
+++ b/pkg/lockfile/fixtures/maven/no-version.xml
@@ -1,0 +1,12 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -158,7 +158,7 @@ func TestParseGoLock_WithoutSupportedVersioning(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "github.com/elastic/go-elasticsearch",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 			BlockLocation: models.FilePosition{

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -132,7 +132,7 @@ func (mld MavenLockDependency) ResolveVersion(lockfile MavenLockFile) (string, *
 	results := versionRequirementReg.FindStringSubmatch(version)
 
 	if results == nil || results[1] == "" {
-		return "0", nil
+		return "", nil
 	}
 
 	return results[1], position

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -986,7 +986,7 @@ func TestMavenLockDependency_ResolveVersion(t *testing.T) {
 			name:   "",
 			fields: fields{Version: "(,1.0]"},
 			args:   args{lockfile: lockfile.MavenLockFile{}},
-			want:   "0",
+			want:   "",
 		},
 		// [1.2,1.3]: Hard requirement for any version between 1.2 and 1.3 inclusive.
 		{
@@ -1014,14 +1014,14 @@ func TestMavenLockDependency_ResolveVersion(t *testing.T) {
 			name:   "",
 			fields: fields{Version: "(,1.0],[1.2,)"},
 			args:   args{lockfile: lockfile.MavenLockFile{}},
-			want:   "0",
+			want:   "",
 		},
 		// (,1.1),(1.1,): Hard requirement for any version except 1.1; for example because 1.1 has a critical vulnerability.
 		{
 			name:   "",
 			fields: fields{Version: "(,1.1),(1.1,)"},
 			args:   args{lockfile: lockfile.MavenLockFile{}},
-			want:   "0",
+			want:   "",
 		},
 	}
 	for _, tt := range tests {
@@ -1300,6 +1300,25 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 				Filename: path,
 			},
 			DepGroups: nil,
+		},
+	})
+}
+
+func TestParseMavenLock_NoVersion(t *testing.T) {
+	t.Parallel()
+	lockfileRelativePath := "fixtures/maven/no-version.xml"
+	packages, err := lockfile.ParseMavenLock(lockfileRelativePath)
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+		{
+			Name:      "org.apache.maven:maven-artifact",
+			Version:   "",
+			Ecosystem: lockfile.MavenEcosystem,
+			CompareAs: lockfile.MavenEcosystem,
 		},
 	})
 }

--- a/pkg/lockfile/parse-requirements-txt.go
+++ b/pkg/lockfile/parse-requirements-txt.go
@@ -26,7 +26,7 @@ func parseLine(path string, line string, lineNumber int, lineOffset int, columnS
 	var constraint string
 	name := line
 
-	version := "0.0.0"
+	version := ""
 
 	if strings.Contains(line, "==") {
 		constraint = "=="
@@ -142,7 +142,7 @@ func extractVersionFromWheelURL(wheelURL string) string {
 	parts := strings.Split(filename, "-")
 
 	if len(parts) < 2 {
-		return "0.0.0"
+		return ""
 	}
 
 	return parts[1]

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -117,7 +117,7 @@ func TestParseRequirementsTxt_OneRequirementUnconstrained(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "flask",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -493,7 +493,7 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "flask",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -510,7 +510,7 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 		},
 		{
 			Name:      "flask-cors",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -593,7 +593,7 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 		},
 		{
 			Name:      "sklearn",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -610,7 +610,7 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 		},
 		{
 			Name:      "requests",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -627,7 +627,7 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 		},
 		{
 			Name:      "gevent",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -662,7 +662,7 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "pytest",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -679,7 +679,7 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 		},
 		{
 			Name:      "pytest-cov",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -696,7 +696,7 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 		},
 		{
 			Name:      "beautifulsoup4",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -757,7 +757,7 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 		},
 		{
 			Name:      "coverage",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -796,7 +796,7 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 		},
 		{
 			Name:      "rejected",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -813,7 +813,7 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 		},
 		{
 			Name:      "green",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -993,7 +993,7 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "flask",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -1010,7 +1010,7 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 		},
 		{
 			Name:      "flask-cors",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -1093,7 +1093,7 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 		},
 		{
 			Name:      "sklearn",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -1110,7 +1110,7 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 		},
 		{
 			Name:      "requests",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -1127,7 +1127,7 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 		},
 		{
 			Name:      "gevent",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -1717,7 +1717,7 @@ func TestParseRequirementsTxt_EnvironmentMarkers(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "aa",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -1735,7 +1735,7 @@ func TestParseRequirementsTxt_EnvironmentMarkers(t *testing.T) {
 		},
 		{
 			Name:      "name6",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{
@@ -1793,7 +1793,7 @@ func TestParseRequirementsTxt_GitUrlPackages(t *testing.T) {
 	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "pyroxy",
-			Version:   "0.0.0",
+			Version:   "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
 			BlockLocation: models.FilePosition{

--- a/pkg/lockfile/types.go
+++ b/pkg/lockfile/types.go
@@ -46,5 +46,5 @@ func (sys Ecosystem) IsDevGroup(groups []string) bool {
 }
 
 func (pkg PackageDetails) IsVersionEmpty() bool {
-	return pkg.Version == "0"
+	return pkg.Version == ""
 }

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -881,7 +881,7 @@ func DoScan(actions ScannerActions, r reporter.Reporter) (models.VulnerabilityRe
 	overrideGoVersion(r, filteredScannedPackages, &configManager)
 
 	if actions.OnlyPackages {
-		vulnerabilityResults := groupBySource(r, filteredScannedPackages, actions)
+		vulnerabilityResults := groupBySource(r, scannedPackages, actions)
 
 		return vulnerabilityResults, nil
 	}

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -44,7 +44,7 @@ func buildVulnerabilityResults(
 			}
 		}
 
-		if rawPkg.Version != "" && rawPkg.Ecosystem != "" {
+		if rawPkg.Ecosystem != "" {
 			pkg.Package = models.PackageInfo{
 				Name:      rawPkg.Name,
 				Version:   rawPkg.Version,
@@ -126,7 +126,7 @@ func groupBySource(r reporter.Reporter, packages []scannedPackage, actions Scann
 	for _, p := range packages {
 		var pkg models.PackageVulns
 		switch {
-		case p.Ecosystem != "" && p.Name != "" && p.Version != "":
+		case p.Ecosystem != "" && p.Name != "":
 			pkg = models.PackageVulns{
 				Package: models.PackageInfo{
 					Name:      p.Name,

--- a/pkg/reporter/sbom/cyclonedx_1_4.go
+++ b/pkg/reporter/sbom/cyclonedx_1_4.go
@@ -17,10 +17,14 @@ func ToCycloneDX14Bom(_ io.Writer, uniquePackages map[string]models.PackageDetai
 	for packageURL, packageDetail := range uniquePackages {
 		component := cyclonedx.Component{}
 		component.Name = packageDetail.Name
-		component.Version = packageDetail.Version
 		component.BOMRef = packageURL
 		component.PackageURL = packageURL
 		component.Type = componentType
+
+		if packageDetail.Version != "" {
+			component.Version = packageDetail.Version
+		}
+
 		components = append(components, component)
 	}
 	bom.Components = &components

--- a/pkg/reporter/sbom/cyclonedx_1_5.go
+++ b/pkg/reporter/sbom/cyclonedx_1_5.go
@@ -18,11 +18,14 @@ func ToCycloneDX15Bom(stderr io.Writer, uniquePackages map[string]models.Package
 		component := cyclonedx.Component{}
 		occurrences := make([]cyclonedx.EvidenceOccurrence, len(packageDetail.Locations))
 		component.Name = packageDetail.Name
-		component.Version = packageDetail.Version
 		component.BOMRef = packageURL
 		component.PackageURL = packageURL
 		component.Type = componentType
 		component.Evidence = &cyclonedx.Evidence{Occurrences: &occurrences}
+
+		if packageDetail.Version != "" {
+			component.Version = packageDetail.Version
+		}
 
 		for index, packageLocations := range packageDetail.Locations {
 			jsonLocation, err := packageLocations.MarshalToJSONString()

--- a/pkg/reporter/sbom/cyclonedx_test.go
+++ b/pkg/reporter/sbom/cyclonedx_test.go
@@ -60,6 +60,21 @@ var input = map[string]models.PackageDetails{
 			},
 		},
 	},
+	"pkg:npm/the-no-version-package": {
+		Name:      "the-no-version-package",
+		Ecosystem: string(models.EcosystemMaven),
+		Locations: []models.PackageLocations{
+			{
+				Block: models.PackageLocation{
+					Filename:    "/path/to/npm/lockfile.lock",
+					LineStart:   12,
+					LineEnd:     15,
+					ColumnStart: 0,
+					ColumnEnd:   0,
+				},
+			},
+		},
+	},
 }
 
 func TestEncoding_EncodeComponentsInValidCycloneDX1_4(t *testing.T) {
@@ -87,6 +102,12 @@ func TestEncoding_EncodeComponentsInValidCycloneDX1_4(t *testing.T) {
 				PackageURL: "pkg:npm/the-npm-package@1.1.0",
 				Name:       "the-npm-package",
 				Version:    "1.1.0",
+				Type:       "library",
+			},
+			{
+				BOMRef:     "pkg:npm/the-no-version-package",
+				PackageURL: "pkg:npm/the-no-version-package",
+				Name:       "the-no-version-package",
 				Type:       "library",
 			},
 		},
@@ -134,6 +155,17 @@ func TestEncoding_EncodeComponentsInValidCycloneDX1_5(t *testing.T) {
 				},
 			},
 		},
+		"pkg:npm/the-no-version-package": {
+			{
+				"block": JSONMap{
+					"file_name":    "/path/to/npm/lockfile.lock",
+					"line_start":   12,
+					"line_end":     15,
+					"column_start": 0,
+					"column_end":   0,
+				},
+			},
+		},
 	}
 
 	expectedBOM := cyclonedx.BOM{
@@ -160,6 +192,15 @@ func TestEncoding_EncodeComponentsInValidCycloneDX1_5(t *testing.T) {
 				Type:       "library",
 				Evidence: &cyclonedx.Evidence{
 					Occurrences: buildOccurrences(t, "pkg:npm/the-npm-package@1.1.0", expectedJSONLocations),
+				},
+			},
+			{
+				BOMRef:     "pkg:npm/the-no-version-package",
+				PackageURL: "pkg:npm/the-no-version-package",
+				Name:       "the-no-version-package",
+				Type:       "library",
+				Evidence: &cyclonedx.Evidence{
+					Occurrences: buildOccurrences(t, "pkg:npm/the-no-version-package", expectedJSONLocations),
 				},
 			},
 		},


### PR DESCRIPTION
## What does this PR do?

Before this PR, if a version was not extracted properly, it would have defaulted to `version=0`. This have 2 major disadvantages : 
1. As all package managers have its own way to express version, the zero-version have a different form depending on the language, making it impossible to filter in a backend
2. It adds a lot of false positive to have version 0 as it will be vulnerable to everything

This PR aims to remove this version 0 and reports all packages (even the un-scannable ones) when having the flag only-packages.
