### PR TITLE
♻️ Schema refactor - lockfile and sourcefile locations

### DIFF
--- a/internal/ci/__snapshots__/vulnerability_result_diff_test.snap
+++ b/internal/ci/__snapshots__/vulnerability_result_diff_test.snap
@@ -43,16 +43,18 @@
             "name": "github.com/gogo/protobuf",
             "version": "1.3.1",
             "ecosystem": "Go",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -150,16 +152,18 @@
             "name": "github.com/gogo/protobuf",
             "version": "1.3.1",
             "ecosystem": "Go",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -457,16 +461,18 @@
             "name": "github.com/gogo/protobuf",
             "version": "1.3.1",
             "ecosystem": "Go",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -591,16 +597,18 @@
             "name": "regex",
             "version": "1.5.1",
             "ecosystem": "crates.io",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [

--- a/internal/output/__snapshots__/machinejson_test.snap
+++ b/internal/output/__snapshots__/machinejson_test.snap
@@ -13,16 +13,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -42,16 +44,18 @@
             "name": "mine2",
             "version": "3.2.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -63,16 +67,18 @@
             "name": "mine3",
             "version": "0.4.1",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -92,16 +98,18 @@
             "name": "mine1",
             "version": "1.3.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -113,16 +121,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -158,16 +168,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -190,16 +202,18 @@
             "name": "mine2",
             "version": "3.2.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -214,16 +228,18 @@
             "name": "mine3",
             "version": "0.4.1",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -243,16 +259,18 @@
             "name": "mine1",
             "version": "1.3.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -264,16 +282,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -312,16 +332,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -345,16 +367,18 @@
             "name": "mine2",
             "version": "3.2.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -369,16 +393,18 @@
             "name": "mine3",
             "version": "0.4.1",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -398,16 +424,18 @@
             "name": "mine1",
             "version": "1.3.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -419,16 +447,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -465,16 +495,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "Packagist",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -497,16 +529,18 @@
             "name": "mine2",
             "version": "3.2.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -521,16 +555,18 @@
             "name": "mine3",
             "version": "0.4.1",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -550,16 +586,18 @@
             "name": "mine1",
             "version": "1.3.5",
             "ecosystem": "NuGet",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -571,16 +609,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "Packagist",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [
@@ -622,16 +662,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [
@@ -658,16 +700,18 @@
             "name": "mine2",
             "version": "3.2.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [
@@ -686,16 +730,18 @@
             "name": "mine3",
             "version": "0.4.1",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -715,16 +761,18 @@
             "name": "mine1",
             "version": "1.3.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -736,16 +784,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [
@@ -862,16 +912,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -907,16 +959,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           }
         }
@@ -949,16 +1003,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -994,16 +1050,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -1044,16 +1102,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -1092,16 +1152,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [
@@ -1143,16 +1205,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -1175,16 +1239,18 @@
             "name": "mine2",
             "version": "5.9.0",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -1220,16 +1286,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1274,16 +1342,18 @@
             "name": "mine2",
             "version": "3.2.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1317,16 +1387,18 @@
             "name": "mine3",
             "version": "0.4.1",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -1346,16 +1418,18 @@
             "name": "mine1",
             "version": "1.3.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -1370,16 +1444,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1440,16 +1516,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1510,16 +1588,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1561,16 +1641,18 @@
             "name": "mine2",
             "version": "5.9.0",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "licenses": [
@@ -1609,16 +1691,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [
@@ -1671,16 +1755,18 @@
             "name": "mine1",
             "version": "1.2.2",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1719,16 +1805,18 @@
             "name": "mine2",
             "version": "3.2.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [
@@ -1762,16 +1850,18 @@
             "name": "mine3",
             "version": "0.4.1",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [
@@ -1845,16 +1935,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1903,16 +1995,18 @@
             "name": "mine1",
             "version": "1.2.2",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1951,16 +2045,18 @@
             "name": "mine2",
             "version": "3.2.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1991,16 +2087,18 @@
             "name": "mine3",
             "version": "0.4.1",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -2071,16 +2169,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           }
         }
@@ -2097,16 +2197,18 @@
             "name": "mine2",
             "version": "3.2.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           }
         },
@@ -2115,16 +2217,18 @@
             "name": "mine3",
             "version": "0.4.1",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           }
         }
@@ -2141,16 +2245,18 @@
             "name": "mine1",
             "version": "1.3.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           }
         },
@@ -2159,16 +2265,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           }
         }
@@ -2199,16 +2307,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -2247,16 +2357,18 @@
             "name": "mine2",
             "version": "3.2.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -2287,16 +2399,18 @@
             "name": "mine3",
             "version": "0.4.1",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           }
         }
@@ -2313,16 +2427,18 @@
             "name": "mine1",
             "version": "1.3.5",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           }
         },
@@ -2331,16 +2447,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -2393,16 +2511,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "Packagist",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -2451,16 +2571,18 @@
             "name": "mine1",
             "version": "1.2.2",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -2499,16 +2621,18 @@
             "name": "mine2",
             "version": "3.2.5",
             "ecosystem": "NuGet",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [
@@ -2542,16 +2666,18 @@
             "name": "mine3",
             "version": "0.4.1",
             "ecosystem": "Packagist",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [
@@ -2694,16 +2820,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           }
         }
@@ -2734,16 +2862,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -2796,16 +2926,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [
@@ -2861,16 +2993,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -2941,16 +3075,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -2975,16 +3111,18 @@
             "name": "mine3",
             "version": "0.10.2-rc",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -3030,16 +3168,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -3078,16 +3218,18 @@
             "name": "mine2",
             "version": "5.9.0",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           }
         }
@@ -3118,16 +3260,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -3166,16 +3310,18 @@
             "name": "mine1",
             "version": "1.2.3",
             "ecosystem": "npm",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "dependency_groups": [

--- a/internal/output/__snapshots__/result_test.snap
+++ b/internal/output/__snapshots__/result_test.snap
@@ -31,16 +31,18 @@
           "name": "regex",
           "version": "1.5.1",
           "ecosystem": "crates.io",
-          "blockLocation": {
-            "line": {
-              "start": 0,
-              "end": 0
-            },
-            "column": {
-              "start": 0,
-              "end": 0
-            },
-            "file_name": ""
+          "lockfileLocations": {
+            "block": {
+              "line": {
+                "start": 0,
+                "end": 0
+              },
+              "column": {
+                "start": 0,
+                "end": 0
+              },
+              "file_name": ""
+            }
           }
         },
         "Source": {
@@ -247,16 +249,18 @@
           "name": "github.com/gogo/protobuf",
           "version": "1.3.1",
           "ecosystem": "Go",
-          "blockLocation": {
-            "line": {
-              "start": 0,
-              "end": 0
-            },
-            "column": {
-              "start": 0,
-              "end": 0
-            },
-            "file_name": ""
+          "lockfileLocations": {
+            "block": {
+              "line": {
+                "start": 0,
+                "end": 0
+              },
+              "column": {
+                "start": 0,
+                "end": 0
+              },
+              "file_name": ""
+            }
           }
         },
         "Source": {
@@ -338,16 +342,18 @@
           "name": "regex",
           "version": "1.5.1",
           "ecosystem": "crates.io",
-          "blockLocation": {
-            "line": {
-              "start": 0,
-              "end": 0
-            },
-            "column": {
-              "start": 0,
-              "end": 0
-            },
-            "file_name": ""
+          "lockfileLocations": {
+            "block": {
+              "line": {
+                "start": 0,
+                "end": 0
+              },
+              "column": {
+                "start": 0,
+                "end": 0
+              },
+              "file_name": ""
+            }
           }
         },
         "Source": {

--- a/internal/sourceanalysis/__snapshots__/go_test.snap
+++ b/internal/sourceanalysis/__snapshots__/go_test.snap
@@ -6,16 +6,18 @@
       "name": "github.com/gogo/protobuf",
       "version": "1.3.1",
       "ecosystem": "Go",
-      "blockLocation": {
-        "line": {
-          "start": 0,
-          "end": 0
-        },
-        "column": {
-          "start": 0,
-          "end": 0
-        },
-        "file_name": ""
+      "lockfileLocations": {
+        "block": {
+          "line": {
+            "start": 0,
+            "end": 0
+          },
+          "column": {
+            "start": 0,
+            "end": 0
+          },
+          "file_name": ""
+        }
       }
     },
     "vulnerabilities": [
@@ -183,16 +185,18 @@
       "name": "github.com/ipfs/go-bitfield",
       "version": "1.0.0",
       "ecosystem": "Go",
-      "blockLocation": {
-        "line": {
-          "start": 0,
-          "end": 0
-        },
-        "column": {
-          "start": 0,
-          "end": 0
-        },
-        "file_name": ""
+      "lockfileLocations": {
+        "block": {
+          "line": {
+            "start": 0,
+            "end": 0
+          },
+          "column": {
+            "start": 0,
+            "end": 0
+          },
+          "file_name": ""
+        }
       }
     },
     "vulnerabilities": [
@@ -347,16 +351,18 @@
       "name": "golang.org/x/image",
       "version": "0.4.0",
       "ecosystem": "Go",
-      "blockLocation": {
-        "line": {
-          "start": 0,
-          "end": 0
-        },
-        "column": {
-          "start": 0,
-          "end": 0
-        },
-        "file_name": ""
+      "lockfileLocations": {
+        "block": {
+          "line": {
+            "start": 0,
+            "end": 0
+          },
+          "column": {
+            "start": 0,
+            "end": 0
+          },
+          "file_name": ""
+        }
       }
     },
     "vulnerabilities": [
@@ -517,16 +523,18 @@
       "name": "github.com/gogo/protobuf",
       "version": "1.3.1",
       "ecosystem": "Go",
-      "blockLocation": {
-        "line": {
-          "start": 0,
-          "end": 0
-        },
-        "column": {
-          "start": 0,
-          "end": 0
-        },
-        "file_name": ""
+      "lockfileLocations": {
+        "block": {
+          "line": {
+            "start": 0,
+            "end": 0
+          },
+          "column": {
+            "start": 0,
+            "end": 0
+          },
+          "file_name": ""
+        }
       }
     },
     "vulnerabilities": [
@@ -678,16 +686,18 @@
       "name": "github.com/ipfs/go-bitfield",
       "version": "1.0.0",
       "ecosystem": "Go",
-      "blockLocation": {
-        "line": {
-          "start": 0,
-          "end": 0
-        },
-        "column": {
-          "start": 0,
-          "end": 0
-        },
-        "file_name": ""
+      "lockfileLocations": {
+        "block": {
+          "line": {
+            "start": 0,
+            "end": 0
+          },
+          "column": {
+            "start": 0,
+            "end": 0
+          },
+          "file_name": ""
+        }
       }
     },
     "vulnerabilities": [
@@ -826,16 +836,18 @@
       "name": "golang.org/x/image",
       "version": "0.4.0",
       "ecosystem": "Go",
-      "blockLocation": {
-        "line": {
-          "start": 0,
-          "end": 0
-        },
-        "column": {
-          "start": 0,
-          "end": 0
-        },
-        "file_name": ""
+      "lockfileLocations": {
+        "block": {
+          "line": {
+            "start": 0,
+            "end": 0
+          },
+          "column": {
+            "start": 0,
+            "end": 0
+          },
+          "file_name": ""
+        }
       }
     },
     "vulnerabilities": [

--- a/pkg/grouper/package_grouper.go
+++ b/pkg/grouper/package_grouper.go
@@ -17,17 +17,26 @@ func GroupByPURL(packageSources []models.PackageSource, considerScanPathAsRoot b
 				continue
 			}
 			existingPackage, packageExists := uniquePackages[packageURL.ToString()]
-			isLocationExtracted := isLocationExtractedSuccessfully(pkg.Package.BlockLocation)
-			location := extractPackageLocations(packageSource.Source.ScanPath, pkg.Package, considerScanPathAsRoot, pathRelativeToScanDir)
+			isLocationExtracted := isLocationExtractedSuccessfully(pkg.Package.LockfileLocations.Block)
+			locations := extractPackageLocations(packageSource.Source.ScanPath, pkg.Package.LockfileLocations, considerScanPathAsRoot, pathRelativeToScanDir)
+			if pkg.Package.SourcefileLocations != nil {
+				sourcefileLocations := extractPackageLocations(packageSource.Source.ScanPath, *pkg.Package.SourcefileLocations, considerScanPathAsRoot, pathRelativeToScanDir)
+				locations.Sourcefile = &models.SourcefilePackageLocations{
+					Block:     sourcefileLocations.Block,
+					Name:      sourcefileLocations.Name,
+					Namespace: sourcefileLocations.Namespace,
+					Version:   sourcefileLocations.Version,
+				}
+			}
 
 			if packageExists && isLocationExtracted {
-				locationHash := location.Block.Hash()
+				locationHash := locations.Block.Hash()
 				if _, isLocationDuplicated := pkgLocations[locationHash]; isLocationDuplicated {
 					continue
 				}
 
-				// Package exists, location exists and is not a duplicate => we need to add it
-				existingPackage.Locations = append(existingPackage.Locations, location)
+				// Package exists, locations exists and is not a duplicate => we need to add it
+				existingPackage.Locations = append(existingPackage.Locations, locations)
 				pkgLocations[locationHash] = true
 				uniquePackages[packageURL.ToString()] = existingPackage
 			} else if !packageExists {
@@ -41,9 +50,9 @@ func GroupByPURL(packageSources []models.PackageSource, considerScanPathAsRoot b
 				}
 
 				if isLocationExtracted {
-					// We add location only if it has been extracted successfully
-					newPackage.Locations = append(newPackage.Locations, location)
-					pkgLocations[location.Block.Hash()] = true
+					// We add locations only if it has been extracted successfully
+					newPackage.Locations = append(newPackage.Locations, locations)
+					pkgLocations[locations.Block.Hash()] = true
 				}
 				uniquePackages[packageURL.ToString()] = newPackage
 			}
@@ -57,19 +66,19 @@ func isLocationExtractedSuccessfully(filePosition models.FilePosition) bool {
 	return filePosition.Line.Start > 0 && filePosition.Line.End > 0 && filePosition.Column.Start > 0 && filePosition.Column.End > 0 && filePosition.Filename != ""
 }
 
-func extractPackageLocations(scanPath string, pkgInfos models.PackageInfo, considerScanPathAsRoot bool, pathRelativeToScanDir bool) models.PackageLocations {
+func extractPackageLocations(scanPath string, fileLocations models.FileLocations, considerScanPathAsRoot bool, pathRelativeToScanDir bool) models.PackageLocations {
 	locations := models.PackageLocations{
 		Block: models.PackageLocation{
-			Filename:    fileposition.RemoveHostPath(scanPath, pkgInfos.BlockLocation.Filename, considerScanPathAsRoot, pathRelativeToScanDir),
-			LineStart:   pkgInfos.BlockLocation.Line.Start,
-			LineEnd:     pkgInfos.BlockLocation.Line.End,
-			ColumnStart: pkgInfos.BlockLocation.Column.Start,
-			ColumnEnd:   pkgInfos.BlockLocation.Column.End,
+			Filename:    fileposition.RemoveHostPath(scanPath, fileLocations.Block.Filename, considerScanPathAsRoot, pathRelativeToScanDir),
+			LineStart:   fileLocations.Block.Line.Start,
+			LineEnd:     fileLocations.Block.Line.End,
+			ColumnStart: fileLocations.Block.Column.Start,
+			ColumnEnd:   fileLocations.Block.Column.End,
 		},
 	}
 
-	locations.Name = mapToPackageLocation(scanPath, pkgInfos.NameLocation, considerScanPathAsRoot, pathRelativeToScanDir)
-	locations.Version = mapToPackageLocation(scanPath, pkgInfos.VersionLocation, considerScanPathAsRoot, pathRelativeToScanDir)
+	locations.Name = mapToPackageLocation(scanPath, fileLocations.Name, considerScanPathAsRoot, pathRelativeToScanDir)
+	locations.Version = mapToPackageLocation(scanPath, fileLocations.Version, considerScanPathAsRoot, pathRelativeToScanDir)
 
 	return locations
 }

--- a/pkg/grouper/package_grouper_test.go
+++ b/pkg/grouper/package_grouper_test.go
@@ -24,10 +24,29 @@ func TestGroupPackageByPURL_ShouldUnifyPackages(t *testing.T) {
 						Name:      "foo.bar:the-first-package",
 						Version:   "1.0.0",
 						Ecosystem: string(lockfile.MavenEcosystem),
-						BlockLocation: models.FilePosition{
-							Line:     models.Position{Start: 1, End: 2},
-							Column:   models.Position{Start: 10, End: 21},
-							Filename: "/dir/lockfile.xml",
+						LockfileLocations: models.FileLocations{
+							Block: models.FilePosition{
+								Line:     models.Position{Start: 1, End: 2},
+								Column:   models.Position{Start: 10, End: 21},
+								Filename: "/dir/lockfile.xml",
+							},
+							Name: &models.FilePosition{
+								Line:     models.Position{Start: 3, End: 3},
+								Column:   models.Position{Start: 5, End: 14},
+								Filename: "/dir/nested/other-lockfile.xml",
+							},
+						},
+						SourcefileLocations: &models.FileLocations{
+							Block: models.FilePosition{
+								Line:     models.Position{Start: 2, End: 2},
+								Column:   models.Position{Start: 15, End: 35},
+								Filename: "/dir/sourcefile",
+							},
+							Name: &models.FilePosition{
+								Line:     models.Position{Start: 2, End: 2},
+								Column:   models.Position{Start: 16, End: 24},
+								Filename: "/dir/sourcefile",
+							},
 						},
 					},
 				},
@@ -36,10 +55,12 @@ func TestGroupPackageByPURL_ShouldUnifyPackages(t *testing.T) {
 						Name:      "foo.bar:the-first-package",
 						Version:   "1.0.0",
 						Ecosystem: string(lockfile.MavenEcosystem),
-						BlockLocation: models.FilePosition{
-							Line:     models.Position{Start: 1, End: 2},
-							Column:   models.Position{Start: 10, End: 21},
-							Filename: "/dir/lockfile.xml",
+						LockfileLocations: models.FileLocations{
+							Block: models.FilePosition{
+								Line:     models.Position{Start: 1, End: 2},
+								Column:   models.Position{Start: 10, End: 21},
+								Filename: "/dir/lockfile.xml",
+							},
 						},
 					},
 				},
@@ -48,10 +69,12 @@ func TestGroupPackageByPURL_ShouldUnifyPackages(t *testing.T) {
 						Name:      "foo.bar:the-first-package",
 						Version:   "1.0.0",
 						Ecosystem: string(lockfile.MavenEcosystem),
-						BlockLocation: models.FilePosition{
-							Line:     models.Position{Start: 1, End: 2},
-							Column:   models.Position{Start: 10, End: 21},
-							Filename: "/dir/lockfile.xml",
+						LockfileLocations: models.FileLocations{
+							Block: models.FilePosition{
+								Line:     models.Position{Start: 1, End: 2},
+								Column:   models.Position{Start: 10, End: 21},
+								Filename: "/dir/lockfile.xml",
+							},
 						},
 					},
 				},
@@ -60,10 +83,12 @@ func TestGroupPackageByPURL_ShouldUnifyPackages(t *testing.T) {
 						Name:      "foo.bar:package-2",
 						Ecosystem: string(lockfile.MavenEcosystem),
 						Version:   "1.0.0",
-						BlockLocation: models.FilePosition{
-							Line:     models.Position{Start: 11, End: 22},
-							Column:   models.Position{Start: 10, End: 21},
-							Filename: "/dir/lockfile.xml",
+						LockfileLocations: models.FileLocations{
+							Block: models.FilePosition{
+								Line:     models.Position{Start: 11, End: 22},
+								Column:   models.Position{Start: 10, End: 21},
+								Filename: "/dir/lockfile.xml",
+							},
 						},
 					},
 				},
@@ -81,10 +106,12 @@ func TestGroupPackageByPURL_ShouldUnifyPackages(t *testing.T) {
 						Name:      "foo.bar:the-first-package",
 						Version:   "1.0.0",
 						Ecosystem: string(lockfile.MavenEcosystem),
-						BlockLocation: models.FilePosition{
-							Line:     models.Position{Start: 1, End: 2},
-							Column:   models.Position{Start: 10, End: 21},
-							Filename: "/dir2/lockfile.json",
+						LockfileLocations: models.FileLocations{
+							Block: models.FilePosition{
+								Line:     models.Position{Start: 1, End: 2},
+								Column:   models.Position{Start: 10, End: 21},
+								Filename: "/dir2/lockfile.json",
+							},
 						},
 					},
 				},
@@ -114,6 +141,29 @@ func TestGroupPackageByPURL_ShouldUnifyPackages(t *testing.T) {
 						LineEnd:     2,
 						ColumnStart: 10,
 						ColumnEnd:   21,
+					},
+					Name: &models.PackageLocation{
+						Filename:    "/dir/nested/other-lockfile.xml",
+						LineStart:   3,
+						LineEnd:     3,
+						ColumnStart: 5,
+						ColumnEnd:   14,
+					},
+					Sourcefile: &models.SourcefilePackageLocations{
+						Block: models.PackageLocation{
+							Filename:    "/dir/sourcefile",
+							LineStart:   2,
+							LineEnd:     2,
+							ColumnStart: 15,
+							ColumnEnd:   35,
+						},
+						Name: &models.PackageLocation{
+							Filename:    "/dir/sourcefile",
+							LineStart:   2,
+							LineEnd:     2,
+							ColumnStart: 16,
+							ColumnEnd:   24,
+						},
 					},
 				},
 				{

--- a/pkg/lockfile/match-package-json_test.go
+++ b/pkg/lockfile/match-package-json_test.go
@@ -72,20 +72,22 @@ func TestPackageJSONMatcher_Match_OnePackage(t *testing.T) {
 		{
 			Name:           "lodash",
 			TargetVersions: []string{"^4.0.0"},
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 5, End: 23},
-				Filename: sourceFile.Path(),
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 6, End: 12},
-				Filename: sourceFile.Path(),
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 16, End: 22},
-				Filename: sourceFile.Path(),
+			SourcefileLocations: &lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 5, End: 23},
+					Filename: sourceFile.Path(),
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 6, End: 12},
+					Filename: sourceFile.Path(),
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 16, End: 22},
+					Filename: sourceFile.Path(),
+				},
 			},
 		},
 	})
@@ -134,39 +136,43 @@ func TestPackageJSONMatcher_Match_TransitiveDependencies(t *testing.T) {
 		{
 			Name:           "debug",
 			TargetVersions: []string{"^0.7", "~0.7.2"},
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 5, End: 20},
-				Filename: sourceFile.Path(),
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 6, End: 11},
-				Filename: sourceFile.Path(),
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 15, End: 19},
-				Filename: sourceFile.Path(),
+			SourcefileLocations: &lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 5, End: 20},
+					Filename: sourceFile.Path(),
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 6, End: 11},
+					Filename: sourceFile.Path(),
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 15, End: 19},
+					Filename: sourceFile.Path(),
+				},
 			},
 		},
 		{
 			Name:           "jear",
 			TargetVersions: []string{"^0.1.4"},
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 5, End: 21},
-				Filename: sourceFile.Path(),
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 6, End: 10},
-				Filename: sourceFile.Path(),
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 14, End: 20},
-				Filename: sourceFile.Path(),
+			SourcefileLocations: &lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 5, End: 21},
+					Filename: sourceFile.Path(),
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 6, End: 10},
+					Filename: sourceFile.Path(),
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 14, End: 20},
+					Filename: sourceFile.Path(),
+				},
 			},
 		},
 		{

--- a/pkg/lockfile/node-modules-npm-v1_test.go
+++ b/pkg/lockfile/node-modules-npm-v1_test.go
@@ -44,10 +44,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackage(t *testing.T) {
 			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 9},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 9},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -68,10 +70,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackageDev(t *testing.T) {
 			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 10},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 10},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -93,10 +97,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_TwoPackages(t *testing.T) {
 			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 9},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 9},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -104,10 +110,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_TwoPackages(t *testing.T) {
 			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 17},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 17},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -128,10 +136,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_ScopedPackages(t *testing.T) {
 			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 17},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 17},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -139,10 +149,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_ScopedPackages(t *testing.T) {
 			Version:   "7.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 12},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 12},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -163,10 +175,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 			Version:   "6.0.23",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 14},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 14},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -174,10 +188,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 			Version:   "7.0.16",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 26, End: 35},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 26, End: 35},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -185,10 +201,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 			Version:   "7.0.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 15, End: 45},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 15, End: 45},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -196,10 +214,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 			Version:   "6.1.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 36, End: 43},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 36, End: 43},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -207,10 +227,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 46, End: 53},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 46, End: 53},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -235,10 +257,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependenciesDup(t *testing.T)
 		Version:   "6.1.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
