### PR TITLE
🐛 Guarding against exotic dependency in PNPM < v9

### DIFF
--- a/pkg/lockfile/fixtures/pnpm/exotic.yaml
+++ b/pkg/lockfile/fixtures/pnpm/exotic.yaml
@@ -14,5 +14,6 @@ packages:
   github.com/kevva/is-positive:
   example.com/foo/1.2.0:
   example.com/foo/1.3.0_bar@2.0.0:
+  example.com:
   /foo/1.4.0_@types+babel__core@7.1.14:
   /foo/bar:

--- a/pkg/lockfile/parse-pnpm-lock.go
+++ b/pkg/lockfile/parse-pnpm-lock.go
@@ -115,6 +115,12 @@ func extractPnpmPackageNameAndVersion(dependencyPath string, lockfileVersion str
 
 	parts = parts[1:]
 
+	if len(parts) == 0 {
+		// Seems path is not complete (or at least the version is not in the path)
+		// TODO : Investigate when it can happen, this is to stabilize the situation
+		return "", ""
+	}
+
 	if strings.HasPrefix(parts[0], "@") {
 		name = strings.Join(parts[:2], "/")
 		parts = parts[2:]


### PR DESCRIPTION
## About this PR

It seems that in some rare cases (not investigated yet), a dependency in a path shape doesn't mention anything else than its registry.

This is a temporary fix to give us time to investigate more PNPM lockfile generation