-		BlockLocation: models.FilePosition{
-			Line:     models.Position{Start: 749, End: 756},
-			Column:   models.Position{Start: 9, End: 10},
-			Filename: filePath,
+		LockfileLocations: lockfile.Locations{
+			Block: models.FilePosition{
+				Line:     models.Position{Start: 749, End: 756},
+				Column:   models.Position{Start: 9, End: 10},
+				Filename: filePath,
+			},
 		},
 	})
 
@@ -247,10 +271,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependenciesDup(t *testing.T)
 		Version:   "5.5.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
-		BlockLocation: models.FilePosition{
-			Line:     models.Position{Start: 759, End: 766},
-			Column:   models.Position{Start: 5, End: 6},
-			Filename: filePath,
+		LockfileLocations: lockfile.Locations{
+			Block: models.FilePosition{
+				Line:     models.Position{Start: 759, End: 766},
+				Column:   models.Position{Start: 5, End: 6},
+				Filename: filePath,
+			},
 		},
 	})
 
@@ -259,10 +285,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependenciesDup(t *testing.T)
 		Version:   "2.0.0",
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
-		BlockLocation: models.FilePosition{
-			Line:     models.Position{Start: 186, End: 190},
-			Column:   models.Position{Start: 9, End: 10},
-			Filename: filePath,
+		LockfileLocations: lockfile.Locations{
+			Block: models.FilePosition{
+				Line:     models.Position{Start: 186, End: 190},
+				Column:   models.Position{Start: 9, End: 10},
+				Filename: filePath,
+			},
 		},
 	})
 }
@@ -283,10 +311,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "3b1bb80b302c2e552685dc8a029797ec832ea7c9",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 18},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 18},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -295,10 +325,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 19, End: 23},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 19, End: 23},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -307,10 +339,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 24, End: 30},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 24, End: 30},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -319,10 +353,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 31, End: 37},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 31, End: 37},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -332,10 +368,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 75, End: 81},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 75, End: 81},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -345,10 +383,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 38, End: 41},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 38, End: 41},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -357,10 +397,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82dcc8e914dabd9305ab9ae580709a7825e824f5",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 82, End: 85},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 82, End: 85},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -369,10 +411,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 42, End: 46},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 42, End: 46},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -382,10 +426,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 86, End: 90},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 86, End: 90},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -395,10 +441,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 47, End: 54},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 47, End: 54},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -408,10 +456,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 55, End: 62},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 55, End: 62},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -421,10 +471,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 63, End: 69},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 63, End: 69},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -434,10 +486,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 70, End: 92},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 70, End: 92},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -446,10 +500,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c2b377e7a254264fd4a1fe328e4e3cfc9e245570",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 93, End: 96},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 93, End: 96},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -458,10 +514,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "280b560161b751ba226d50c7db1e0a14a78c2de0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 97, End: 101},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 97, End: 101},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -477,17 +535,19 @@ func TestNodeModulesExtractor_Extract_npm_v1_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "lodash",
 			Version:   "1.3.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 9},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 9},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -496,10 +556,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 15},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 15},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -514,16 +576,18 @@ func TestNodeModulesExtractor_Extract_npm_v1_Alias(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "@babel/code-frame",
 			Version:   "7.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 12},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 12},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -531,10 +595,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Alias(t *testing.T) {
 			Version:   "4.2.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 23, End: 32},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 23, End: 32},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -542,10 +608,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_Alias(t *testing.T) {
 			Version:   "5.1.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 22},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 22},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -560,16 +628,18 @@ func TestNodeModulesExtractor_Extract_npm_v1_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 11},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 11},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev", "optional"},
 		},
@@ -578,10 +648,12 @@ func TestNodeModulesExtractor_Extract_npm_v1_OptionalPackage(t *testing.T) {
 			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 20},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 12, End: 20},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"optional"},
 		},

--- a/pkg/lockfile/node-modules-npm-v2_test.go
+++ b/pkg/lockfile/node-modules-npm-v2_test.go
@@ -45,10 +45,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackage(t *testing.T) {
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 14},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 14},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -70,10 +72,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackageDev(t *testing.T) {
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 15},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 15},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -96,10 +100,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_TwoPackages(t *testing.T) {
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 17},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 17},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -108,10 +114,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_TwoPackages(t *testing.T) {
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 18, End: 28},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 18, End: 28},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -132,10 +140,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_ScopedPackages(t *testing.T) {
 			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 18, End: 22},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 18, End: 22},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -143,10 +153,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_ScopedPackages(t *testing.T) {
 			Version:   "7.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 17},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 17},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -167,10 +179,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 			Version:   "6.0.23",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 22},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 22},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -178,10 +192,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 			Version:   "7.0.16",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 34, End: 46},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 34, End: 46},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -189,10 +205,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 			Version:   "7.0.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 23, End: 33},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 23, End: 33},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -200,10 +218,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 			Version:   "6.1.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 47, End: 57},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 47, End: 57},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -211,10 +231,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 58, End: 68},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 58, End: 68},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -235,10 +257,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependenciesDup(t *testing.T)
 			Version:   "6.1.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 20},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 20},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -246,10 +270,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependenciesDup(t *testing.T)
 			Version:   "2.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 32, End: 39},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 32, End: 39},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -272,10 +298,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "3b1bb80b302c2e552685dc8a029797ec832ea7c9",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 26, End: 41},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 26, End: 41},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -284,10 +312,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 42, End: 49},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 42, End: 49},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -297,10 +327,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 50, End: 59},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 50, End: 59},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -311,10 +343,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 60, End: 72},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 60, End: 72},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -324,10 +358,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 130, End: 142},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 130, End: 142},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -338,10 +374,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 73, End: 82},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 73, End: 82},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -351,10 +389,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82dcc8e914dabd9305ab9ae580709a7825e824f5",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 143, End: 152},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 143, End: 152},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -365,10 +405,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 83, End: 92},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 83, End: 92},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -378,10 +420,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 153, End: 162},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 153, End: 162},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -392,10 +436,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 93, End: 105},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 93, End: 105},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -406,10 +452,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 106, End: 118},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 106, End: 118},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -419,10 +467,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 119, End: 129},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 119, End: 129},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -432,10 +482,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "c2b377e7a254264fd4a1fe328e4e3cfc9e245570",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 163, End: 165},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 163, End: 165},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -445,10 +497,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "280b560161b751ba226d50c7db1e0a14a78c2de0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 166, End: 175},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 166, End: 175},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -472,10 +526,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Files(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 16, End: 35},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 16, End: 35},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -485,10 +541,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 36, End: 41},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 36, End: 41},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -498,10 +556,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 42, End: 47},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 42, End: 47},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -524,10 +584,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Alias(t *testing.T) {
 			TargetVersions: []string{"^7.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 21},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 21},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -536,10 +598,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Alias(t *testing.T) {
 			TargetVersions: []string{"^4.2.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 32, End: 42},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 32, End: 42},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 		{
@@ -548,10 +612,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_Alias(t *testing.T) {
 			TargetVersions: []string{"^5.1.2"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 22, End: 31},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 22, End: 31},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 		},
 	})
@@ -573,10 +639,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_OptionalPackage(t *testing.T) {
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 15},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 15},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"optional"},
 		},
@@ -585,10 +653,12 @@ func TestNodeModulesExtractor_Extract_npm_v2_OptionalPackage(t *testing.T) {
 			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 16, End: 27},
-				Column:   models.Position{Start: 6, End: 6},
-				Filename: filePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 16, End: 27},
+					Column:   models.Position{Start: 6, End: 6},
+					Filename: filePath,
+				},
 			},
 			DepGroups: []string{"dev", "optional"},
 		},

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -100,13 +100,15 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 
 		blockLocation, nameLocation, versionLocation := extractLocations(block, start, end, f.Path(), name, version)
 		packages[require.Mod.Path+"@"+require.Mod.Version] = PackageDetails{
-			Name:            name,
-			Version:         version,
-			Ecosystem:       GoEcosystem,
-			CompareAs:       GoEcosystem,
-			BlockLocation:   blockLocation,
-			NameLocation:    nameLocation,
-			VersionLocation: versionLocation,
+			Name:      name,
+			Version:   version,
+			Ecosystem: GoEcosystem,
+			CompareAs: GoEcosystem,
+			LockfileLocations: Locations{
+				Block:   blockLocation,
+				Name:    nameLocation,
+				Version: versionLocation,
+			},
 		}
 	}
 
@@ -140,13 +142,15 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 
 			blockLocation, nameLocation, versionLocation := extractLocations(block, start, end, f.Path(), name, version)
 			packages[replacement] = PackageDetails{
-				Name:            name,
-				Version:         version,
-				Ecosystem:       GoEcosystem,
-				CompareAs:       GoEcosystem,
-				BlockLocation:   blockLocation,
-				VersionLocation: versionLocation,
-				NameLocation:    nameLocation,
+				Name:      name,
+				Version:   version,
+				Ecosystem: GoEcosystem,
+				CompareAs: GoEcosystem,
+				LockfileLocations: Locations{
+					Block:   blockLocation,
+					Version: versionLocation,
+					Name:    nameLocation,
+				},
 			}
 		}
 	}
@@ -157,8 +161,10 @@ func (e GoLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 			Version:   parsedLockfile.Go.Version,
 			Ecosystem: GoEcosystem,
 			CompareAs: GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Filename: f.Path(),
+			LockfileLocations: Locations{
+				Block: models.FilePosition{
+					Filename: f.Path(),
+				},
 			},
 		}
 	}

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -112,20 +112,22 @@ func TestParseGoLock_WithPathMajor(t *testing.T) {
 			Version:   "8",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 1, End: 54},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 46, End: 47},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 9, End: 47},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 1, End: 54},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 46, End: 47},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 9, End: 47},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -133,10 +135,12 @@ func TestParseGoLock_WithPathMajor(t *testing.T) {
 			Version:   "1.11",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 0, End: 0},
-				Column:   models.Position{Start: 0, End: 0},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 0, End: 0},
+					Column:   models.Position{Start: 0, End: 0},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -161,15 +165,17 @@ func TestParseGoLock_WithoutSupportedVersioning(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 1, End: 51},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 9, End: 44},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 1, End: 51},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 9, End: 44},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -177,10 +183,12 @@ func TestParseGoLock_WithoutSupportedVersioning(t *testing.T) {
 			Version:   "1.11",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 0, End: 0},
-				Column:   models.Position{Start: 0, End: 0},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 0, End: 0},
+					Column:   models.Position{Start: 0, End: 0},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -205,20 +213,22 @@ func TestParseGoLock_OnePackage(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 2, End: 35},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 30, End: 35},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 2, End: 28},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 2, End: 35},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 30, End: 35},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 2, End: 28},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -243,20 +253,22 @@ func TestParseGoLock_TwoPackages(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 2, End: 35},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 30, End: 35},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 2, End: 28},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 2, End: 35},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 30, End: 35},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 2, End: 28},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -264,20 +276,22 @@ func TestParseGoLock_TwoPackages(t *testing.T) {
 			Version:   "2.4.0",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 2, End: 25},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 20, End: 25},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 2, End: 18},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 2, End: 25},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 20, End: 25},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 2, End: 18},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -285,10 +299,12 @@ func TestParseGoLock_TwoPackages(t *testing.T) {
 			Version:   "1.17",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 0, End: 0},
-				Column:   models.Position{Start: 0, End: 0},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 0, End: 0},
+					Column:   models.Position{Start: 0, End: 0},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -313,20 +329,22 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 2, End: 35},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 30, End: 35},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 2, End: 28},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 2, End: 35},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 30, End: 35},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 2, End: 28},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -334,20 +352,22 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			Version:   "2.4.0",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 2, End: 25},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 20, End: 25},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 2, End: 18},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 2, End: 25},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 20, End: 25},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 2, End: 18},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -355,20 +375,22 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			Version:   "0.1.9",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 11, End: 11},
-				Column:   models.Position{Start: 2, End: 38},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 11, End: 11},
-				Column:   models.Position{Start: 33, End: 38},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 11, End: 11},
-				Column:   models.Position{Start: 2, End: 31},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 11},
+					Column:   models.Position{Start: 2, End: 38},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 11, End: 11},
+					Column:   models.Position{Start: 33, End: 38},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 11, End: 11},
+					Column:   models.Position{Start: 2, End: 31},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -376,20 +398,22 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			Version:   "0.0.14",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 2, End: 36},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 30, End: 36},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 2, End: 28},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 2, End: 36},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 30, End: 36},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 2, End: 28},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -397,20 +421,22 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			Version:   "0.0.0-20210630005230-0f9fa26af87c",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 2, End: 53},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 20, End: 53},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 2, End: 18},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 2, End: 53},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 20, End: 53},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 2, End: 18},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -418,10 +444,12 @@ func TestParseGoLock_IndirectPackages(t *testing.T) {
 			Version:   "1.17",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 0, End: 0},
-				Column:   models.Position{Start: 0, End: 0},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 0, End: 0},
+					Column:   models.Position{Start: 0, End: 0},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -446,20 +474,22 @@ func TestParseGoLock_Replacements_One(t *testing.T) {
 			Version:   "1.4.5",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 1, End: 63},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 58, End: 63},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 36, End: 56},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 1, End: 63},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 58, End: 63},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 36, End: 56},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -484,20 +514,22 @@ func TestParseGoLock_Replacements_Mixed(t *testing.T) {
 			Version:   "1.4.5",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 5, End: 59},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 54, End: 59},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 32, End: 52},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 5, End: 59},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 54, End: 59},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 32, End: 52},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -505,20 +537,22 @@ func TestParseGoLock_Replacements_Mixed(t *testing.T) {
 			Version:   "0.5.6",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 5, End: 28},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 23, End: 28},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 5, End: 21},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 5, End: 28},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 23, End: 28},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 5, End: 21},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -543,20 +577,22 @@ func TestParseGoLock_Replacements_Local(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 5, End: 38},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 33, End: 38},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 5, End: 31},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 5, End: 38},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 33, End: 38},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 5, End: 31},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -564,15 +600,17 @@ func TestParseGoLock_Replacements_Local(t *testing.T) {
 			Version:   "",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 5, End: 42},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 32, End: 42},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 5, End: 42},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 32, End: 42},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -597,20 +635,22 @@ func TestParseGoLock_Replacements_Different(t *testing.T) {
 			Version:   "1.4.5",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 5, End: 59},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 54, End: 59},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 32, End: 52},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 5, End: 59},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 54, End: 59},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 32, End: 52},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -618,20 +658,22 @@ func TestParseGoLock_Replacements_Different(t *testing.T) {
 			Version:   "1.4.2",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 5, End: 59},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 54, End: 59},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 32, End: 52},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 5, End: 59},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 54, End: 59},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 32, End: 52},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -656,20 +698,22 @@ func TestParseGoLock_Replacements_NotRequired(t *testing.T) {
 			Version:   "0.5.6",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 5, End: 28},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 23, End: 28},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 5, End: 21},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 5, End: 28},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 23, End: 28},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 5, End: 21},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -677,20 +721,22 @@ func TestParseGoLock_Replacements_NotRequired(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 5, End: 38},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 33, End: 38},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 5, End: 31},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 5, End: 38},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 33, End: 38},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 5, End: 31},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -715,20 +761,22 @@ func TestParseGoLock_Replacements_NoVersion(t *testing.T) {
 			Version:   "1.4.5",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 5, End: 52},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 47, End: 52},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 25, End: 45},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 5, End: 52},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 47, End: 52},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 25, End: 45},
+					Filename: path,
+				},
 			},
 		},
 	})

--- a/pkg/lockfile/parse-gradle-lock.go
+++ b/pkg/lockfile/parse-gradle-lock.go
@@ -3,10 +3,9 @@ package lockfile
 import (
 	"bufio"
 	"fmt"
+	"github.com/google/osv-scanner/pkg/models"
 	"path/filepath"
 	"strings"
-
-	"github.com/google/osv-scanner/pkg/models"
 )
 
 const (
@@ -35,10 +34,12 @@ func parseToGradlePackageDetail(line string, lineNumber int, path string) (Packa
 		Version:   version,
 		Ecosystem: MavenEcosystem,
 		CompareAs: MavenEcosystem,
-		BlockLocation: models.FilePosition{
-			Line:     models.Position{Start: lineNumber, End: lineNumber},
-			Column:   models.Position{Start: 1, End: len(line) + 1},
-			Filename: path,
+		LockfileLocations: Locations{
+			Block: models.FilePosition{
+				Line:     models.Position{Start: lineNumber, End: lineNumber},
+				Column:   models.Position{Start: 1, End: len(line) + 1},
+				Filename: path,
+			},
 		},
 	}, nil
 }

--- a/pkg/lockfile/parse-gradle-lock_test.go
+++ b/pkg/lockfile/parse-gradle-lock_test.go
@@ -140,10 +140,12 @@ func TestParseGradleLock_OnePackage(t *testing.T) {
 			Version:   "5.7.3",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 119},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 119},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -168,10 +170,12 @@ func TestParseGradleLock_MultiplePackage(t *testing.T) {
 			Version:   "2.7.4",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 1, End: 134},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 1, End: 134},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -179,10 +183,12 @@ func TestParseGradleLock_MultiplePackage(t *testing.T) {
 			Version:   "2.7.5",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 1, End: 104},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 1, End: 104},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -190,10 +196,12 @@ func TestParseGradleLock_MultiplePackage(t *testing.T) {
 			Version:   "2.7.6",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 1, End: 85},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 1, End: 85},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -201,10 +209,12 @@ func TestParseGradleLock_MultiplePackage(t *testing.T) {
 			Version:   "2.7.7",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 1, End: 116},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 1, End: 116},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -212,10 +222,12 @@ func TestParseGradleLock_MultiplePackage(t *testing.T) {
 			Version:   "2.7.8",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 9, End: 9},
-				Column:   models.Position{Start: 1, End: 121},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 9, End: 9},
+					Column:   models.Position{Start: 1, End: 121},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -240,10 +252,12 @@ func TestParseGradleLock_WithInvalidLines(t *testing.T) {
 			Version:   "2.7.4",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 1, End: 134},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 1, End: 134},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -251,10 +265,12 @@ func TestParseGradleLock_WithInvalidLines(t *testing.T) {
 			Version:   "2.7.5",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 14, End: 14},
-				Column:   models.Position{Start: 1, End: 144},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 14, End: 14},
+					Column:   models.Position{Start: 1, End: 144},
+					Filename: path,
+				},
 			},
 		},
 	})

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -123,20 +123,22 @@ func TestParseMavenLock_OnePackage(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 11},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 9, End: 9},
-				Column:   models.Position{Start: 19, End: 33},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 10, End: 10},
-				Column:   models.Position{Start: 16, End: 21},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 11},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 9, End: 9},
+					Column:   models.Position{Start: 19, End: 33},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 10, End: 10},
+					Column:   models.Position{Start: 16, End: 21},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -161,20 +163,22 @@ func TestParseMavenLock_OnePackageWithMultipleVersionVariable(t *testing.T) {
 			Version:   "1.0.0-SNAPSHOT",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 9, End: 13},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 11, End: 11},
-				Column:   models.Position{Start: 19, End: 33},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 16, End: 40},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 9, End: 13},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 11, End: 11},
+					Column:   models.Position{Start: 19, End: 33},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 16, End: 40},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -199,20 +203,22 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 			Version:   "4.1.42.Final",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 11},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 9, End: 9},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 10, End: 10},
-				Column:   models.Position{Start: 16, End: 28},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 11},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 9, End: 9},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 10, End: 10},
+					Column:   models.Position{Start: 16, End: 28},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -220,20 +226,22 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 			Version:   "1.7.25",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 16},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 14, End: 14},
-				Column:   models.Position{Start: 19, End: 32},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 15, End: 15},
-				Column:   models.Position{Start: 16, End: 22},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 12, End: 16},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 14, End: 14},
+					Column:   models.Position{Start: 19, End: 32},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 15, End: 15},
+					Column:   models.Position{Start: 16, End: 22},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -258,20 +266,22 @@ func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 			Version:   "4.1.42.Final",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 10},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 9, End: 9},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 23, End: 23},
-				Column:   models.Position{Start: 18, End: 30},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 10},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 9, End: 9},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 23, End: 23},
+					Column:   models.Position{Start: 18, End: 30},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -279,20 +289,22 @@ func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 			Version:   "1.7.25",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 11, End: 15},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 19, End: 32},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 14, End: 14},
-				Column:   models.Position{Start: 16, End: 22},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 15},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 19, End: 32},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 14, End: 14},
+					Column:   models.Position{Start: 16, End: 22},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -317,20 +329,22 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 18, End: 22},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 20, End: 20},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 23, End: 28},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 18, End: 22},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 20, End: 20},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 23, End: 28},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -338,20 +352,22 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 			Version:   "2.3.4",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 24, End: 28},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 26, End: 26},
-				Column:   models.Position{Start: 19, End: 29},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 25, End: 30},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 24, End: 28},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 26, End: 26},
+					Column:   models.Position{Start: 19, End: 29},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 25, End: 30},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -359,20 +375,22 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 			Version:   "9.4.35.v20201120",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 30, End: 33},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 32, End: 32},
-				Column:   models.Position{Start: 19, End: 33},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 14, End: 14},
-				Column:   models.Position{Start: 20, End: 42},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 30, End: 33},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 32, End: 32},
+					Column:   models.Position{Start: 19, End: 33},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 14, End: 14},
+					Column:   models.Position{Start: 20, End: 42},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -398,20 +416,22 @@ func TestMavenLock_WithParent(t *testing.T) {
 			Version:   "3.0.2",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 26, End: 29},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: parentPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 28, End: 28},
-				Column:   models.Position{Start: 19, End: 25},
-				Filename: parentPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 20, End: 20},
-				Column:   models.Position{Start: 18, End: 23},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 26, End: 29},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: parentPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 28, End: 28},
+					Column:   models.Position{Start: 19, End: 25},
+					Filename: parentPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 20, End: 20},
+					Column:   models.Position{Start: 18, End: 23},
+					Filename: parentPath,
+				},
 			},
 		},
 		{
@@ -419,20 +439,22 @@ func TestMavenLock_WithParent(t *testing.T) {
 			Version:   "4.1.42.Final",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 14, End: 17},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 16, End: 16},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 15, End: 15},
-				Column:   models.Position{Start: 18, End: 30},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 14, End: 17},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 16, End: 16},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 15, End: 15},
+					Column:   models.Position{Start: 18, End: 30},
+					Filename: parentPath,
+				},
 			},
 		},
 		{
@@ -440,20 +462,22 @@ func TestMavenLock_WithParent(t *testing.T) {
 			Version:   "1.7.25",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 18, End: 22},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 20, End: 20},
-				Column:   models.Position{Start: 19, End: 32},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 21, End: 21},
-				Column:   models.Position{Start: 16, End: 22},
-				Filename: childPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 18, End: 22},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 20, End: 20},
+					Column:   models.Position{Start: 19, End: 32},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 21, End: 21},
+					Column:   models.Position{Start: 16, End: 22},
+					Filename: childPath,
+				},
 			},
 		},
 		{
@@ -461,20 +485,22 @@ func TestMavenLock_WithParent(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 23, End: 27},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 25, End: 25},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 23, End: 28},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 23, End: 27},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 25, End: 25},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 23, End: 28},
+					Filename: parentPath,
+				},
 			},
 		},
 		{
@@ -482,20 +508,22 @@ func TestMavenLock_WithParent(t *testing.T) {
 			Version:   "2.3.4",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 28, End: 32},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 30, End: 30},
-				Column:   models.Position{Start: 19, End: 29},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 25, End: 30},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 28, End: 32},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 30, End: 30},
+					Column:   models.Position{Start: 19, End: 29},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 25, End: 30},
+					Filename: parentPath,
+				},
 			},
 		},
 		{
@@ -503,20 +531,22 @@ func TestMavenLock_WithParent(t *testing.T) {
 			Version:   "1.0-SNAPSHOT",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 33, End: 37},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 35, End: 35},
-				Column:   models.Position{Start: 19, End: 22},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 12, End: 24},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 33, End: 37},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 35, End: 35},
+					Column:   models.Position{Start: 19, End: 22},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 12, End: 24},
+					Filename: parentPath,
+				},
 			},
 		},
 	})
@@ -542,20 +572,22 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			Version:   "3.0.2",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 25, End: 28},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: parentPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 27, End: 27},
-				Column:   models.Position{Start: 19, End: 25},
-				Filename: parentPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 19, End: 19},
-				Column:   models.Position{Start: 18, End: 23},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 25, End: 28},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: parentPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 27, End: 27},
+					Column:   models.Position{Start: 19, End: 25},
+					Filename: parentPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 19, End: 19},
+					Column:   models.Position{Start: 18, End: 23},
+					Filename: parentPath,
+				},
 			},
 		},
 		{
@@ -563,20 +595,22 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			Version:   "4.1.42.Final",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 14, End: 17},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 16, End: 16},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 14, End: 14},
-				Column:   models.Position{Start: 18, End: 30},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 14, End: 17},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 16, End: 16},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 14, End: 14},
+					Column:   models.Position{Start: 18, End: 30},
+					Filename: parentPath,
+				},
 			},
 		},
 		{
@@ -584,20 +618,22 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			Version:   "1.7.25",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 18, End: 22},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 20, End: 20},
-				Column:   models.Position{Start: 19, End: 32},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 21, End: 21},
-				Column:   models.Position{Start: 16, End: 22},
-				Filename: childPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 18, End: 22},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 20, End: 20},
+					Column:   models.Position{Start: 19, End: 32},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 21, End: 21},
+					Column:   models.Position{Start: 16, End: 22},
+					Filename: childPath,
+				},
 			},
 		},
 		{
@@ -605,20 +641,22 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 23, End: 27},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 25, End: 25},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 23, End: 28},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 23, End: 27},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 25, End: 25},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 23, End: 28},
+					Filename: parentPath,
+				},
 			},
 		},
 		{
@@ -626,20 +664,22 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 			Version:   "2.3.4",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 28, End: 32},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 30, End: 30},
-				Column:   models.Position{Start: 19, End: 29},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 25, End: 30},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 28, End: 32},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 30, End: 30},
+					Column:   models.Position{Start: 19, End: 29},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 25, End: 30},
+					Filename: parentPath,
+				},
 			},
 		},
 	})
@@ -665,20 +705,22 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			Version:   "3.0.2",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 25, End: 28},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: parentPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 27, End: 27},
-				Column:   models.Position{Start: 19, End: 25},
-				Filename: parentPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 19, End: 19},
-				Column:   models.Position{Start: 18, End: 23},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 25, End: 28},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: parentPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 27, End: 27},
+					Column:   models.Position{Start: 19, End: 25},
+					Filename: parentPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 19, End: 19},
+					Column:   models.Position{Start: 18, End: 23},
+					Filename: parentPath,
+				},
 			},
 		},
 		{
@@ -686,20 +728,22 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			Version:   "4.1.42.Final",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 16},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 15, End: 15},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 14, End: 14},
-				Column:   models.Position{Start: 18, End: 30},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 16},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 15, End: 15},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 14, End: 14},
+					Column:   models.Position{Start: 18, End: 30},
+					Filename: parentPath,
+				},
 			},
 		},
 		{
@@ -707,20 +751,22 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			Version:   "1.7.25",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 17, End: 21},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 19, End: 19},
-				Column:   models.Position{Start: 19, End: 32},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 20, End: 20},
-				Column:   models.Position{Start: 16, End: 22},
-				Filename: childPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 17, End: 21},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 19, End: 19},
+					Column:   models.Position{Start: 19, End: 32},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 20, End: 20},
+					Column:   models.Position{Start: 16, End: 22},
+					Filename: childPath,
+				},
 			},
 		},
 		{
@@ -728,20 +774,22 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 22, End: 26},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 24, End: 24},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 23, End: 28},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 22, End: 26},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 24, End: 24},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 23, End: 28},
+					Filename: parentPath,
+				},
 			},
 		},
 		{
@@ -749,20 +797,22 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 			Version:   "2.3.4",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 27, End: 31},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 29, End: 29},
-				Column:   models.Position{Start: 19, End: 29},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 25, End: 30},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 27, End: 31},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 29, End: 29},
+					Column:   models.Position{Start: 19, End: 29},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 25, End: 30},
+					Filename: parentPath,
+				},
 			},
 		},
 	})
@@ -788,20 +838,22 @@ func TestMavenLock_WithParent_Child_Project(t *testing.T) {
 			Version:   "1.0-CHILD-SNAPSHOT",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 11, End: 15},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: parentPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 19, End: 25},
-				Filename: parentPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 12, End: 30},
-				Filename: childPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 15},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: parentPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 19, End: 25},
+					Filename: parentPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 12, End: 30},
+					Filename: childPath,
+				},
 			},
 		},
 	})
@@ -828,20 +880,22 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			Version:   "3.0.2",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 26, End: 29},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: rootPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 28, End: 28},
-				Column:   models.Position{Start: 19, End: 25},
-				Filename: rootPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 20, End: 20},
-				Column:   models.Position{Start: 18, End: 23},
-				Filename: rootPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 26, End: 29},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: rootPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 28, End: 28},
+					Column:   models.Position{Start: 19, End: 25},
+					Filename: rootPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 20, End: 20},
+					Column:   models.Position{Start: 18, End: 23},
+					Filename: rootPath,
+				},
 			},
 		},
 		{
@@ -849,20 +903,22 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			Version:   "4.1.42.Final",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 14, End: 17},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: parentPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 16, End: 16},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: parentPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 15, End: 15},
-				Column:   models.Position{Start: 18, End: 30},
-				Filename: rootPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 14, End: 17},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: parentPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 16, End: 16},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: parentPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 15, End: 15},
+					Column:   models.Position{Start: 18, End: 30},
+					Filename: rootPath,
+				},
 			},
 		},
 		{
@@ -870,20 +926,22 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			Version:   "1.7.25",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 18, End: 22},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: parentPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 20, End: 20},
-				Column:   models.Position{Start: 19, End: 32},
-				Filename: parentPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 21, End: 21},
-				Column:   models.Position{Start: 16, End: 22},
-				Filename: parentPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 18, End: 22},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: parentPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 20, End: 20},
+					Column:   models.Position{Start: 19, End: 32},
+					Filename: parentPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 21, End: 21},
+					Column:   models.Position{Start: 16, End: 22},
+					Filename: parentPath,
+				},
 			},
 		},
 		{
@@ -891,20 +949,22 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 23, End: 27},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: parentPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 25, End: 25},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: parentPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 23, End: 28},
-				Filename: rootPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 23, End: 27},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: parentPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 25, End: 25},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: parentPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 23, End: 28},
+					Filename: rootPath,
+				},
 			},
 		},
 		{
@@ -912,20 +972,22 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			Version:   "9.4.35.v20201120",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 14, End: 18},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: childPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 16, End: 16},
-				Column:   models.Position{Start: 19, End: 29},
-				Filename: childPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 20, End: 42},
-				Filename: rootPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 14, End: 18},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: childPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 16, End: 16},
+					Column:   models.Position{Start: 19, End: 29},
+					Filename: childPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 20, End: 42},
+					Filename: rootPath,
+				},
 			},
 		},
 		{
@@ -933,20 +995,22 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 			Version:   "1.0-SNAPSHOT",
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 33, End: 37},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: parentPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 35, End: 35},
-				Column:   models.Position{Start: 19, End: 22},
-				Filename: parentPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 12, End: 24},
-				Filename: rootPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 33, End: 37},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: parentPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 35, End: 35},
+					Column:   models.Position{Start: 19, End: 22},
+					Filename: parentPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 12, End: 24},
+					Filename: rootPath,
+				},
 			},
 		},
 	})
@@ -1059,20 +1123,22 @@ func TestParseMavenLock_WithScope(t *testing.T) {
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 8},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 19, End: 24},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 16, End: 20},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 8},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 19, End: 24},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 16, End: 20},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"test"},
 		},
@@ -1099,20 +1165,22 @@ func TestParseMavenLock_WithUnusedDependencyManagementDependencies(t *testing.T)
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 17, End: 21},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 19, End: 19},
-				Column:   models.Position{Start: 19, End: 28},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 20, End: 20},
-				Column:   models.Position{Start: 16, End: 28},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 17, End: 21},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 19, End: 19},
+					Column:   models.Position{Start: 19, End: 28},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 20, End: 20},
+					Column:   models.Position{Start: 16, End: 28},
+					Filename: path,
+				},
 			},
 			DepGroups: nil,
 		},
@@ -1139,20 +1207,22 @@ func TestParseMavenLock_WithOverriddenDependencyVersions(t *testing.T) {
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 14, End: 18},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 16, End: 16},
-				Column:   models.Position{Start: 19, End: 24},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 17, End: 17},
-				Column:   models.Position{Start: 16, End: 20},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 14, End: 18},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 16, End: 16},
+					Column:   models.Position{Start: 19, End: 24},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 17, End: 17},
+					Column:   models.Position{Start: 16, End: 20},
+					Filename: path,
+				},
 			},
 			DepGroups: nil,
 		},
@@ -1179,20 +1249,22 @@ func TestParseMavenLock_WithProjectVersionProperty(t *testing.T) {
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 12},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 10, End: 10},
-				Column:   models.Position{Start: 19, End: 22},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 12, End: 24},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 12},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 10, End: 10},
+					Column:   models.Position{Start: 19, End: 22},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 12, End: 24},
+					Filename: path,
+				},
 			},
 			DepGroups: nil,
 		},
@@ -1202,20 +1274,22 @@ func TestParseMavenLock_WithProjectVersionProperty(t *testing.T) {
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 17},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 15, End: 15},
-				Column:   models.Position{Start: 19, End: 22},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 12, End: 24},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 17},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 15, End: 15},
+					Column:   models.Position{Start: 19, End: 22},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 12, End: 24},
+					Filename: path,
+				},
 			},
 			DepGroups: nil,
 		},
@@ -1238,20 +1312,22 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 27, End: 30},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 21, End: 30},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 20, End: 32},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 27, End: 30},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 21, End: 30},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 20, End: 32},
+					Filename: path,
+				},
 			},
 			DepGroups: nil,
 		},
@@ -1261,20 +1337,22 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 31, End: 35},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 24, End: 30},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 20, End: 42},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 31, End: 35},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 24, End: 30},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 20, End: 42},
+					Filename: path,
+				},
 			},
 			DepGroups: nil,
 		},
@@ -1284,20 +1362,22 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 			Ecosystem: lockfile.MavenEcosystem,
 			CompareAs: lockfile.MavenEcosystem,
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 36, End: 40},
-				Column:   models.Position{Start: 5, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 38, End: 38},
-				Column:   models.Position{Start: 19, End: 35},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 20, End: 42},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 36, End: 40},
+					Column:   models.Position{Start: 5, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 38, End: 38},
+					Column:   models.Position{Start: 19, End: 35},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 20, End: 42},
+					Filename: path,
+				},
 			},
 			DepGroups: nil,
 		},

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -58,11 +58,12 @@ func TestParseNpmLock_v1_OnePackage(t *testing.T) {
 		{
 			Name:    "wrappy",
 			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 9},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 9},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -86,11 +87,12 @@ func TestParseNpmLock_v1_OnePackageDev(t *testing.T) {
 		{
 			Name:    "wrappy",
 			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 10},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 10},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev"},
@@ -115,22 +117,24 @@ func TestParseNpmLock_v1_TwoPackages(t *testing.T) {
 		{
 			Name:    "wrappy",
 			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 9},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 9},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:    "supports-color",
 			Version: "5.5.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 17},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 17},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -154,22 +158,24 @@ func TestParseNpmLock_v1_ScopedPackages(t *testing.T) {
 		{
 			Name:    "wrappy",
 			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 17},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 17},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:    "@babel/code-frame",
 			Version: "7.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 12},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 12},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -193,55 +199,60 @@ func TestParseNpmLock_v1_NestedDependencies(t *testing.T) {
 		{
 			Name:    "postcss",
 			Version: "6.0.23",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 14},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 14},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:    "postcss",
 			Version: "7.0.16",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 26, End: 35},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 26, End: 35},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:    "postcss-calc",
 			Version: "7.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 15, End: 45},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 15, End: 45},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:    "supports-color",
 			Version: "6.1.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 36, End: 43},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 36, End: 43},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:    "supports-color",
 			Version: "5.5.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 46, End: 53},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 46, End: 53},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -269,10 +280,12 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 	expectPackage(t, packages, lockfile.PackageDetails{
 		Name:    "supports-color",
 		Version: "6.1.0",
-		BlockLocation: models.FilePosition{
-			Line:     models.Position{Start: 749, End: 756},
-			Column:   models.Position{Start: 9, End: 10},
-			Filename: path,
+		LockfileLocations: lockfile.Locations{
+			Block: models.FilePosition{
+				Line:     models.Position{Start: 749, End: 756},
+				Column:   models.Position{Start: 9, End: 10},
+				Filename: path,
+			},
 		},
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
@@ -281,10 +294,12 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 	expectPackage(t, packages, lockfile.PackageDetails{
 		Name:    "supports-color",
 		Version: "5.5.0",
-		BlockLocation: models.FilePosition{
-			Line:     models.Position{Start: 759, End: 766},
-			Column:   models.Position{Start: 5, End: 6},
-			Filename: path,
+		LockfileLocations: lockfile.Locations{
+			Block: models.FilePosition{
+				Line:     models.Position{Start: 759, End: 766},
+				Column:   models.Position{Start: 5, End: 6},
+				Filename: path,
+			},
 		},
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
@@ -293,10 +308,12 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 	expectPackage(t, packages, lockfile.PackageDetails{
 		Name:    "supports-color",
 		Version: "2.0.0",
-		BlockLocation: models.FilePosition{
-			Line:     models.Position{Start: 186, End: 190},
-			Column:   models.Position{Start: 9, End: 10},
-			Filename: path,
+		LockfileLocations: lockfile.Locations{
+			Block: models.FilePosition{
+				Line:     models.Position{Start: 186, End: 190},
+				Column:   models.Position{Start: 9, End: 10},
+				Filename: path,
+			},
 		},
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
@@ -320,11 +337,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "@segment/analytics.js-integration-facebook-pixel",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 18},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 18},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "3b1bb80b302c2e552685dc8a029797ec832ea7c9",
@@ -332,11 +350,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "ansi-styles",
 			Version: "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 19, End: 23},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 19, End: 23},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -344,11 +363,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "babel-preset-php",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 24, End: 30},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 24, End: 30},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
@@ -356,11 +376,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "is-number-1",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 31, End: 37},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 31, End: 37},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -369,11 +390,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "is-number-1",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 75, End: 81},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 75, End: 81},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
@@ -382,11 +404,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "is-number-2",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 38, End: 41},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 38, End: 41},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
@@ -394,11 +417,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "is-number-2",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 82, End: 85},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 82, End: 85},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82dcc8e914dabd9305ab9ae580709a7825e824f5",
@@ -406,11 +430,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "is-number-3",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 42, End: 46},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 42, End: 46},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
@@ -419,11 +444,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "is-number-3",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 86, End: 90},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 86, End: 90},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
@@ -432,11 +458,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "is-number-4",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 47, End: 54},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 47, End: 54},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -445,11 +472,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "is-number-5",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 55, End: 62},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 55, End: 62},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -458,11 +486,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "is-number-6",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 63, End: 69},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 63, End: 69},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
@@ -471,11 +500,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "postcss-calc",
 			Version: "7.0.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 70, End: 92},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 70, End: 92},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -483,11 +513,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "raven-js",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 93, End: 96},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 93, End: 96},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c2b377e7a254264fd4a1fe328e4e3cfc9e245570",
@@ -495,11 +526,12 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 		{
 			Name:    "slick-carousel",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 97, End: 101},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 97, End: 101},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "280b560161b751ba226d50c7db1e0a14a78c2de0",
@@ -525,11 +557,12 @@ func TestParseNpmLock_v1_Files(t *testing.T) {
 		{
 			Name:    "lodash",
 			Version: "1.3.1",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 9},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 9},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -537,11 +570,12 @@ func TestParseNpmLock_v1_Files(t *testing.T) {
 		{
 			Name:    "other_package",
 			Version: "",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 15},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 15},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
@@ -566,33 +600,36 @@ func TestParseNpmLock_v1_Alias(t *testing.T) {
 		{
 			Name:    "@babel/code-frame",
 			Version: "7.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 12},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 12},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:    "string-width",
 			Version: "4.2.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 23, End: 32},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 23, End: 32},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
 		{
 			Name:    "string-width",
 			Version: "5.1.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 22},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 22},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 		},
@@ -616,11 +653,12 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 		{
 			Name:    "wrappy",
 			Version: "1.0.2",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 11},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 11},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev", "optional"},
@@ -628,11 +666,12 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 		{
 			Name:    "supports-color",
 			Version: "5.5.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 20},
-				Column:   models.Position{Start: 5, End: 6},
-				Filename: path,
-			},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 12, End: 20},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				}},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"optional"},

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -3,6 +3,7 @@ package lockfile_test
 import (
 	"bytes"
 	"errors"
+	"github.com/google/osv-scanner/pkg/models"
 	"io"
 	"io/fs"
 	"os"
@@ -25,7 +26,7 @@ func TestParseNpmLock_v2_FileDoesNotExist(t *testing.T) {
 	packages, err := lockfile.ParseNpmLock(path)
 
 	expectErrIs(t, err, fs.ErrNotExist)
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
+	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseNpmLock_v2_InvalidJson(t *testing.T) {
@@ -39,7 +40,7 @@ func TestParseNpmLock_v2_InvalidJson(t *testing.T) {
 	packages, err := lockfile.ParseNpmLock(path)
 
 	expectErrContaining(t, err, "could not extract from")
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
+	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseNpmLock_v2_NoPackages(t *testing.T) {
@@ -55,7 +56,7 @@ func TestParseNpmLock_v2_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
+	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseNpmLock_v2_OnePackage(t *testing.T) {
@@ -71,13 +72,20 @@ func TestParseNpmLock_v2_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 14},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -117,13 +125,20 @@ func TestParseNpmLock_v2_OnePackage_MatcherFailed(t *testing.T) {
 	_ = r.Close()
 
 	assert.Contains(t, buffer.String(), matcherError.Error())
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 14},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 	})
 
@@ -144,14 +159,21 @@ func TestParseNpmLock_v2_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			DepGroups:      []string{"dev"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 15},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"dev"},
 		},
 	})
 }
@@ -169,14 +191,21 @@ func TestParseNpmLock_v2_LinkDependency(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			DepGroups:      []string{"dev"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 15},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"dev"},
 		},
 	})
 }
@@ -194,13 +223,20 @@ func TestParseNpmLock_v2_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 17},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "supports-color",
@@ -208,6 +244,13 @@ func TestParseNpmLock_v2_TwoPackages(t *testing.T) {
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 18, End: 28},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -225,18 +268,32 @@ func TestParseNpmLock_v2_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "wrappy",
 			Version:   "1.0.2",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 18, End: 22},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@babel/code-frame",
 			Version:   "7.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 17},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -254,36 +311,71 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "postcss",
 			Version:   "6.0.23",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 22},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "postcss",
 			Version:   "7.0.16",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 34, End: 46},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "postcss-calc",
 			Version:   "7.0.1",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 23, End: 33},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "supports-color",
 			Version:   "6.1.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 47, End: 57},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "supports-color",
 			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 58, End: 68},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -301,18 +393,32 @@ func TestParseNpmLock_v2_NestedDependenciesDup(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "supports-color",
 			Version:   "6.1.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 20},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "supports-color",
 			Version:   "2.0.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 32, End: 39},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -330,7 +436,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@segment/analytics.js-integration-facebook-pixel",
 			Version:        "2.4.1",
@@ -338,6 +444,13 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "3b1bb80b302c2e552685dc8a029797ec832ea7c9",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 26, End: 41},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "ansi-styles",
@@ -345,6 +458,13 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 42, End: 49},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "babel-preset-php",
@@ -353,7 +473,14 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
-			DepGroups:      []string{"dev"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 50, End: 59},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"dev"},
 		},
 		{
 			Name:           "is-number-1",
@@ -362,7 +489,14 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
-			DepGroups:      []string{"dev"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 60, End: 72},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"dev"},
 		},
 		{
 			Name:      "is-number-1",
@@ -370,6 +504,13 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 130, End: 142},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 			DepGroups: []string{"dev"},
 		},
 		{
@@ -379,7 +520,14 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
-			DepGroups:      []string{"dev"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 73, End: 82},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"dev"},
 		},
 		{
 			Name:      "is-number-2",
@@ -387,6 +535,13 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82dcc8e914dabd9305ab9ae580709a7825e824f5",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 143, End: 152},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 			DepGroups: []string{"dev"},
 		},
 		{
@@ -396,7 +551,14 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
-			DepGroups:      []string{"dev"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 83, End: 92},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"dev"},
 		},
 		{
 			Name:      "is-number-3",
@@ -404,6 +566,13 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 153, End: 162},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 			DepGroups: []string{"dev"},
 		},
 		{
@@ -413,7 +582,14 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
-			DepGroups:      []string{"dev"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 93, End: 105},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"dev"},
 		},
 		{
 			Name:           "is-number-5",
@@ -422,7 +598,14 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
-			DepGroups:      []string{"dev"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 106, End: 118},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"dev"},
 		},
 		{
 			Name:      "postcss-calc",
@@ -430,6 +613,13 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 119, End: 129},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "raven-js",
@@ -438,6 +628,13 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "c2b377e7a254264fd4a1fe328e4e3cfc9e245570",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 163, End: 165},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "slick-carousel",
@@ -446,7 +643,14 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "280b560161b751ba226d50c7db1e0a14a78c2de0",
-			DepGroups:      []string{"dev"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 166, End: 175},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"dev"},
 		},
 	})
 }
@@ -464,7 +668,7 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "etag",
 			Version:        "1.8.0",
@@ -472,7 +676,14 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
-			DepGroups:      []string{"dev"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 16, End: 35},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"dev"},
 		},
 		{
 			Name:      "abbrev",
@@ -480,6 +691,13 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 36, End: 41},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 			DepGroups: []string{"dev"},
 		},
 		{
@@ -488,6 +706,13 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 42, End: 47},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 			DepGroups: []string{"dev"},
 		},
 	})
@@ -506,13 +731,20 @@ func TestParseNpmLock_v2_Alias(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@babel/code-frame",
 			Version:        "7.0.0",
 			TargetVersions: []string{"^7.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 21},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "string-width",
@@ -520,6 +752,13 @@ func TestParseNpmLock_v2_Alias(t *testing.T) {
 			TargetVersions: []string{"^4.2.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 32, End: 42},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "string-width",
@@ -527,6 +766,13 @@ func TestParseNpmLock_v2_Alias(t *testing.T) {
 			TargetVersions: []string{"^5.1.2"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 22, End: 31},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -544,20 +790,34 @@ func TestParseNpmLock_v2_OptionalPackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "wrappy",
 			Version:        "1.0.2",
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			DepGroups:      []string{"optional"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 15},
+					Column:   models.Position{Start: 5, End: 6},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"optional"},
 		},
 		{
 			Name:      "supports-color",
 			Version:   "5.5.0",
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 16, End: 27},
+					Column:   models.Position{Start: 6, End: 6},
+					Filename: path,
+				},
+			},
 			DepGroups: []string{"dev", "optional"},
 		},
 	})

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -131,10 +131,12 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency, path s
 			Version:   finalVersion,
 			Ecosystem: NpmEcosystem,
 			CompareAs: NpmEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     detail.Line,
-				Column:   detail.Column,
-				Filename: path,
+			LockfileLocations: Locations{
+				Block: models.FilePosition{
+					Line:     detail.Line,
+					Column:   detail.Column,
+					Filename: path,
+				},
 			},
 			Commit:    commit,
 			DepGroups: detail.depGroups(),
@@ -248,10 +250,12 @@ func parseNpmLockPackages(packages map[string]*NpmLockPackage, path string) map[
 				TargetVersions: targetVersions,
 				Ecosystem:      NpmEcosystem,
 				CompareAs:      NpmEcosystem,
-				BlockLocation: models.FilePosition{
-					Line:     detail.Line,
-					Column:   detail.Column,
-					Filename: path,
+				LockfileLocations: Locations{
+					Block: models.FilePosition{
+						Line:     detail.Line,
+						Column:   detail.Column,
+						Filename: path,
+					},
 				},
 				Commit:    commit,
 				DepGroups: detail.depGroups(),

--- a/pkg/lockfile/parse-pipenv-lock.go
+++ b/pkg/lockfile/parse-pipenv-lock.go
@@ -101,13 +101,15 @@ func addPkgDetails(details map[string]PackageDetails, packages map[string]*Pipen
 
 		if _, ok := details[name+"@"+version]; !ok {
 			pkgDetails := PackageDetails{
-				Name:            name,
-				Version:         version,
-				Ecosystem:       PipenvEcosystem,
-				CompareAs:       PipenvEcosystem,
-				BlockLocation:   blockLocation,
-				NameLocation:    pipenvPackage.NamePosition,
-				VersionLocation: pipenvPackage.VersionPosition,
+				Name:      name,
+				Version:   version,
+				Ecosystem: PipenvEcosystem,
+				CompareAs: PipenvEcosystem,
+				LockfileLocations: Locations{
+					Block:   blockLocation,
+					Name:    pipenvPackage.NamePosition,
+					Version: pipenvPackage.VersionPosition,
+				},
 			}
 			if group != "" {
 				pkgDetails.DepGroups = append(pkgDetails.DepGroups, group)

--- a/pkg/lockfile/parse-pipenv-lock_test.go
+++ b/pkg/lockfile/parse-pipenv-lock_test.go
@@ -112,20 +112,22 @@ func TestParsePipenvLock_OnePackage(t *testing.T) {
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 19, End: 64},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 19, End: 19},
-				Column:   models.Position{Start: 10, End: 20},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 63, End: 63},
-				Column:   models.Position{Start: 25, End: 32},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 19, End: 64},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 19, End: 19},
+					Column:   models.Position{Start: 10, End: 20},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 63, End: 63},
+					Column:   models.Position{Start: 25, End: 32},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -150,20 +152,22 @@ func TestParsePipenvLock_OnePackageDev(t *testing.T) {
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 20, End: 65},
-				Column:   models.Position{Start: 9, End: 10},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 20, End: 20},
-				Column:   models.Position{Start: 10, End: 20},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 64, End: 64},
-				Column:   models.Position{Start: 25, End: 32},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 20, End: 65},
+					Column:   models.Position{Start: 9, End: 10},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 20, End: 20},
+					Column:   models.Position{Start: 10, End: 20},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 64, End: 64},
+					Column:   models.Position{Start: 25, End: 32},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -189,20 +193,22 @@ func TestParsePipenvLock_TwoPackages(t *testing.T) {
 			Version:   "2.1.2",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 19, End: 26},
-				Column:   models.Position{Start: 7, End: 8},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 19, End: 19},
-				Column:   models.Position{Start: 8, End: 20},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 25, End: 25},
-				Column:   models.Position{Start: 23, End: 30},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 19, End: 26},
+					Column:   models.Position{Start: 7, End: 8},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 19, End: 19},
+					Column:   models.Position{Start: 8, End: 20},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 25, End: 25},
+					Column:   models.Position{Start: 23, End: 30},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -210,20 +216,22 @@ func TestParsePipenvLock_TwoPackages(t *testing.T) {
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 29, End: 74},
-				Column:   models.Position{Start: 7, End: 8},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 29, End: 29},
-				Column:   models.Position{Start: 8, End: 18},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 73, End: 73},
-				Column:   models.Position{Start: 23, End: 30},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 29, End: 74},
+					Column:   models.Position{Start: 7, End: 8},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 29, End: 29},
+					Column:   models.Position{Start: 8, End: 18},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 73, End: 73},
+					Column:   models.Position{Start: 23, End: 30},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -249,20 +257,22 @@ func TestParsePipenvLock_TwoPackagesAlt(t *testing.T) {
 			Version:   "2.1.2",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 19, End: 26},
-				Column:   models.Position{Start: 7, End: 8},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 19, End: 19},
-				Column:   models.Position{Start: 8, End: 20},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 25, End: 25},
-				Column:   models.Position{Start: 23, End: 30},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 19, End: 26},
+					Column:   models.Position{Start: 7, End: 8},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 19, End: 19},
+					Column:   models.Position{Start: 8, End: 20},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 25, End: 25},
+					Column:   models.Position{Start: 23, End: 30},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -270,20 +280,22 @@ func TestParsePipenvLock_TwoPackagesAlt(t *testing.T) {
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 27, End: 72},
-				Column:   models.Position{Start: 7, End: 8},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 27, End: 27},
-				Column:   models.Position{Start: 8, End: 18},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 71, End: 71},
-				Column:   models.Position{Start: 23, End: 30},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 27, End: 72},
+					Column:   models.Position{Start: 7, End: 8},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 27, End: 27},
+					Column:   models.Position{Start: 8, End: 18},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 71, End: 71},
+					Column:   models.Position{Start: 23, End: 30},
+					Filename: path,
+				},
 			},
 		},
 	})
@@ -308,20 +320,22 @@ func TestParsePipenvLock_MultiplePackages(t *testing.T) {
 			Version:   "2.1.2",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 19, End: 26},
-				Column:   models.Position{Start: 7, End: 8},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 19, End: 19},
-				Column:   models.Position{Start: 8, End: 20},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 25, End: 25},
-				Column:   models.Position{Start: 23, End: 30},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 19, End: 26},
+					Column:   models.Position{Start: 7, End: 8},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 19, End: 19},
+					Column:   models.Position{Start: 8, End: 20},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 25, End: 25},
+					Column:   models.Position{Start: 23, End: 30},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -329,20 +343,22 @@ func TestParsePipenvLock_MultiplePackages(t *testing.T) {
 			Version:   "1.0.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 27, End: 31},
-				Column:   models.Position{Start: 7, End: 8},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 27, End: 27},
-				Column:   models.Position{Start: 8, End: 14},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 30, End: 30},
-				Column:   models.Position{Start: 23, End: 30},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 27, End: 31},
+					Column:   models.Position{Start: 7, End: 8},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 27, End: 27},
+					Column:   models.Position{Start: 8, End: 14},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 30, End: 30},
+					Column:   models.Position{Start: 23, End: 30},
+					Filename: path,
+				},
 			},
 		},
 		{
@@ -350,20 +366,22 @@ func TestParsePipenvLock_MultiplePackages(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 88, End: 95},
-				Column:   models.Position{Start: 7, End: 8},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 88, End: 88},
-				Column:   models.Position{Start: 8, End: 14},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 94, End: 94},
-				Column:   models.Position{Start: 23, End: 30},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 88, End: 95},
+					Column:   models.Position{Start: 7, End: 8},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 88, End: 88},
+					Column:   models.Position{Start: 8, End: 14},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 94, End: 94},
+					Column:   models.Position{Start: 23, End: 30},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"dev"},
 		},
@@ -372,20 +390,22 @@ func TestParsePipenvLock_MultiplePackages(t *testing.T) {
 			Version:   "2.1.1",
 			Ecosystem: lockfile.PipenvEcosystem,
 			CompareAs: lockfile.PipenvEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 32, End: 77},
-				Column:   models.Position{Start: 7, End: 8},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 32, End: 32},
-				Column:   models.Position{Start: 8, End: 18},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 76, End: 76},
-				Column:   models.Position{Start: 23, End: 30},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 32, End: 77},
+					Column:   models.Position{Start: 7, End: 8},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 32, End: 32},
+					Column:   models.Position{Start: 8, End: 18},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 76, End: 76},
+					Column:   models.Position{Start: 23, End: 30},
+					Filename: path,
+				},
 			},
 		},
 	})

--- a/pkg/lockfile/parse-pnpm-lock-v9_test.go
+++ b/pkg/lockfile/parse-pnpm-lock-v9_test.go
@@ -1,6 +1,9 @@
 package lockfile_test
 
 import (
+	"github.com/google/osv-scanner/pkg/models"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/osv-scanner/pkg/lockfile"
@@ -20,111 +23,180 @@ func TestParsePnpmLock_v9_NoPackages(t *testing.T) {
 
 func TestParsePnpmLock_v9_OnePackage(t *testing.T) {
 	t.Parallel()
-
-	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/one-package.v9.yaml")
-
+	dir, err := os.Getwd()
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	path := filepath.FromSlash(filepath.Join(dir, "fixtures/pnpm/one-package.v9.yaml"))
+	packages, err := lockfile.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "acorn",
 			Version:        "8.11.3",
 			TargetVersions: []string{"^8.11.3"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 17, End: 20},
+					Column:   models.Position{Start: 3, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
 
 func TestParsePnpmLock_v9_OnePackageDev(t *testing.T) {
 	t.Parallel()
-
-	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/one-package-dev.v9.yaml")
-
+	dir, err := os.Getwd()
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	path := filepath.FromSlash(filepath.Join(dir, "fixtures/pnpm/one-package-dev.v9.yaml"))
+	packages, err := lockfile.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "acorn",
 			Version:        "8.11.3",
 			TargetVersions: []string{"^8.11.3"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 17, End: 20},
+					Column:   models.Position{Start: 3, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
 
 func TestParsePnpmLock_v9_ScopedPackages(t *testing.T) {
 	t.Parallel()
-
-	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/scoped-packages.v9.yaml")
-
+	dir, err := os.Getwd()
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	path := filepath.FromSlash(filepath.Join(dir, "fixtures/pnpm/scoped-packages.v9.yaml"))
+	packages, err := lockfile.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@typescript-eslint/types",
 			Version:        "5.62.0",
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 17, End: 19},
+					Column:   models.Position{Start: 3, End: 54},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
 
 func TestParsePnpmLock_v9_PeerDependencies(t *testing.T) {
 	t.Parallel()
-
-	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/peer-dependencies.v9.yaml")
-
+	dir, err := os.Getwd()
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	path := filepath.FromSlash(filepath.Join(dir, "fixtures/pnpm/peer-dependencies.v9.yaml"))
+	packages, err := lockfile.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "acorn-jsx",
 			Version:        "5.3.2",
 			TargetVersions: []string{"^5.3.2"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 17, End: 20},
+					Column:   models.Position{Start: 3, End: 40},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "acorn",
 			Version:   "8.11.3",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 22, End: 25},
+					Column:   models.Position{Start: 3, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
 
 func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 	t.Parallel()
-
-	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/peer-dependencies-advanced.v9.yaml")
-
+	dir, err := os.Getwd()
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	path := filepath.FromSlash(filepath.Join(dir, "fixtures/pnpm/peer-dependencies-advanced.v9.yaml"))
+	packages, err := lockfile.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "@eslint-community/eslint-utils",
 			Version:   "4.4.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 26, End: 30},
+					Column:   models.Position{Start: 3, End: 42},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@eslint/eslintrc",
 			Version:   "2.1.4",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 32, End: 34},
+					Column:   models.Position{Start: 3, End: 54},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "@typescript-eslint/eslint-plugin",
@@ -132,6 +204,13 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^5.12.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 36, End: 45},
+					Column:   models.Position{Start: 3, End: 23},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "@typescript-eslint/parser",
@@ -139,30 +218,65 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^5.12.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 47, End: 55},
+					Column:   models.Position{Start: 3, End: 23},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@typescript-eslint/type-utils",
 			Version:   "5.62.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 57, End: 65},
+					Column:   models.Position{Start: 3, End: 23},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@typescript-eslint/typescript-estree",
 			Version:   "5.62.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 67, End: 74},
+					Column:   models.Position{Start: 3, End: 23},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@typescript-eslint/utils",
 			Version:   "5.62.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 76, End: 80},
+					Column:   models.Position{Start: 3, End: 41},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "debug",
 			Version:   "4.3.4",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 82, End: 89},
+					Column:   models.Position{Start: 3, End: 23},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "eslint",
@@ -170,24 +284,52 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^8.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 91, End: 94},
+					Column:   models.Position{Start: 3, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "has-flag",
 			Version:   "4.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 96, End: 98},
+					Column:   models.Position{Start: 3, End: 27},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "supports-color",
 			Version:   "7.2.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 100, End: 102},
+					Column:   models.Position{Start: 3, End: 27},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "tsutils",
 			Version:   "3.21.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 104, End: 108},
+					Column:   models.Position{Start: 3, End: 158},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "typescript",
@@ -195,25 +337,43 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^4.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 110, End: 113},
+					Column:   models.Position{Start: 3, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
 
 func TestParsePnpmLock_v9_MultipleVersions(t *testing.T) {
 	t.Parallel()
-
-	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/multiple-versions.v9.yaml")
-
+	dir, err := os.Getwd()
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	path := filepath.FromSlash(filepath.Join(dir, "fixtures/pnpm/multiple-versions.v9.yaml"))
+	packages, err := lockfile.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "uuid",
 			Version:   "8.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 20, End: 22},
+					Column:   models.Position{Start: 3, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "uuid",
@@ -221,26 +381,44 @@ func TestParsePnpmLock_v9_MultipleVersions(t *testing.T) {
 			TargetVersions: []string{"^8.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 24, End: 26},
+					Column:   models.Position{Start: 3, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "xmlbuilder",
 			Version:   "11.0.1",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 28, End: 30},
+					Column:   models.Position{Start: 3, End: 29},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
 
 func TestParsePnpmLock_v9_Commits(t *testing.T) {
 	t.Parallel()
-
-	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/commits.v9.yaml")
-
+	dir, err := os.Getwd()
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	path := filepath.FromSlash(filepath.Join(dir, "fixtures/pnpm/commits.v9.yaml"))
+	packages, err := lockfile.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ansi-regex",
 			Version:        "6.0.1",
@@ -248,6 +426,13 @@ func TestParsePnpmLock_v9_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "02fa893d619d3da85411acc8fd4e2eea0e95a9d9",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 20, End: 23},
+					Column:   models.Position{Start: 3, End: 28},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "is-number",
@@ -256,26 +441,44 @@ func TestParsePnpmLock_v9_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "98e8ff1da1a89f93d1397a24d7413ed15421c139",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 25, End: 28},
+					Column:   models.Position{Start: 3, End: 32},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
 
 func TestParsePnpmLock_v9_MixedGroups(t *testing.T) {
 	t.Parallel()
-
-	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/mixed-groups.v9.yaml")
-
+	dir, err := os.Getwd()
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	path := filepath.FromSlash(filepath.Join(dir, "fixtures/pnpm/mixed-groups.v9.yaml"))
+	packages, err := lockfile.ParsePnpmLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "ansi-regex",
 			Version:        "5.0.1",
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 25, End: 27},
+					Column:   models.Position{Start: 3, End: 27},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "uuid",
@@ -283,6 +486,13 @@ func TestParsePnpmLock_v9_MixedGroups(t *testing.T) {
 			TargetVersions: []string{"^8.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 33, End: 35},
+					Column:   models.Position{Start: 3, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "is-number",
@@ -290,6 +500,13 @@ func TestParsePnpmLock_v9_MixedGroups(t *testing.T) {
 			TargetVersions: []string{"^7.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 29, End: 31},
+					Column:   models.Position{Start: 3, End: 32},
+					Filename: path,
+				},
+			},
 		},
 	})
 }

--- a/pkg/lockfile/parse-pnpm-lock_test.go
+++ b/pkg/lockfile/parse-pnpm-lock_test.go
@@ -3,6 +3,7 @@ package lockfile_test
 import (
 	"bytes"
 	"errors"
+	"github.com/google/osv-scanner/pkg/models"
 	"io"
 	"io/fs"
 	"os"
@@ -72,7 +73,7 @@ func TestParsePnpmLock_FileDoesNotExist(t *testing.T) {
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/does-not-exist")
 
 	expectErrIs(t, err, fs.ErrNotExist)
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
+	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParsePnpmLock_InvalidYaml(t *testing.T) {
@@ -81,7 +82,7 @@ func TestParsePnpmLock_InvalidYaml(t *testing.T) {
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/not-yaml.txt")
 
 	expectErrContaining(t, err, "could not extract from")
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
+	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParsePnpmLock_Empty(t *testing.T) {
@@ -93,7 +94,7 @@ func TestParsePnpmLock_Empty(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
+	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParsePnpmLock_NoPackages(t *testing.T) {
@@ -105,7 +106,7 @@ func TestParsePnpmLock_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
+	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParsePnpmLock_OnePackage(t *testing.T) {
@@ -121,13 +122,20 @@ func TestParsePnpmLock_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "acorn",
 			Version:        "8.7.0",
 			TargetVersions: []string{"^8.7.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 15},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -167,13 +175,20 @@ func TestParsePnpmLock_OnePackage_MatcherFailed(t *testing.T) {
 	_ = r.Close()
 
 	assert.Contains(t, buffer.String(), matcherError.Error())
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "acorn",
 			Version:        "8.7.0",
 			TargetVersions: []string{"^8.7.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 15},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 	})
 
@@ -194,13 +209,20 @@ func TestParsePnpmLock_OnePackageV6Lockfile(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "acorn",
 			Version:        "8.7.0",
 			TargetVersions: []string{"8.7.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 14},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -218,13 +240,20 @@ func TestParsePnpmLock_OnePackageDev(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "acorn",
 			Version:        "8.7.0",
 			TargetVersions: []string{"^8.7.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 15},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -242,13 +271,20 @@ func TestParsePnpmLock_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@typescript-eslint/types",
 			Version:        "5.13.0",
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 14},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -266,13 +302,20 @@ func TestParsePnpmLock_ScopedPackagesV6Lockfile(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@typescript-eslint/types",
 			Version:        "5.57.1",
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 13},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -290,13 +333,20 @@ func TestParsePnpmLock_PeerDependencies(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "acorn-jsx",
 			Version:        "5.3.2",
 			TargetVersions: []string{"^5.3.2"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 19},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "acorn",
@@ -304,6 +354,13 @@ func TestParsePnpmLock_PeerDependencies(t *testing.T) {
 			TargetVersions: []string{"^8.7.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 21, End: 25},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -321,13 +378,20 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@typescript-eslint/eslint-plugin",
 			Version:        "5.13.0",
 			TargetVersions: []string{"^5.12.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 17, End: 42},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "@typescript-eslint/parser",
@@ -335,36 +399,78 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^5.12.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 44, End: 62},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@typescript-eslint/type-utils",
 			Version:   "5.13.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 64, End: 81},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@typescript-eslint/types",
 			Version:   "5.13.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 83, End: 86},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@typescript-eslint/typescript-estree",
 			Version:   "5.13.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 88, End: 107},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@typescript-eslint/utils",
 			Version:   "5.13.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 109, End: 125},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "eslint-utils",
 			Version:   "3.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 127, End: 135},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "eslint",
@@ -372,12 +478,26 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^8.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 137, End: 179},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "tsutils",
 			Version:   "3.21.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 181, End: 189},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -395,91 +515,189 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "aws-sdk",
 			Version:        "2.1087.0",
 			TargetVersions: []string{"^2.1087.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 24},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "base64-js",
 			Version:   "1.5.1",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 26, End: 28},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "buffer",
 			Version:   "4.9.2",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 30, End: 36},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "events",
 			Version:   "1.1.1",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 38, End: 41},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "ieee754",
 			Version:   "1.1.13",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 43, End: 45},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "isarray",
 			Version:   "1.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 47, End: 49},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "jmespath",
 			Version:   "0.16.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 51, End: 54},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "punycode",
 			Version:   "1.3.2",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 56, End: 58},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "querystring",
 			Version:   "0.2.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 60, End: 64},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "sax",
 			Version:   "1.2.1",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 66, End: 68},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "url",
 			Version:   "0.10.3",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 70, End: 75},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "uuid",
 			Version:   "3.3.2",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 77, End: 81},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "xml2js",
 			Version:   "0.4.19",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 83, End: 88},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "xmlbuilder",
 			Version:   "9.0.7",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 90, End: 93},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -497,12 +715,19 @@ func TestParsePnpmLock_MultipleVersions(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "uuid",
 			Version:   "3.3.2",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 17},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "uuid",
@@ -510,12 +735,26 @@ func TestParsePnpmLock_MultipleVersions(t *testing.T) {
 			TargetVersions: []string{"^8.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 19, End: 22},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "xmlbuilder",
 			Version:   "9.0.7",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 24, End: 27},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -533,7 +772,7 @@ func TestParsePnpmLock_Tarball(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@my-org/my-package",
 			Version:        "3.2.3",
@@ -541,7 +780,14 @@ func TestParsePnpmLock_Tarball(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "",
-			DepGroups:      []string{"dev"},
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 14},
+					Column:   models.Position{Start: 3, End: 14},
+					Filename: path,
+				},
+			},
+			DepGroups: []string{"dev"},
 		},
 	})
 }
@@ -559,48 +805,97 @@ func TestParsePnpmLock_Exotic(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:      "foo",
 			Version:   "1.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 10},
+					Column:   models.Position{Start: 3, End: 14},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@foo/bar",
 			Version:   "1.0.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 11},
+					Column:   models.Position{Start: 3, End: 19},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "foo",
 			Version:   "1.1.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 3, End: 32},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@foo/bar",
 			Version:   "1.1.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 3, End: 37},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "foo",
 			Version:   "1.2.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 15, End: 15},
+					Column:   models.Position{Start: 3, End: 25},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "foo",
 			Version:   "1.3.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 16, End: 16},
+					Column:   models.Position{Start: 3, End: 35},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "foo",
 			Version:   "1.4.0",
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 17, End: 17},
+					Column:   models.Position{Start: 3, End: 40},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -618,7 +913,7 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "my-bitbucket-package",
 			Version:        "1.0.0",
@@ -626,6 +921,13 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "6104ae42cd32c3d724036d3964678f197b2c9cdb",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 14, End: 18},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "@my-scope/my-package",
@@ -634,6 +936,13 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "267087851ad5fac92a184749c27cd539e2fc862e",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 20, End: 26},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "@my-scope/my-other-package",
@@ -641,6 +950,13 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 			Commit:    "fbfc962ab51eb1d754749b68c064460221fbd689",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 28, End: 32},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "faker-parser",
@@ -648,6 +964,13 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 			Ecosystem: lockfile.PnpmEcosystem,
 			CompareAs: lockfile.PnpmEcosystem,
 			Commit:    "d2dc42a9351d4d89ec48c525e34f612b6d77993f",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 34, End: 40},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "mocks",
@@ -656,6 +979,13 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "590f321b4eb3f692bb211bd74e22947639a6f79d",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 42, End: 48},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -673,7 +1003,7 @@ func TestParsePnpmLock_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "my-file-package",
 			Version:        "0.0.0",
@@ -681,6 +1011,13 @@ func TestParsePnpmLock_Files(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 14},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "a-local-package",
@@ -688,6 +1025,13 @@ func TestParsePnpmLock_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 16, End: 20},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "a-nested-local-package",
@@ -695,6 +1039,13 @@ func TestParsePnpmLock_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 22, End: 26},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "one-up",
@@ -702,6 +1053,13 @@ func TestParsePnpmLock_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 28, End: 32},
+					Column:   models.Position{Start: 3, End: 15},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:      "one-up-with-peer",
@@ -709,6 +1067,13 @@ func TestParsePnpmLock_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 34, End: 40},
+					Column:   models.Position{Start: 3, End: 25},
+					Filename: path,
+				},
+			},
 		},
 	})
 }

--- a/pkg/lockfile/parse-poetry-lock.go
+++ b/pkg/lockfile/parse-poetry-lock.go
@@ -80,14 +80,16 @@ func (e PoetryLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 		}
 
 		pkgDetails := PackageDetails{
-			Name:            lockPackage.Name,
-			Version:         lockPackage.Version,
-			Commit:          lockPackage.Source.Commit,
-			BlockLocation:   blockLocation,
-			NameLocation:    nameLocation,
-			VersionLocation: versionLocation,
-			Ecosystem:       PoetryEcosystem,
-			CompareAs:       PoetryEcosystem,
+			Name:    lockPackage.Name,
+			Version: lockPackage.Version,
+			Commit:  lockPackage.Source.Commit,
+			LockfileLocations: Locations{
+				Block:   blockLocation,
+				Name:    nameLocation,
+				Version: versionLocation,
+			},
+			Ecosystem: PoetryEcosystem,
+			CompareAs: PoetryEcosystem,
 		}
 
 		if lockPackage.Optional {

--- a/pkg/lockfile/parse-poetry-lock_test.go
+++ b/pkg/lockfile/parse-poetry-lock_test.go
@@ -110,20 +110,22 @@ func TestParsePoetryLock_OnePackage(t *testing.T) {
 		{
 			Name:    "numpy",
 			Version: "1.23.3",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 7},
-				Column:   models.Position{Start: 1, End: 26},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 9, End: 14},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 12, End: 18},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 7},
+					Column:   models.Position{Start: 1, End: 26},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 9, End: 14},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 12, End: 18},
+					Filename: path,
+				},
 			},
 			Ecosystem: lockfile.PoetryEcosystem,
 			CompareAs: lockfile.PoetryEcosystem,
@@ -148,20 +150,22 @@ func TestParsePoetryLock_TwoPackages(t *testing.T) {
 		{
 			Name:    "proto-plus",
 			Version: "1.22.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 13},
-				Column:   models.Position{Start: 1, End: 47},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 9, End: 19},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 12, End: 18},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 13},
+					Column:   models.Position{Start: 1, End: 47},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 9, End: 19},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 12, End: 18},
+					Filename: path,
+				},
 			},
 			Ecosystem: lockfile.PoetryEcosystem,
 			CompareAs: lockfile.PoetryEcosystem,
@@ -169,20 +173,22 @@ func TestParsePoetryLock_TwoPackages(t *testing.T) {
 		{
 			Name:    "protobuf",
 			Version: "4.21.5",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 15, End: 21},
-				Column:   models.Position{Start: 1, End: 26},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 16, End: 16},
-				Column:   models.Position{Start: 9, End: 17},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 17, End: 17},
-				Column:   models.Position{Start: 12, End: 18},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 15, End: 21},
+					Column:   models.Position{Start: 1, End: 26},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 16, End: 16},
+					Column:   models.Position{Start: 9, End: 17},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 17, End: 17},
+					Column:   models.Position{Start: 12, End: 18},
+					Filename: path,
+				},
 			},
 			Ecosystem: lockfile.PoetryEcosystem,
 			CompareAs: lockfile.PoetryEcosystem,
@@ -207,20 +213,22 @@ func TestParsePoetryLock_PackageWithMetadata(t *testing.T) {
 		{
 			Name:    "emoji",
 			Version: "2.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 10},
-				Column:   models.Position{Start: 1, End: 42},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 9, End: 14},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 12, End: 17},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 10},
+					Column:   models.Position{Start: 1, End: 42},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 9, End: 14},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 12, End: 17},
+					Filename: path,
+				},
 			},
 			Ecosystem: lockfile.PoetryEcosystem,
 			CompareAs: lockfile.PoetryEcosystem,
@@ -245,20 +253,22 @@ func TestParsePoetryLock_PackageWithGitSource(t *testing.T) {
 		{
 			Name:    "ike",
 			Version: "0.2.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 14},
-				Column:   models.Position{Start: 1, End: 64},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 9, End: 12},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 12, End: 17},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 14},
+					Column:   models.Position{Start: 1, End: 64},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 9, End: 12},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 12, End: 17},
+					Filename: path,
+				},
 			},
 			Ecosystem: lockfile.PoetryEcosystem,
 			CompareAs: lockfile.PoetryEcosystem,
@@ -284,20 +294,22 @@ func TestParsePoetryLock_PackageWithLegacySource(t *testing.T) {
 		{
 			Name:    "appdirs",
 			Version: "1.4.4",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 12},
-				Column:   models.Position{Start: 1, End: 23},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 9, End: 16},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 12, End: 17},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 12},
+					Column:   models.Position{Start: 1, End: 23},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 9, End: 16},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 12, End: 17},
+					Filename: path,
+				},
 			},
 			Ecosystem: lockfile.PoetryEcosystem,
 			CompareAs: lockfile.PoetryEcosystem,
@@ -323,20 +335,22 @@ func TestParsePoetryLock_OptionalPackage(t *testing.T) {
 		{
 			Name:    "numpy",
 			Version: "1.23.3",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 7},
-				Column:   models.Position{Start: 1, End: 26},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 9, End: 14},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 12, End: 18},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 7},
+					Column:   models.Position{Start: 1, End: 26},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 9, End: 14},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 12, End: 18},
+					Filename: path,
+				},
 			},
 			Ecosystem: lockfile.PoetryEcosystem,
 			CompareAs: lockfile.PoetryEcosystem,

--- a/pkg/lockfile/parse-requirements-txt.go
+++ b/pkg/lockfile/parse-requirements-txt.go
@@ -78,13 +78,15 @@ func parseLine(path string, line string, lineNumber int, lineOffset int, columnS
 	}
 
 	return PackageDetails{
-		Name:            normalizedRequirementName(name),
-		Version:         version,
-		BlockLocation:   blockLocation,
-		NameLocation:    nameLocation,
-		VersionLocation: versionLocation,
-		Ecosystem:       PipEcosystem,
-		CompareAs:       PipEcosystem,
+		Name:    normalizedRequirementName(name),
+		Version: version,
+		LockfileLocations: Locations{
+			Block:   blockLocation,
+			Name:    nameLocation,
+			Version: versionLocation,
+		},
+		Ecosystem: PipEcosystem,
+		CompareAs: PipEcosystem,
 	}
 }
 

--- a/pkg/lockfile/parse-requirements-txt_test.go
+++ b/pkg/lockfile/parse-requirements-txt_test.go
@@ -120,15 +120,17 @@ func TestParseRequirementsTxt_OneRequirementUnconstrained(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"one-package-unconstrained"},
 		},
@@ -154,20 +156,22 @@ func TestParseRequirementsTxt_OneRequirementConstrained(t *testing.T) {
 			Version:   "2.2.24",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 9, End: 15},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 9, End: 15},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"one-package-constrained"},
 		},
@@ -193,20 +197,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "2.5.1",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 8},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 10, End: 15},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 8},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 10, End: 15},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -215,20 +221,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "4.9.3",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 22},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 17, End: 22},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 22},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 17, End: 22},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -237,20 +245,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "1.17.19",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 8, End: 15},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 8, End: 15},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -259,20 +269,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "1.20.19",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 1, End: 18},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 11, End: 18},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 1, End: 18},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 11, End: 18},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -281,20 +293,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "2020.12.5",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 11, End: 11},
-				Column:   models.Position{Start: 1, End: 19},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 11, End: 11},
-				Column:   models.Position{Start: 1, End: 8},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 11, End: 11},
-				Column:   models.Position{Start: 10, End: 19},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 11},
+					Column:   models.Position{Start: 1, End: 19},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 11, End: 11},
+					Column:   models.Position{Start: 1, End: 8},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 11, End: 11},
+					Column:   models.Position{Start: 10, End: 19},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -303,20 +317,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "4.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 1, End: 8},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 10, End: 15},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 1, End: 8},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 10, End: 15},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -325,20 +341,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "0.17.1",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 15, End: 15},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 15, End: 15},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 15, End: 15},
-				Column:   models.Position{Start: 9, End: 15},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 15, End: 15},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 15, End: 15},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 15, End: 15},
+					Column:   models.Position{Start: 9, End: 15},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -347,20 +365,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "7.1.2",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 17, End: 17},
-				Column:   models.Position{Start: 1, End: 13},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 17, End: 17},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 17, End: 17},
-				Column:   models.Position{Start: 8, End: 13},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 17, End: 17},
+					Column:   models.Position{Start: 1, End: 13},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 17, End: 17},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 17, End: 17},
+					Column:   models.Position{Start: 8, End: 13},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -369,20 +389,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "3.2.1",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 19, End: 19},
-				Column:   models.Position{Start: 1, End: 28},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 19, End: 19},
-				Column:   models.Position{Start: 1, End: 21},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 19, End: 19},
-				Column:   models.Position{Start: 23, End: 28},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 19, End: 19},
+					Column:   models.Position{Start: 1, End: 28},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 19, End: 19},
+					Column:   models.Position{Start: 1, End: 21},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 19, End: 19},
+					Column:   models.Position{Start: 23, End: 28},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -391,20 +413,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "2.4.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 21, End: 21},
-				Column:   models.Position{Start: 1, End: 21},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 21, End: 21},
-				Column:   models.Position{Start: 1, End: 14},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 21, End: 21},
-				Column:   models.Position{Start: 16, End: 21},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 21, End: 21},
+					Column:   models.Position{Start: 1, End: 21},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 21, End: 21},
+					Column:   models.Position{Start: 1, End: 14},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 21, End: 21},
+					Column:   models.Position{Start: 16, End: 21},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -413,20 +437,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "1.4.7",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 23, End: 23},
-				Column:   models.Position{Start: 1, End: 19},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 23, End: 23},
-				Column:   models.Position{Start: 1, End: 12},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 23, End: 23},
-				Column:   models.Position{Start: 14, End: 19},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 23, End: 23},
+					Column:   models.Position{Start: 1, End: 19},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 23, End: 23},
+					Column:   models.Position{Start: 1, End: 12},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 23, End: 23},
+					Column:   models.Position{Start: 14, End: 19},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -435,20 +461,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "1.11.1",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 25, End: 25},
-				Column:   models.Position{Start: 1, End: 24},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 25, End: 25},
-				Column:   models.Position{Start: 1, End: 16},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 25, End: 25},
-				Column:   models.Position{Start: 18, End: 24},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 25, End: 25},
+					Column:   models.Position{Start: 1, End: 24},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 25, End: 25},
+					Column:   models.Position{Start: 1, End: 16},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 25, End: 25},
+					Column:   models.Position{Start: 18, End: 24},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -457,20 +485,22 @@ func TestParseRequirementsTxt_MultipleRequirementsConstrained(t *testing.T) {
 			Version:   "2.2.24",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 27, End: 27},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 27, End: 27},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 27, End: 27},
-				Column:   models.Position{Start: 9, End: 15},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 27, End: 27},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 27, End: 27},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 27, End: 27},
+					Column:   models.Position{Start: 9, End: 15},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-constrained"},
 		},
@@ -496,15 +526,17 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -513,15 +545,17 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 1, End: 11},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 1, End: 11},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 1, End: 11},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 1, End: 11},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -530,20 +564,22 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 			Version:   "0.23.4",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 9, End: 15},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 9, End: 15},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -552,20 +588,22 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 			Version:   "1.16.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 14},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 8, End: 14},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 14},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 8, End: 14},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -574,20 +612,22 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 			Version:   "0.20.1",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 1, End: 21},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 1, End: 13},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 15, End: 21},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 1, End: 21},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 1, End: 13},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 15, End: 21},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -596,15 +636,17 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 1, End: 8},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 1, End: 8},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 1, End: 8},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 1, End: 8},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -613,15 +655,17 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -630,15 +674,17 @@ func TestParseRequirementsTxt_MultipleRequirementsMixed(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -665,15 +711,17 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"file-format-example"},
 		},
@@ -682,15 +730,17 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 11},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 11},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 11},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 11},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"file-format-example"},
 		},
@@ -699,15 +749,17 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"file-format-example"},
 		},
@@ -716,20 +768,22 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 			Version:   "0.6.1",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 9, End: 9},
-				Column:   models.Position{Start: 1, End: 70},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 9, End: 9},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: sourcePath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 9, End: 9},
-				Column:   models.Position{Start: 11, End: 16},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 9, End: 9},
+					Column:   models.Position{Start: 1, End: 70},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 9, End: 9},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: sourcePath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 9, End: 9},
+					Column:   models.Position{Start: 11, End: 16},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"file-format-example"},
 		},
@@ -738,20 +792,22 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 			Version:   "4.1.1",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 10, End: 10},
-				Column:   models.Position{Start: 1, End: 52},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 10, End: 10},
-				Column:   models.Position{Start: 1, End: 8},
-				Filename: sourcePath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 10, End: 10},
-				Column:   models.Position{Start: 12, End: 17},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 10},
+					Column:   models.Position{Start: 1, End: 52},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 10, End: 10},
+					Column:   models.Position{Start: 1, End: 8},
+					Filename: sourcePath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 10, End: 10},
+					Column:   models.Position{Start: 12, End: 17},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"file-format-example"},
 		},
@@ -760,15 +816,17 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 11, End: 11},
-				Column:   models.Position{Start: 1, End: 77},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 11, End: 11},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 11},
+					Column:   models.Position{Start: 1, End: 77},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 11, End: 11},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"file-format-example"},
 		},
@@ -777,20 +835,22 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 			Version:   "1.1",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 1, End: 73},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 1, End: 14},
-				Filename: sourcePath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 18, End: 21},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 1, End: 73},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 1, End: 14},
+					Filename: sourcePath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 18, End: 21},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"file-format-example"},
 		},
@@ -799,15 +859,17 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 23, End: 23},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 23, End: 23},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 23, End: 23},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 23, End: 23},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"file-format-example"},
 		},
@@ -816,15 +878,17 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 24, End: 24},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 24, End: 24},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 24, End: 24},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 24, End: 24},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"file-format-example"},
 		},
@@ -833,20 +897,22 @@ func TestParseRequirementsTxt_FileFormatExample(t *testing.T) {
 			Version:   "2.2.24",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: otherPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: otherPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 9, End: 15},
-				Filename: otherPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: otherPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: otherPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 9, End: 15},
+					Filename: otherPath,
+				},
 			},
 			DepGroups: []string{"other-file"},
 		},
@@ -872,20 +938,22 @@ func TestParseRequirementsTxt_WithAddedSupport(t *testing.T) {
 			Version:   "20.3.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 23},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 17, End: 23},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 23},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 17, End: 23},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"with-added-support"},
 		},
@@ -911,20 +979,22 @@ func TestParseRequirementsTxt_NonNormalizedNames(t *testing.T) {
 			Version:   "5.4.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 22},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 17, End: 22},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 22},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 17, End: 22},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"non-normalized-names"},
 		},
@@ -933,20 +1003,22 @@ func TestParseRequirementsTxt_NonNormalizedNames(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 1, End: 14},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 9, End: 14},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 1, End: 14},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 9, End: 14},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"non-normalized-names"},
 		},
@@ -955,20 +1027,22 @@ func TestParseRequirementsTxt_NonNormalizedNames(t *testing.T) {
 			Version:   "20.3.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 1, End: 23},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 17, End: 23},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 1, End: 23},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 17, End: 23},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"non-normalized-names"},
 		},
@@ -996,15 +1070,17 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: multiplePackagesPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: multiplePackagesPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: multiplePackagesPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: multiplePackagesPath,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -1013,15 +1089,17 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 1, End: 11},
-				Filename: multiplePackagesPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 1, End: 11},
-				Filename: multiplePackagesPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 1, End: 11},
+					Filename: multiplePackagesPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 1, End: 11},
+					Filename: multiplePackagesPath,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -1030,20 +1108,22 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 			Version:   "0.23.4",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: multiplePackagesPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: multiplePackagesPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 9, End: 15},
-				Filename: multiplePackagesPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: multiplePackagesPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: multiplePackagesPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 9, End: 15},
+					Filename: multiplePackagesPath,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed", "with-multiple-r-options"},
 		},
@@ -1052,20 +1132,22 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 			Version:   "1.16.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 14},
-				Filename: multiplePackagesPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: multiplePackagesPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 8, End: 14},
-				Filename: multiplePackagesPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 14},
+					Filename: multiplePackagesPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: multiplePackagesPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 8, End: 14},
+					Filename: multiplePackagesPath,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -1074,20 +1156,22 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 			Version:   "0.20.1",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 1, End: 21},
-				Filename: multiplePackagesPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 1, End: 13},
-				Filename: multiplePackagesPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 5, End: 5},
-				Column:   models.Position{Start: 15, End: 21},
-				Filename: multiplePackagesPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 1, End: 21},
+					Filename: multiplePackagesPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 1, End: 13},
+					Filename: multiplePackagesPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 5, End: 5},
+					Column:   models.Position{Start: 15, End: 21},
+					Filename: multiplePackagesPath,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -1096,15 +1180,17 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 1, End: 8},
-				Filename: multiplePackagesPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 1, End: 8},
-				Filename: multiplePackagesPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 1, End: 8},
+					Filename: multiplePackagesPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 1, End: 8},
+					Filename: multiplePackagesPath,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -1113,15 +1199,17 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: multiplePackagesPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: multiplePackagesPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: multiplePackagesPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 7, End: 7},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: multiplePackagesPath,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -1130,15 +1218,17 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: multiplePackagesPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 8, End: 8},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: multiplePackagesPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: multiplePackagesPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 8, End: 8},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: multiplePackagesPath,
+				},
 			},
 			DepGroups: []string{"multiple-packages-mixed"},
 		},
@@ -1147,20 +1237,22 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 			Version:   "1.2.3",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 16},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: sourcePath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 11, End: 16},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 16},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: sourcePath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 11, End: 16},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"with-multiple-r-options"},
 		},
@@ -1169,20 +1261,22 @@ func TestParseRequirementsTxt_WithMultipleROptions(t *testing.T) {
 			Version:   "2.2.24",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: onePackagePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: onePackagePath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 9, End: 15},
-				Filename: onePackagePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: onePackagePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: onePackagePath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 9, End: 15},
+					Filename: onePackagePath,
+				},
 			},
 			DepGroups: []string{"one-package-constrained"},
 		},
@@ -1218,20 +1312,22 @@ func TestParseRequirementsTxt_WithURLROption(t *testing.T) {
 			Commit:    "",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 16},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 11, End: 16},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 16},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 11, End: 16},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"with-url-r-option"},
 		},
@@ -1259,20 +1355,22 @@ func TestParseRequirementsTxt_DuplicateROptions(t *testing.T) {
 			Version:   "0.1.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 14},
-				Filename: basePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: basePath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 9, End: 14},
-				Filename: basePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 14},
+					Filename: basePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: basePath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 9, End: 14},
+					Filename: basePath,
+				},
 			},
 			DepGroups: []string{"duplicate-r-base"},
 		},
@@ -1281,20 +1379,22 @@ func TestParseRequirementsTxt_DuplicateROptions(t *testing.T) {
 			Version:   "0.23.4",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: sourcePath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 9, End: 15},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: sourcePath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 9, End: 15},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"duplicate-r-dev"},
 		},
@@ -1303,20 +1403,22 @@ func TestParseRequirementsTxt_DuplicateROptions(t *testing.T) {
 			Version:   "1.2.3",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 16},
-				Filename: testPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: testPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 11, End: 16},
-				Filename: testPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 16},
+					Filename: testPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: testPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 11, End: 16},
+					Filename: testPath,
+				},
 			},
 			DepGroups: []string{"duplicate-r-test", "duplicate-r-dev"},
 		},
@@ -1325,20 +1427,22 @@ func TestParseRequirementsTxt_DuplicateROptions(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 16},
-				Filename: testPath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: testPath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 11, End: 16},
-				Filename: testPath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 16},
+					Filename: testPath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: testPath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 11, End: 16},
+					Filename: testPath,
+				},
 			},
 			DepGroups: []string{"duplicate-r-test"},
 		},
@@ -1364,20 +1468,22 @@ func TestParseRequirementsTxt_CyclicRSelf(t *testing.T) {
 			Version:   "0.23.4",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 15},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 9, End: 15},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 15},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 9, End: 15},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"cyclic-r-self"},
 		},
@@ -1386,20 +1492,22 @@ func TestParseRequirementsTxt_CyclicRSelf(t *testing.T) {
 			Version:   "1.2.3",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 16},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 9},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 11, End: 16},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 16},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 9},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 11, End: 16},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"cyclic-r-self"},
 		},
@@ -1427,20 +1535,22 @@ func TestParseRequirementsTxt_CyclicRComplex(t *testing.T) {
 			Version:   "1",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 20},
-				Filename: sourcePath,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: sourcePath,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 19, End: 20},
-				Filename: sourcePath,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 20},
+					Filename: sourcePath,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: sourcePath,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 19, End: 20},
+					Filename: sourcePath,
+				},
 			},
 			DepGroups: []string{"cyclic-r-complex-1"},
 		},
@@ -1449,20 +1559,22 @@ func TestParseRequirementsTxt_CyclicRComplex(t *testing.T) {
 			Version:   "2",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 20},
-				Filename: cyclic2Path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: cyclic2Path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 19, End: 20},
-				Filename: cyclic2Path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 20},
+					Filename: cyclic2Path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: cyclic2Path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 19, End: 20},
+					Filename: cyclic2Path,
+				},
 			},
 			DepGroups: []string{"cyclic-r-complex-2"},
 		},
@@ -1471,20 +1583,22 @@ func TestParseRequirementsTxt_CyclicRComplex(t *testing.T) {
 			Version:   "3",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 20},
-				Filename: cyclic3Path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: cyclic3Path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 4, End: 4},
-				Column:   models.Position{Start: 19, End: 20},
-				Filename: cyclic3Path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 20},
+					Filename: cyclic3Path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: cyclic3Path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 4, End: 4},
+					Column:   models.Position{Start: 19, End: 20},
+					Filename: cyclic3Path,
+				},
 			},
 			DepGroups: []string{"cyclic-r-complex-3"},
 		},
@@ -1510,20 +1624,22 @@ func TestParseRequirementsTxt_WithPerRequirementOptions(t *testing.T) {
 			Version:   "1.26.121",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 95},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 8, End: 16},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 95},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 8, End: 16},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"with-per-requirement-options"},
 		},
@@ -1532,20 +1648,22 @@ func TestParseRequirementsTxt_WithPerRequirementOptions(t *testing.T) {
 			Version:   "1.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 1, End: 13},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 1, End: 4},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 8, End: 13},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 1, End: 13},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 1, End: 4},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 8, End: 13},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"with-per-requirement-options"},
 		},
@@ -1554,20 +1672,22 @@ func TestParseRequirementsTxt_WithPerRequirementOptions(t *testing.T) {
 			Version:   "1.2",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 6, End: 8},
-				Column:   models.Position{Start: 1, End: 81},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 1, End: 11},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 15, End: 18},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 6, End: 8},
+					Column:   models.Position{Start: 1, End: 81},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 1, End: 11},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 15, End: 18},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"with-per-requirement-options"},
 		},
@@ -1576,20 +1696,22 @@ func TestParseRequirementsTxt_WithPerRequirementOptions(t *testing.T) {
 			Version:   "1.2",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 1, End: 50},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 1, End: 11},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 12, End: 12},
-				Column:   models.Position{Start: 15, End: 18},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 1, End: 50},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 1, End: 11},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 12, End: 12},
+					Column:   models.Position{Start: 15, End: 18},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"with-per-requirement-options"},
 		},
@@ -1615,20 +1737,22 @@ func TestParseRequirementsTxt_LineContinuation(t *testing.T) {
 			Version:   "1.2.3",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 2, End: 6},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 1, End: 4},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 6, End: 6},
-				Column:   models.Position{Start: 1, End: 6},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 2, End: 6},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 1, End: 4},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 6, End: 6},
+					Column:   models.Position{Start: 1, End: 6},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"line-continuation"},
 		},
@@ -1637,20 +1761,22 @@ func TestParseRequirementsTxt_LineContinuation(t *testing.T) {
 			Version:   "4.5\\\\",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 9, End: 9},
-				Column:   models.Position{Start: 1, End: 13},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 9, End: 9},
-				Column:   models.Position{Start: 1, End: 4},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 9, End: 9},
-				Column:   models.Position{Start: 8, End: 13},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 9, End: 9},
+					Column:   models.Position{Start: 1, End: 13},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 9, End: 9},
+					Column:   models.Position{Start: 1, End: 4},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 9, End: 9},
+					Column:   models.Position{Start: 8, End: 13},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"line-continuation"},
 		},
@@ -1659,20 +1785,22 @@ func TestParseRequirementsTxt_LineContinuation(t *testing.T) {
 			Version:   "7.8.9",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 13, End: 14},
-				Column:   models.Position{Start: 1, End: 13},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 1, End: 4},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 13, End: 13},
-				Column:   models.Position{Start: 8, End: 13},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 14},
+					Column:   models.Position{Start: 1, End: 13},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 1, End: 4},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 13, End: 13},
+					Column:   models.Position{Start: 8, End: 13},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"line-continuation"},
 		},
@@ -1681,20 +1809,22 @@ func TestParseRequirementsTxt_LineContinuation(t *testing.T) {
 			Version:   "10.11.12",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 17, End: 17},
-				Column:   models.Position{Start: 1, End: 17},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 17, End: 17},
-				Column:   models.Position{Start: 1, End: 4},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 17, End: 17},
-				Column:   models.Position{Start: 8, End: 16},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 17, End: 17},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 17, End: 17},
+					Column:   models.Position{Start: 1, End: 4},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 17, End: 17},
+					Column:   models.Position{Start: 8, End: 16},
+					Filename: path,
+				},
 			},
 			DepGroups: []string{"line-continuation"},
 		},
@@ -1720,15 +1850,17 @@ func TestParseRequirementsTxt_EnvironmentMarkers(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 26},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 3},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 26},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 3},
+					Filename: path,
+				},
 			},
 			Commit:    "",
 			DepGroups: []string{"environment-markers"},
@@ -1738,15 +1870,17 @@ func TestParseRequirementsTxt_EnvironmentMarkers(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 1, End: 67},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 2, End: 2},
-				Column:   models.Position{Start: 1, End: 20},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 1, End: 67},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 2, End: 2},
+					Column:   models.Position{Start: 1, End: 20},
+					Filename: path,
+				},
 			},
 			Commit:    "",
 			DepGroups: []string{"environment-markers"},
@@ -1756,20 +1890,22 @@ func TestParseRequirementsTxt_EnvironmentMarkers(t *testing.T) {
 			Version:   "5.4",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 41},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 1, End: 12},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 3, End: 3},
-				Column:   models.Position{Start: 14, End: 17},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 41},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 1, End: 12},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 3, End: 3},
+					Column:   models.Position{Start: 14, End: 17},
+					Filename: path,
+				},
 			},
 			Commit:    "",
 			DepGroups: []string{"environment-markers"},
@@ -1796,15 +1932,17 @@ func TestParseRequirementsTxt_GitUrlPackages(t *testing.T) {
 			Version:   "0.0.0",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 52},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 52},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: path,
+				},
 			},
 			Commit:    "",
 			DepGroups: []string{"url-packages"},
@@ -1834,20 +1972,22 @@ func TestParseRequirementsTxt_WhlUrlPackages(t *testing.T) {
 			Version:   "2.2.1",
 			Ecosystem: lockfile.PipEcosystem,
 			CompareAs: lockfile.PipEcosystem,
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 161},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 7},
-				Filename: path,
-			},
-			VersionLocation: &models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 124, End: 129},
-				Filename: path,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 161},
+					Filename: path,
+				},
+				Name: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 7},
+					Filename: path,
+				},
+				Version: &models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 124, End: 129},
+					Filename: path,
+				},
 			},
 			Commit:    "",
 			DepGroups: []string{"whl-url-packages"},

--- a/pkg/lockfile/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v1_test.go
@@ -3,6 +3,7 @@ package lockfile_test
 import (
 	"bytes"
 	"errors"
+	"github.com/google/osv-scanner/pkg/models"
 	"io"
 	"io/fs"
 	"os"
@@ -20,7 +21,7 @@ func TestParseYarnLock_v1_FileDoesNotExist(t *testing.T) {
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/does-not-exist")
 
 	expectErrIs(t, err, fs.ErrNotExist)
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
+	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseYarnLock_v1_NoPackages(t *testing.T) {
@@ -32,7 +33,7 @@ func TestParseYarnLock_v1_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
+	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseYarnLock_v1_OnePackage(t *testing.T) {
@@ -48,13 +49,20 @@ func TestParseYarnLock_v1_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "balanced-match",
 			Version:        "1.0.2",
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 8},
+					Column:   models.Position{Start: 1, End: 108},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -94,13 +102,20 @@ func TestParseYarnLock_v1_OnePackage_MatcherFailed(t *testing.T) {
 	_ = r.Close()
 
 	assert.Contains(t, buffer.String(), matcherError.Error())
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "balanced-match",
 			Version:        "1.0.2",
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 8},
+					Column:   models.Position{Start: 1, End: 108},
+					Filename: path,
+				},
+			},
 		},
 	})
 
@@ -121,13 +136,20 @@ func TestParseYarnLock_v1_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "concat-stream",
 			Version:        "1.6.2",
 			TargetVersions: []string{"^1.5.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 18},
+					Column:   models.Position{Start: 1, End: 24},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "concat-map",
@@ -135,6 +157,13 @@ func TestParseYarnLock_v1_TwoPackages(t *testing.T) {
 			TargetVersions: []string{"0.0.1"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 8},
+					Column:   models.Position{Start: 1, End: 46},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -152,13 +181,20 @@ func TestParseYarnLock_v1_WithQuotes(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "concat-stream",
 			Version:        "1.6.2",
 			TargetVersions: []string{"^1.5.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 18},
+					Column:   models.Position{Start: 1, End: 26},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "concat-map",
@@ -166,6 +202,13 @@ func TestParseYarnLock_v1_WithQuotes(t *testing.T) {
 			TargetVersions: []string{"0.0.1"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 8},
+					Column:   models.Position{Start: 1, End: 48},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -183,13 +226,20 @@ func TestParseYarnLock_v1_MultipleVersions(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "define-properties",
 			Version:        "1.1.3",
 			TargetVersions: []string{"^1.1.3"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 10},
+					Column:   models.Position{Start: 1, End: 26},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "define-property",
@@ -197,6 +247,13 @@ func TestParseYarnLock_v1_MultipleVersions(t *testing.T) {
 			TargetVersions: []string{"^0.2.5"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 12, End: 17},
+					Column:   models.Position{Start: 1, End: 27},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "define-property",
@@ -204,6 +261,13 @@ func TestParseYarnLock_v1_MultipleVersions(t *testing.T) {
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 19, End: 24},
+					Column:   models.Position{Start: 1, End: 27},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "define-property",
@@ -211,6 +275,13 @@ func TestParseYarnLock_v1_MultipleVersions(t *testing.T) {
 			TargetVersions: []string{"^2.0.2"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 26, End: 32},
+					Column:   models.Position{Start: 1, End: 22},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -228,13 +299,20 @@ func TestParseYarnLock_v1_MultipleConstraints(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@babel/code-frame",
 			Version:        "7.12.13",
 			TargetVersions: []string{"^7.0.0", "^7.12.13"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 15},
+					Column:   models.Position{Start: 1, End: 34},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "domelementtype",
@@ -242,6 +320,13 @@ func TestParseYarnLock_v1_MultipleConstraints(t *testing.T) {
 			TargetVersions: []string{"1", "^1.3.1"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 8},
+					Column:   models.Position{Start: 1, End: 108},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -259,13 +344,20 @@ func TestParseYarnLock_v1_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@babel/code-frame",
 			Version:        "7.12.11",
 			TargetVersions: []string{"7.12.11"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 10},
+					Column:   models.Position{Start: 1, End: 33},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "@babel/compat-data",
@@ -273,6 +365,13 @@ func TestParseYarnLock_v1_ScopedPackages(t *testing.T) {
 			TargetVersions: []string{"^7.13.11"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 12, End: 15},
+					Column:   models.Position{Start: 1, End: 108},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -290,13 +389,20 @@ func TestParseYarnLock_v1_WithPrerelease(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "css-tree",
 			Version:        "1.0.0-alpha.37",
 			TargetVersions: []string{"1.0.0-alpha.37"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 11},
+					Column:   models.Position{Start: 1, End: 24},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "gensync",
@@ -304,6 +410,13 @@ func TestParseYarnLock_v1_WithPrerelease(t *testing.T) {
 			TargetVersions: []string{"^1.0.0-beta.2"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 13, End: 16},
+					Column:   models.Position{Start: 1, End: 108},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "node-fetch",
@@ -311,6 +424,13 @@ func TestParseYarnLock_v1_WithPrerelease(t *testing.T) {
 			TargetVersions: []string{"3.0.0-beta.9"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 18, End: 24},
+					Column:   models.Position{Start: 1, End: 24},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "resolve",
@@ -318,6 +438,13 @@ func TestParseYarnLock_v1_WithPrerelease(t *testing.T) {
 			TargetVersions: []string{"^1.1.7", "^1.10.0", "^1.12.0", "^1.14.2", "^1.20.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 26, End: 32},
+					Column:   models.Position{Start: 1, End: 24},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "resolve",
@@ -325,6 +452,13 @@ func TestParseYarnLock_v1_WithPrerelease(t *testing.T) {
 			TargetVersions: []string{"^2.0.0-next.3"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 34, End: 40},
+					Column:   models.Position{Start: 1, End: 24},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -342,13 +476,20 @@ func TestParseYarnLock_v1_WithBuildString(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "domino",
 			Version:        "2.1.6+git",
 			TargetVersions: []string{"https://github.com/angular/domino.git#f2435fe1f9f7c91ade0bd472c4723e5eacd7d19a"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 8},
+					Column:   models.Position{Start: 1, End: 108},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "tslib",
@@ -356,6 +497,13 @@ func TestParseYarnLock_v1_WithBuildString(t *testing.T) {
 			TargetVersions: []string{"^2.3.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 13},
+					Column:   models.Position{Start: 1, End: 108},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -373,7 +521,7 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "mine1",
 			Version:        "1.0.0-alpha.37",
@@ -381,6 +529,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "0a2d2506c1fe299691fc5db53a2097db3bd615bc",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 9},
+					Column:   models.Position{Start: 1, End: 31},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "mine2",
@@ -389,6 +544,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "0a2d2506c1fe299691fc5db53a2097db3bd615bc",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 11, End: 15},
+					Column:   models.Position{Start: 1, End: 31},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "mine3",
@@ -397,6 +559,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "094e581aaf927d010e4b61d706ba584551dac502",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 17, End: 19},
+					Column:   models.Position{Start: 1, End: 111},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:    "mine4",
@@ -408,6 +577,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.YarnEcosystem,
 			CompareAs: lockfile.YarnEcosystem,
 			Commit:    "aa3bdfcb1d845c79f14abb66f60d35b8a3ee5998",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 21, End: 23},
+					Column:   models.Position{Start: 1, End: 101},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "mine4",
@@ -416,6 +592,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "aa3bdfcb1d845c79f14abb66f60d35b8a3ee5998",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 25, End: 27},
+					Column:   models.Position{Start: 1, End: 111},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "my-package",
@@ -424,6 +607,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "b3bd3f1b3dad036e671251f5258beaae398f983a",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 29, End: 31},
+					Column:   models.Position{Start: 1, End: 103},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "@bower_components/angular-animate",
@@ -432,6 +622,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "e7f778fc054a086ba3326d898a00fa1bc78650a8",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 33, End: 35},
+					Column:   models.Position{Start: 1, End: 105},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "@bower_components/alertify",
@@ -440,6 +637,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "e7b6c46d76604d297c389d830817b611c9a8f17c",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 37, End: 39},
+					Column:   models.Position{Start: 1, End: 115},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "minimist",
@@ -448,6 +652,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "3754568bfd43a841d2d72d7fb54598635aea8fa4",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 41, End: 43},
+					Column:   models.Position{Start: 1, End: 93},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "bats-assert",
@@ -456,6 +667,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "4bdd58d3fbcdce3209033d44d884e87add1d8405",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 45, End: 47},
+					Column:   models.Position{Start: 1, End: 95},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "bats-support",
@@ -464,6 +682,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "d140a65044b2d6810381935ae7f0c94c7023c8c3",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 49, End: 51},
+					Column:   models.Position{Start: 1, End: 96},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "bats",
@@ -472,6 +697,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "172580d2ce19ee33780b5f1df817bbddced43789",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 53, End: 55},
+					Column:   models.Position{Start: 1, End: 93},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "vue",
@@ -480,6 +712,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "bb253db0b3e17124b6d1fe93fbf2db35470a1347",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 57, End: 59},
+					Column:   models.Position{Start: 1, End: 87},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "kit",
@@ -488,6 +727,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "5b6830c0252eb73c6024d40a8ff5106d3023a2a6",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 61, End: 66},
+					Column:   models.Position{Start: 1, End: 32},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "casadistance",
@@ -496,6 +742,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "f0308391f0c50104182bfb2332a53e4e523a4603",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 68, End: 70},
+					Column:   models.Position{Start: 1, End: 110},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "babel-preset-php",
@@ -504,6 +757,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 72, End: 76},
+					Column:   models.Position{Start: 1, End: 24},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "is-number",
@@ -512,6 +772,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 78, End: 80},
+					Column:   models.Position{Start: 1, End: 113},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "is-number",
@@ -520,6 +787,13 @@ func TestParseYarnLock_v1_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 82, End: 84},
+					Column:   models.Position{Start: 1, End: 113},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -537,7 +811,7 @@ func TestParseYarnLock_v1_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "etag",
 			Version:        "1.8.1",
@@ -545,6 +819,13 @@ func TestParseYarnLock_v1_Files(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 7},
+					Column:   models.Position{Start: 1, End: 105},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "filedep",
@@ -553,6 +834,13 @@ func TestParseYarnLock_v1_Files(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 9, End: 10},
+					Column:   models.Position{Start: 1, End: 18},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "lodash",
@@ -561,6 +849,13 @@ func TestParseYarnLock_v1_Files(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 12, End: 14},
+					Column:   models.Position{Start: 1, End: 109},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "other_package",
@@ -569,6 +864,13 @@ func TestParseYarnLock_v1_Files(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 16, End: 22},
+					Column:   models.Position{Start: 1, End: 18},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "sprintf-js",
@@ -577,6 +879,13 @@ func TestParseYarnLock_v1_Files(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 24, End: 25},
+					Column:   models.Position{Start: 1, End: 18},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "etag",
@@ -585,6 +894,13 @@ func TestParseYarnLock_v1_Files(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 27, End: 28},
+					Column:   models.Position{Start: 1, End: 18},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -602,13 +918,20 @@ func TestParseYarnLock_v1_WithAliases(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@babel/helper-validator-identifier",
 			Version:        "7.22.20",
 			TargetVersions: []string{"^7.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 15, End: 18},
+					Column:   models.Position{Start: 1, End: 108},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "ansi-regex",
@@ -616,6 +939,13 @@ func TestParseYarnLock_v1_WithAliases(t *testing.T) {
 			TargetVersions: []string{"^6.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 10, End: 13},
+					Column:   models.Position{Start: 1, End: 108},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "ansi-regex",
@@ -623,6 +953,13 @@ func TestParseYarnLock_v1_WithAliases(t *testing.T) {
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 5, End: 8},
+					Column:   models.Position{Start: 1, End: 108},
+					Filename: path,
+				},
+			},
 		},
 	})
 }

--- a/pkg/lockfile/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v2_test.go
@@ -3,6 +3,7 @@ package lockfile_test
 import (
 	"bytes"
 	"errors"
+	"github.com/google/osv-scanner/pkg/models"
 	"io"
 	"io/fs"
 	"os"
@@ -20,7 +21,7 @@ func TestParseYarnLock_v2_FileDoesNotExist(t *testing.T) {
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/does-not-exist")
 
 	expectErrIs(t, err, fs.ErrNotExist)
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
+	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseYarnLock_v2_NoPackages(t *testing.T) {
@@ -32,7 +33,7 @@ func TestParseYarnLock_v2_NoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{})
+	expectPackages(t, packages, []lockfile.PackageDetails{})
 }
 
 func TestParseYarnLock_v2_OnePackage(t *testing.T) {
@@ -48,13 +49,20 @@ func TestParseYarnLock_v2_OnePackage(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "balanced-match",
 			Version:        "1.0.2",
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 13},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -94,13 +102,20 @@ func TestParseYarnLock_v2_OnePackage_MatcherFailed(t *testing.T) {
 	_ = r.Close()
 
 	assert.Contains(t, buffer.String(), matcherError.Error())
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "balanced-match",
 			Version:        "1.0.2",
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 13},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 
@@ -121,13 +136,20 @@ func TestParseYarnLock_v2_TwoPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "compare-func",
 			Version:        "2.0.0",
 			TargetVersions: []string{"^2.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 16},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "concat-map",
@@ -135,6 +157,13 @@ func TestParseYarnLock_v2_TwoPackages(t *testing.T) {
 			TargetVersions: []string{"0.0.1"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 18, End: 23},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -152,13 +181,20 @@ func TestParseYarnLock_v2_WithQuotes(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "compare-func",
 			Version:        "2.0.0",
 			TargetVersions: []string{"^2.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 16},
+					Column:   models.Position{Start: 1, End: 19},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "concat-map",
@@ -166,6 +202,13 @@ func TestParseYarnLock_v2_WithQuotes(t *testing.T) {
 			TargetVersions: []string{"0.0.1"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 18, End: 23},
+					Column:   models.Position{Start: 1, End: 19},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -183,13 +226,20 @@ func TestParseYarnLock_v2_MultipleVersions(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "debug",
 			Version:        "4.3.3",
 			TargetVersions: []string{"4", "^4.0.0", "^4.1.0", "^4.1.1", "^4.3.1", "^4.3.2", "^4.3.3"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 18},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "debug",
@@ -197,6 +247,13 @@ func TestParseYarnLock_v2_MultipleVersions(t *testing.T) {
 			TargetVersions: []string{"^2.6.9"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 20, End: 27},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "debug",
@@ -204,6 +261,13 @@ func TestParseYarnLock_v2_MultipleVersions(t *testing.T) {
 			TargetVersions: []string{"^3.2.7"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 29, End: 36},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -221,13 +285,20 @@ func TestParseYarnLock_v2_ScopedPackages(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@babel/cli",
 			Version:        "7.16.8",
 			TargetVersions: []string{"^7.4.4"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 33},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "@babel/code-frame",
@@ -235,6 +306,13 @@ func TestParseYarnLock_v2_ScopedPackages(t *testing.T) {
 			TargetVersions: []string{"^7.0.0", "^7.12.13", "^7.16.7"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 35, End: 42},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "@babel/compat-data",
@@ -242,6 +320,13 @@ func TestParseYarnLock_v2_ScopedPackages(t *testing.T) {
 			TargetVersions: []string{"^7.13.11", "^7.16.4", "^7.16.8"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 44, End: 49},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -259,13 +344,20 @@ func TestParseYarnLock_v2_WithPrerelease(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@nicolo-ribaudo/chokidar-2",
 			Version:        "2.1.8-no-fsevents.3",
 			TargetVersions: []string{"2.1.8-no-fsevents.3"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 13},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "gensync",
@@ -273,6 +365,13 @@ func TestParseYarnLock_v2_WithPrerelease(t *testing.T) {
 			TargetVersions: []string{"^1.0.0-beta.2"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 15, End: 20},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "eslint-plugin-jest",
@@ -280,6 +379,13 @@ func TestParseYarnLock_v2_WithPrerelease(t *testing.T) {
 			TargetVersions: []string{"workspace:."},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 22, End: 76},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -297,7 +403,7 @@ func TestParseYarnLock_v2_WithBuildString(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "domino",
 			Version:        "2.1.6+git",
@@ -305,6 +411,13 @@ func TestParseYarnLock_v2_WithBuildString(t *testing.T) {
 			TargetVersions: []string{"https://github.com/angular/domino.git#f2435fe1f9f7c91ade0bd472c4723e5eacd7d19a"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 13},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "tslib",
@@ -312,6 +425,13 @@ func TestParseYarnLock_v2_WithBuildString(t *testing.T) {
 			TargetVersions: []string{"^2.3.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 15, End: 20},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "zone.js",
@@ -319,6 +439,13 @@ func TestParseYarnLock_v2_WithBuildString(t *testing.T) {
 			TargetVersions: []string{"workspace:."},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 22, End: 29},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -336,7 +463,7 @@ func TestParseYarnLock_v2_Commits(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@my-scope/my-first-package",
 			Version:        "0.0.6",
@@ -344,6 +471,13 @@ func TestParseYarnLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "0b824c650d3a03444dbcf2b27a5f3566f6e41358",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 10},
+					Column:   models.Position{Start: 1, End: 138},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "my-second-package",
@@ -352,6 +486,13 @@ func TestParseYarnLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "59e2127b9f9d4fda5f928c4204213b3502cd5bb0",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 12, End: 19},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "@typegoose/typegoose",
@@ -360,6 +501,13 @@ func TestParseYarnLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "3ed06e5097ab929f69755676fee419318aaec73a",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 21, End: 35},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "vuejs",
@@ -368,6 +516,13 @@ func TestParseYarnLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "0948d999f2fddf9f90991956493f976273c5da1f",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 37, End: 42},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "my-third-package",
@@ -376,6 +531,13 @@ func TestParseYarnLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "5675a0aed98e067ff6ecccc5ac674fe8995960e0",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 45, End: 47},
+					Column:   models.Position{Start: 1, End: 128},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "my-node-sdk",
@@ -384,6 +546,13 @@ func TestParseYarnLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "053dea9e0b8af442d8f867c8e690d2fb0ceb1bf5",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 50, End: 55},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "is-really-great",
@@ -392,6 +561,13 @@ func TestParseYarnLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "191eeef50c584714e1fb8927d17ee72b3b8c97c4",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 58, End: 63},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -409,7 +585,7 @@ func TestParseYarnLock_v2_Files(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "my-package",
 			Version:        "0.0.2",
@@ -417,6 +593,13 @@ func TestParseYarnLock_v2_Files(t *testing.T) {
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
 			Commit:         "",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 13},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }
@@ -434,13 +617,20 @@ func TestParseYarnLock_v2_WithAliases(t *testing.T) {
 		t.Errorf("Got unexpected error: %v", err)
 	}
 
-	expectPackagesWithoutLocations(t, packages, []lockfile.PackageDetails{
+	expectPackages(t, packages, []lockfile.PackageDetails{
 		{
 			Name:           "@babel/helper-validator-identifier",
 			Version:        "7.22.20",
 			TargetVersions: []string{"^7.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 22, End: 27},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "ansi-regex",
@@ -448,6 +638,13 @@ func TestParseYarnLock_v2_WithAliases(t *testing.T) {
 			TargetVersions: []string{"^6.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 15, End: 20},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "ansi-regex",
@@ -455,6 +652,13 @@ func TestParseYarnLock_v2_WithAliases(t *testing.T) {
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 8, End: 13},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 		{
 			Name:           "mine",
@@ -462,6 +666,13 @@ func TestParseYarnLock_v2_WithAliases(t *testing.T) {
 			TargetVersions: []string{"workspace:."},
 			Ecosystem:      lockfile.YarnEcosystem,
 			CompareAs:      lockfile.YarnEcosystem,
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 29, End: 37},
+					Column:   models.Position{Start: 1, End: 17},
+					Filename: path,
+				},
+			},
 		},
 	})
 }

--- a/pkg/lockfile/types.go
+++ b/pkg/lockfile/types.go
@@ -2,17 +2,22 @@ package lockfile
 
 import "github.com/google/osv-scanner/pkg/models"
 
+type Locations struct {
+	Block   models.FilePosition  `json:"block"`
+	Version *models.FilePosition `json:"version,omitempty"`
+	Name    *models.FilePosition `json:"name,omitempty"`
+}
+
 type PackageDetails struct {
-	Name            string               `json:"name"`
-	Version         string               `json:"version"`
-	TargetVersions  []string             `json:"targetVersions,omitempty"`
-	Commit          string               `json:"commit,omitempty"`
-	Ecosystem       Ecosystem            `json:"ecosystem,omitempty"`
-	CompareAs       Ecosystem            `json:"compareAs,omitempty"`
-	DepGroups       []string             `json:"-"`
-	BlockLocation   models.FilePosition  `json:"blockLocation,omitempty"`
-	VersionLocation *models.FilePosition `json:"versionLocation,omitempty"`
-	NameLocation    *models.FilePosition `json:"nameLocation,omitempty"`
+	Name                string     `json:"name"`
+	Version             string     `json:"version"`
+	TargetVersions      []string   `json:"targetVersions,omitempty"`
+	Commit              string     `json:"commit,omitempty"`
+	Ecosystem           Ecosystem  `json:"ecosystem,omitempty"`
+	CompareAs           Ecosystem  `json:"compareAs,omitempty"`
+	DepGroups           []string   `json:"-"`
+	LockfileLocations   Locations  `json:"lockfileLocations"`
+	SourcefileLocations *Locations `json:"sourcefileLocations,omitempty"`
 }
 
 type Ecosystem string

--- a/pkg/models/location.go
+++ b/pkg/models/location.go
@@ -21,11 +21,19 @@ type PackageLocation struct {
 	ColumnEnd   int    `json:"column_end"`
 }
 
-type PackageLocations struct {
+type SourcefilePackageLocations struct {
 	Block     PackageLocation  `json:"block"`
 	Namespace *PackageLocation `json:"namespace,omitempty"`
 	Name      *PackageLocation `json:"name,omitempty"`
 	Version   *PackageLocation `json:"version,omitempty"`
+}
+
+type PackageLocations struct {
+	Block      PackageLocation             `json:"block"`
+	Namespace  *PackageLocation            `json:"namespace,omitempty"`
+	Name       *PackageLocation            `json:"name,omitempty"`
+	Version    *PackageLocation            `json:"version,omitempty"`
+	Sourcefile *SourcefilePackageLocations `json:"sourcefile,omitempty"`
 }
 
 func (location PackageLocations) MarshalToJSONString() (string, error) {

--- a/pkg/models/results.go
+++ b/pkg/models/results.go
@@ -169,13 +169,18 @@ type AnalysisInfo struct {
 	Called bool `json:"called"`
 }
 
+type FileLocations struct {
+	Block   FilePosition  `json:"block,omitempty"`
+	Version *FilePosition `json:"version,omitempty"`
+	Name    *FilePosition `json:"name,omitempty"`
+}
+
 // Specific package information
 type PackageInfo struct {
-	Name            string        `json:"name"`
-	Version         string        `json:"version"`
-	Ecosystem       string        `json:"ecosystem"`
-	Commit          string        `json:"commit,omitempty"`
-	BlockLocation   FilePosition  `json:"blockLocation"`
-	VersionLocation *FilePosition `json:"versionLocation,omitempty"`
-	NameLocation    *FilePosition `json:"nameLocation,omitempty"`
+	Name                string         `json:"name"`
+	Version             string         `json:"version"`
+	Ecosystem           string         `json:"ecosystem"`
+	Commit              string         `json:"commit,omitempty"`
+	LockfileLocations   FileLocations  `json:"lockfileLocations"`
+	SourcefileLocations *FileLocations `json:"sourcefileLocations,omitempty"`
 }

--- a/pkg/osvscanner/__snapshots__/osvscanner_internal_test.snap
+++ b/pkg/osvscanner/__snapshots__/osvscanner_internal_test.snap
@@ -25,16 +25,18 @@
             "name": "remove_dir_all",
             "version": "0.5.3",
             "ecosystem": "crates.io",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -187,16 +189,18 @@
             "name": "time",
             "version": "0.1.45",
             "ecosystem": "crates.io",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -455,16 +459,18 @@
             "name": "golang.org/x/net",
             "version": "0.1.0",
             "ecosystem": "Go",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -962,16 +968,18 @@
             "name": "ascii",
             "version": "0.8.7",
             "ecosystem": "crates.io",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1119,16 +1127,18 @@
             "name": "remove_dir_all",
             "version": "0.5.3",
             "ecosystem": "crates.io",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1281,16 +1291,18 @@
             "name": "time",
             "version": "0.1.45",
             "ecosystem": "crates.io",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1562,16 +1574,18 @@
             "name": "chromium",
             "version": "73.0.3683.75-1",
             "ecosystem": "Debian:10",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1679,16 +1693,18 @@
             "name": "golang.org/x/net",
             "version": "0.1.0",
             "ecosystem": "Go",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1907,16 +1923,18 @@
             "name": "ascii",
             "version": "0.8.7",
             "ecosystem": "crates.io",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [
@@ -1996,16 +2014,18 @@
             "name": "time",
             "version": "0.1.45",
             "ecosystem": "crates.io",
-            "blockLocation": {
-              "line": {
-                "start": 0,
-                "end": 0
-              },
-              "column": {
-                "start": 0,
-                "end": 0
-              },
-              "file_name": ""
+            "lockfileLocations": {
+              "block": {
+                "line": {
+                  "start": 0,
+                  "end": 0
+                },
+                "column": {
+                  "start": 0,
+                  "end": 0
+                },
+                "file_name": ""
+              }
             }
           },
           "vulnerabilities": [

--- a/pkg/osvscanner/osvscanner.go
+++ b/pkg/osvscanner/osvscanner.go
@@ -400,9 +400,8 @@ func scanLockfile(r reporter.Reporter, path string, parseAs string, enabledParse
 				Path: path,
 				Type: "lockfile",
 			},
-			BlockLocation:   pkgDetail.BlockLocation,
-			VersionLocation: pkgDetail.VersionLocation,
-			NameLocation:    pkgDetail.NameLocation,
+			LockfileLocations:   pkgDetail.LockfileLocations,
+			SourcefileLocations: pkgDetail.SourcefileLocations,
 		}
 	}
 
@@ -734,16 +733,15 @@ func parseLockfilePath(lockfileElem string) (string, string) {
 }
 
 type scannedPackage struct {
-	PURL            string
-	Name            string
-	Ecosystem       lockfile.Ecosystem
-	Commit          string
-	Version         string
-	Source          models.SourceInfo
-	DepGroups       []string
-	BlockLocation   models.FilePosition
-	VersionLocation *models.FilePosition
-	NameLocation    *models.FilePosition
+	PURL                string
+	Name                string
+	Ecosystem           lockfile.Ecosystem
+	Commit              string
+	Version             string
+	Source              models.SourceInfo
+	DepGroups           []string
+	LockfileLocations   lockfile.Locations
+	SourcefileLocations *lockfile.Locations
 }
 
 func initializeEnabledParsers(enabledParsers []string) map[string]bool {

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -77,9 +77,16 @@ func buildVulnerabilityResults(
 				includePackage = true
 			}
 		}
-		pkg.Package.BlockLocation = rawPkg.BlockLocation
-		pkg.Package.NameLocation = rawPkg.NameLocation
-		pkg.Package.VersionLocation = rawPkg.VersionLocation
+		pkg.Package.LockfileLocations.Block = rawPkg.LockfileLocations.Block
+		pkg.Package.LockfileLocations.Name = rawPkg.LockfileLocations.Name
+		pkg.Package.LockfileLocations.Version = rawPkg.LockfileLocations.Version
+		if rawPkg.SourcefileLocations != nil {
+			pkg.Package.SourcefileLocations = &models.FileLocations{
+				Block:   rawPkg.SourcefileLocations.Block,
+				Name:    rawPkg.SourcefileLocations.Name,
+				Version: rawPkg.SourcefileLocations.Version,
+			}
+		}
 		if actions.ScanLicensesSummary {
 			pkg.Licenses = licensesResp[i]
 		}
@@ -153,9 +160,16 @@ func groupBySource(r reporter.Reporter, packages []scannedPackage, actions Scann
 
 		pkg.Vulnerabilities = nil
 		pkg.Groups = nil
-		pkg.Package.BlockLocation = p.BlockLocation
-		pkg.Package.VersionLocation = p.VersionLocation
-		pkg.Package.NameLocation = p.NameLocation
+		pkg.Package.LockfileLocations.Block = p.LockfileLocations.Block
+		pkg.Package.LockfileLocations.Name = p.LockfileLocations.Name
+		pkg.Package.LockfileLocations.Version = p.LockfileLocations.Version
+		if p.SourcefileLocations != nil {
+			pkg.Package.SourcefileLocations = &models.FileLocations{
+				Block:   p.SourcefileLocations.Block,
+				Name:    p.SourcefileLocations.Name,
+				Version: p.SourcefileLocations.Version,
+			}
+		}
 		groupedBySource[p.Source] = append(groupedBySource[p.Source], pkg)
 	}
 

--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -24,10 +24,12 @@ func Test_assembleResult(t *testing.T) {
 			Name:      "pkg-1",
 			Ecosystem: lockfile.Ecosystem("npm"),
 			Version:   "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 1},
-				Filename: "dir/package-lock.json",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 1},
+					Filename: "dir/package-lock.json",
+				},
 			},
 			Source: models.SourceInfo{
 				Path: "dir/package-lock.json",
@@ -38,10 +40,12 @@ func Test_assembleResult(t *testing.T) {
 			Name:      "pkg-2",
 			Ecosystem: lockfile.Ecosystem("npm"),
 			Version:   "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 1},
-				Filename: "dir/package-lock.json",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 1},
+					Filename: "dir/package-lock.json",
+				},
 			},
 			Source: models.SourceInfo{
 				Path: "dir/package-lock.json",
@@ -52,10 +56,12 @@ func Test_assembleResult(t *testing.T) {
 			Name:      "pkg-3",
 			Ecosystem: lockfile.Ecosystem("npm"),
 			Version:   "1.0.0",
-			BlockLocation: models.FilePosition{
-				Line:     models.Position{Start: 1, End: 1},
-				Column:   models.Position{Start: 1, End: 1},
-				Filename: "other-dir/package-lock.json",
+			LockfileLocations: lockfile.Locations{
+				Block: models.FilePosition{
+					Line:     models.Position{Start: 1, End: 1},
+					Column:   models.Position{Start: 1, End: 1},
+					Filename: "other-dir/package-lock.json",
+				},
 			},
 			Source: models.SourceInfo{
 				Path: "other-dir/package-lock.json",
@@ -121,10 +127,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-1",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "dir/package-lock.json",
+									},
 								},
 							},
 							Vulnerabilities: []models.Vulnerability{
@@ -156,10 +164,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-3",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "other-dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "other-dir/package-lock.json",
+									},
 								},
 							},
 							Vulnerabilities: []models.Vulnerability{
@@ -238,10 +248,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-1",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "dir/package-lock.json",
+									},
 								},
 							},
 							Vulnerabilities: []models.Vulnerability{
@@ -264,10 +276,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-2",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "dir/package-lock.json",
+									},
 								},
 							},
 						},
@@ -284,10 +298,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-3",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "other-dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "other-dir/package-lock.json",
+									},
 								},
 							},
 							Vulnerabilities: []models.Vulnerability{
@@ -389,10 +405,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-1",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "dir/package-lock.json",
+									},
 								},
 							},
 							Vulnerabilities: []models.Vulnerability{
@@ -416,10 +434,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-2",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "dir/package-lock.json",
+									},
 								},
 							},
 							Licenses: makeLicenses([]string{"MIT"}),
@@ -437,10 +457,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-3",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "other-dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "other-dir/package-lock.json",
+									},
 								},
 							},
 							Vulnerabilities: []models.Vulnerability{
@@ -541,10 +563,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-1",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "dir/package-lock.json",
+									},
 								},
 							},
 							Vulnerabilities: []models.Vulnerability{
@@ -577,10 +601,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-3",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "other-dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "other-dir/package-lock.json",
+									},
 								},
 							},
 							Vulnerabilities: []models.Vulnerability{
@@ -666,10 +692,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-1",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "dir/package-lock.json",
+									},
 								},
 							},
 							Vulnerabilities: []models.Vulnerability{
@@ -693,10 +721,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-2",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "dir/package-lock.json",
+									},
 								},
 							},
 							Licenses: makeLicenses([]string{"MIT"}),
@@ -714,10 +744,12 @@ func Test_assembleResult(t *testing.T) {
 								Name:      "pkg-3",
 								Ecosystem: "npm",
 								Version:   "1.0.0",
-								BlockLocation: models.FilePosition{
-									Line:     models.Position{Start: 1, End: 1},
-									Column:   models.Position{Start: 1, End: 1},
-									Filename: "other-dir/package-lock.json",
+								LockfileLocations: models.FileLocations{
+									Block: models.FilePosition{
+										Line:     models.Position{Start: 1, End: 1},
+										Column:   models.Position{Start: 1, End: 1},
+										Filename: "other-dir/package-lock.json",
+									},
 								},
 							},
 							Vulnerabilities: []models.Vulnerability{

--- a/pkg/reporter/purl/composer_extractor_test.go
+++ b/pkg/reporter/purl/composer_extractor_test.go
@@ -19,8 +19,10 @@ func TestComposerExtraction_shouldExtractPackages(t *testing.T) {
 			Version:   "7.0.0",
 			Ecosystem: string(models.EcosystemPackagist),
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line: models.Position{Start: 0, End: 0},
+			LockfileLocations: models.FileLocations{
+				Block: models.FilePosition{
+					Line: models.Position{Start: 0, End: 0},
+				},
 			},
 		},
 		expectedNamespace: "symfony",
@@ -53,8 +55,10 @@ func TestComposerExtraction_shouldFilterPackages(t *testing.T) {
 				Version:   "7.0.0",
 				Ecosystem: string(models.EcosystemPackagist),
 				Commit:    "",
-				BlockLocation: models.FilePosition{
-					Line: models.Position{Start: 0, End: 0},
+				LockfileLocations: models.FileLocations{
+					Block: models.FilePosition{
+						Line: models.Position{Start: 0, End: 0},
+					},
 				},
 			},
 		},
@@ -65,8 +69,10 @@ func TestComposerExtraction_shouldFilterPackages(t *testing.T) {
 				Version:   "7.0.0",
 				Ecosystem: string(models.EcosystemPackagist),
 				Commit:    "",
-				BlockLocation: models.FilePosition{
-					Line: models.Position{Start: 0, End: 0},
+				LockfileLocations: models.FileLocations{
+					Block: models.FilePosition{
+						Line: models.Position{Start: 0, End: 0},
+					},
 				},
 			},
 		},

--- a/pkg/reporter/purl/golang_extractor_test.go
+++ b/pkg/reporter/purl/golang_extractor_test.go
@@ -22,8 +22,10 @@ func TestGolangExtraction_shouldExtractPackages(t *testing.T) {
 				Version:   "v0.14.0",
 				Ecosystem: string(models.EcosystemGo),
 				Commit:    "",
-				BlockLocation: models.FilePosition{
-					Line: models.Position{Start: 0, End: 0},
+				LockfileLocations: models.FileLocations{
+					Block: models.FilePosition{
+						Line: models.Position{Start: 0, End: 0},
+					},
 				},
 			},
 			expectedNamespace: "golang.org/x",
@@ -36,8 +38,10 @@ func TestGolangExtraction_shouldExtractPackages(t *testing.T) {
 				Version:   "v2.26.0",
 				Ecosystem: string(models.EcosystemGo),
 				Commit:    "",
-				BlockLocation: models.FilePosition{
-					Line: models.Position{Start: 0, End: 0},
+				LockfileLocations: models.FileLocations{
+					Block: models.FilePosition{
+						Line: models.Position{Start: 0, End: 0},
+					},
 				},
 			},
 			expectedNamespace: "github.com/urfave/cli",
@@ -50,8 +54,10 @@ func TestGolangExtraction_shouldExtractPackages(t *testing.T) {
 				Version:   "v0.24.0",
 				Ecosystem: string(models.EcosystemGo),
 				Commit:    "",
-				BlockLocation: models.FilePosition{
-					Line: models.Position{Start: 0, End: 0},
+				LockfileLocations: models.FileLocations{
+					Block: models.FilePosition{
+						Line: models.Position{Start: 0, End: 0},
+					},
 				},
 			},
 			expectedNamespace: "",
@@ -91,8 +97,10 @@ func TestGolangExtraction_shouldFilterPackages(t *testing.T) {
 				Version:   "v2.26.0",
 				Ecosystem: string(models.EcosystemGo),
 				Commit:    "",
-				BlockLocation: models.FilePosition{
-					Line: models.Position{Start: 0, End: 0},
+				LockfileLocations: models.FileLocations{
+					Block: models.FilePosition{
+						Line: models.Position{Start: 0, End: 0},
+					},
 				},
 			},
 		},

--- a/pkg/reporter/purl/maven_extractor_test.go
+++ b/pkg/reporter/purl/maven_extractor_test.go
@@ -19,8 +19,10 @@ func TestMavenExtraction_shouldExtractPackages(t *testing.T) {
 			Version:   "1.2.17",
 			Ecosystem: string(models.EcosystemMaven),
 			Commit:    "",
-			BlockLocation: models.FilePosition{
-				Line: models.Position{Start: 0, End: 0},
+			LockfileLocations: models.FileLocations{
+				Block: models.FilePosition{
+					Line: models.Position{Start: 0, End: 0},
+				},
 			},
 		},
 		expectedNamespace: "log4j",
@@ -53,8 +55,10 @@ func TestMavenExtraction_shouldFilterPackages(t *testing.T) {
 				Version:   "1.2.17",
 				Ecosystem: string(models.EcosystemMaven),
 				Commit:    "",
-				BlockLocation: models.FilePosition{
-					Line: models.Position{Start: 0, End: 0},
+				LockfileLocations: models.FileLocations{
+					Block: models.FilePosition{
+						Line: models.Position{Start: 0, End: 0},
+					},
 				},
 			},
 		},
@@ -65,8 +69,10 @@ func TestMavenExtraction_shouldFilterPackages(t *testing.T) {
 				Version:   "1.2.17",
 				Ecosystem: string(models.EcosystemMaven),
 				Commit:    "",
-				BlockLocation: models.FilePosition{
-					Line: models.Position{Start: 0, End: 0},
+				LockfileLocations: models.FileLocations{
+					Block: models.FilePosition{
+						Line: models.Position{Start: 0, End: 0},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
WON'T DO - We will report the source file locations when the lock file is auto generated from the source file: it does not add any value to have also the lock file locations, and it will complicate the schema
