### PR TITLE
🐛 Reporting an empty CycloneDX when no packages are found

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -2295,3 +2295,17 @@ No issues found
 Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the filesystem. `scan` is assumed to be a subcommand here. If you intended for `scan` to be an argument to `scan`, you must specify `scan scan` in your command line.
 
 ---
+
+[TestRun_WithEmptyCycloneDX15 - 1]
+{"$schema":"http://cyclonedx.org/schema/bom-1.5.schema.json","bomFormat":"CycloneDX","specVersion":"1.5","version":1,"components":[]}
+
+---
+
+[TestRun_WithEmptyCycloneDX15 - 2]
+Scanning dir ./fixtures/locks-empty
+Scanned /Users/marc.wieser/go/src/github.com/DataDog/osv-scanner/cmd/osv-scanner/fixtures/locks-empty/Gemfile.lock file and found 0 packages
+Scanned /Users/marc.wieser/go/src/github.com/DataDog/osv-scanner/cmd/osv-scanner/fixtures/locks-empty/composer.lock file and found 0 packages
+Scanned /Users/marc.wieser/go/src/github.com/DataDog/osv-scanner/cmd/osv-scanner/fixtures/locks-empty/yarn.lock file and found 0 packages
+No package sources found, --help for usage information.
+
+---

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -1,5 +1,6 @@
 
 [TestRun/#00 - 1]
+No issues found
 
 ---
 
@@ -21,6 +22,7 @@ built at: n/a
 
 [TestRun/#02 - 1]
 Scanning dir ./fixtures/locks-many/not-a-lockfile.toml
+No issues found
 
 ---
 
@@ -1677,6 +1679,7 @@ Loaded OSS-Fuzz local db from <tempdir>/osv-scanner/OSS-Fuzz/all.zip
 
 [TestRun_LocalDatabases/#02 - 1]
 Scanning dir ./fixtures/locks-many/not-a-lockfile.toml
+No issues found
 
 ---
 
@@ -1687,6 +1690,7 @@ No package sources found, --help for usage information.
 
 [TestRun_LocalDatabases/#02 - 3]
 Scanning dir ./fixtures/locks-many/not-a-lockfile.toml
+No issues found
 
 ---
 
@@ -2303,9 +2307,9 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
 
 [TestRun_WithEmptyCycloneDX15 - 2]
 Scanning dir ./fixtures/locks-empty
-Scanned /Users/marc.wieser/go/src/github.com/DataDog/osv-scanner/cmd/osv-scanner/fixtures/locks-empty/Gemfile.lock file and found 0 packages
-Scanned /Users/marc.wieser/go/src/github.com/DataDog/osv-scanner/cmd/osv-scanner/fixtures/locks-empty/composer.lock file and found 0 packages
-Scanned /Users/marc.wieser/go/src/github.com/DataDog/osv-scanner/cmd/osv-scanner/fixtures/locks-empty/yarn.lock file and found 0 packages
+Scanned <rootdir>/fixtures/locks-empty/Gemfile.lock file and found 0 packages
+Scanned <rootdir>/fixtures/locks-empty/composer.lock file and found 0 packages
+Scanned <rootdir>/fixtures/locks-empty/yarn.lock file and found 0 packages
 No package sources found, --help for usage information.
 
 ---

--- a/cmd/osv-scanner/main.go
+++ b/cmd/osv-scanner/main.go
@@ -55,7 +55,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		}
 		switch {
 		case errors.Is(err, osvscanner.VulnerabilitiesFoundErr):
-			return 1
+			return 0
 		case errors.Is(err, osvscanner.NoPackagesFoundErr):
 			r.Errorf("No package sources found, --help for usage information.\n")
 			return 0

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -692,6 +692,29 @@ func TestRun_WithCycloneDX15(t *testing.T) {
 	sbom_test.AssertBomEqual(t, expectedBom, bom, true)
 }
 
+func TestRun_WithEmptyCycloneDX15(t *testing.T) {
+	t.Parallel()
+	args := []string{
+		"",
+		"-r",
+		"--experimental-only-packages",
+		"--format=cyclonedx-1-5",
+		"--consider-scan-path-as-root",
+		"./fixtures/locks-empty",
+	}
+	stdoutBuffer := &bytes.Buffer{}
+	stderrBuffer := &bytes.Buffer{}
+
+	ec := run(args, stdoutBuffer, stderrBuffer)
+
+	if ec != 0 {
+		require.Failf(t, "The run did not finish successfully", "Error code = %v ; Error = %v", ec, stderrBuffer.String())
+	}
+
+	testutility.NewSnapshot().MatchText(t, stdoutBuffer.String())
+	testutility.NewSnapshot().MatchText(t, stderrBuffer.String())
+}
+
 func TestRun_WithExplicitParsers(t *testing.T) {
 	t.Parallel()
 	args := []string{

--- a/cmd/osv-scanner/main_test.go
+++ b/cmd/osv-scanner/main_test.go
@@ -88,13 +88,13 @@ func TestRun(t *testing.T) {
 		{
 			name: "folder of supported sbom with vulns",
 			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/sbom-insecure/"},
-			exit: 1,
+			exit: 0,
 		},
 		// one specific supported sbom with vulns
 		{
 			name: "one specific supported sbom with vulns",
 			args: []string{"", "--config=./fixtures/osv-scanner-empty-config.toml", "--sbom", "./fixtures/sbom-insecure/alpine.cdx.xml"},
-			exit: 1,
+			exit: 0,
 		},
 		// one specific unsupported lockfile
 		{
@@ -158,7 +158,7 @@ func TestRun(t *testing.T) {
 		{
 			name: "Sarif with vulns",
 			args: []string{"", "--format", "sarif", "--config", "./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
-			exit: 1,
+			exit: 0,
 		},
 		// output format: gh-annotations
 		{
@@ -169,13 +169,13 @@ func TestRun(t *testing.T) {
 		{
 			name: "gh-annotations with vulns",
 			args: []string{"", "--format", "gh-annotations", "--config", "./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
-			exit: 1,
+			exit: 0,
 		},
 		// output format: markdown table
 		{
 			name: "",
 			args: []string{"", "--format", "markdown", "--config", "./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
-			exit: 1,
+			exit: 0,
 		},
 		// output format: unsupported
 		{
@@ -234,7 +234,7 @@ func TestRunCallAnalysis(t *testing.T) {
 				"--call-analysis=go",
 				"--config=./fixtures/osv-scanner-empty-config.toml",
 				"./fixtures/call-analysis-go-project"},
-			exit: 1,
+			exit: 0,
 		},
 	}
 	for _, tt := range tests {
@@ -301,7 +301,7 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 				"package-lock.json:" + filepath.FromSlash("./fixtures/locks-insecure/my-package-lock.json"),
 				filepath.FromSlash("./fixtures/locks-insecure"),
 			},
-			exit: 1,
+			exit: 0,
 		},
 		// multiple, + output order is deterministic
 		{
@@ -312,7 +312,7 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 				"-L", "yarn.lock:" + filepath.FromSlash("./fixtures/locks-insecure/my-yarn.lock"),
 				filepath.FromSlash("./fixtures/locks-insecure"),
 			},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "",
@@ -322,7 +322,7 @@ func TestRun_LockfileWithExplicitParseAs(t *testing.T) {
 				"-L", "package-lock.json:" + filepath.FromSlash("./fixtures/locks-insecure/my-package-lock.json"),
 				filepath.FromSlash("./fixtures/locks-insecure"),
 			},
-			exit: 1,
+			exit: 0,
 		},
 		// files that error on parsing stop parsable files from being checked
 		{
@@ -385,12 +385,12 @@ func TestRun_GithubActions(t *testing.T) {
 		{
 			name: "scanning osv-scanner custom format",
 			args: []string{"", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner-flutter-deps.json"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "scanning osv-scanner custom format output json",
 			args: []string{"", "-L", "osv-scanner:./fixtures/locks-insecure/osv-scanner-flutter-deps.json", "--format=sarif"},
-			exit: 1,
+			exit: 0,
 		},
 	}
 	for _, tt := range tests {
@@ -417,7 +417,7 @@ func TestRun_LocalDatabases(t *testing.T) {
 		{
 			name: "",
 			args: []string{"", "--experimental-local-db", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/sbom-insecure/postgres-stretch.cdx.xml"},
-			exit: 1,
+			exit: 0,
 		},
 		// one specific unsupported lockfile
 		{
@@ -516,27 +516,27 @@ func TestRun_Licenses(t *testing.T) {
 		{
 			name: "Vulnerabilities and license summary",
 			args: []string{"", "--experimental-licenses-summary", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "Vulnerabilities and license violations with allowlist",
 			args: []string{"", "--experimental-licenses", "MIT", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "Vulnerabilities and all license violations allowlisted",
 			args: []string{"", "--experimental-licenses", "Apache-2.0", "--config=./fixtures/osv-scanner-empty-config.toml", "./fixtures/locks-many/package-lock.json"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "Some packages with license violations and show-all-packages in json",
 			args: []string{"", "--format=json", "--experimental-licenses", "MIT", "--experimental-all-packages", "./fixtures/locks-licenses/package-lock.json"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "Some packages with license violations in json",
 			args: []string{"", "--format=json", "--experimental-licenses", "MIT", "./fixtures/locks-licenses/package-lock.json"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "No license violations and show-all-packages in json",
@@ -711,8 +711,10 @@ func TestRun_WithEmptyCycloneDX15(t *testing.T) {
 		require.Failf(t, "The run did not finish successfully", "Error code = %v ; Error = %v", ec, stderrBuffer.String())
 	}
 
-	testutility.NewSnapshot().MatchText(t, stdoutBuffer.String())
-	testutility.NewSnapshot().MatchText(t, stderrBuffer.String())
+	stdout := testutility.NormalizeStdStream(t, stdoutBuffer)
+	stderr := testutility.NormalizeStdStream(t, stderrBuffer)
+	testutility.NewSnapshot().MatchText(t, stdout)
+	testutility.NewSnapshot().MatchText(t, stderr)
 }
 
 func TestRun_WithExplicitParsers(t *testing.T) {
@@ -1205,37 +1207,37 @@ func TestRun_OCIImage(t *testing.T) {
 		{
 			name: "Alpine 3.10 image tar with 3.18 version file",
 			args: []string{"", "--experimental-oci-image", "../../internal/image/fixtures/test-alpine.tar"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "scanning node_modules using npm with no packages",
 			args: []string{"", "--experimental-oci-image", "../../internal/image/fixtures/test-node_modules-npm-empty.tar"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "scanning node_modules using npm with some packages",
 			args: []string{"", "--experimental-oci-image", "../../internal/image/fixtures/test-node_modules-npm-full.tar"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "scanning node_modules using yarn with no packages",
 			args: []string{"", "--experimental-oci-image", "../../internal/image/fixtures/test-node_modules-yarn-empty.tar"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "scanning node_modules using yarn with some packages",
 			args: []string{"", "--experimental-oci-image", "../../internal/image/fixtures/test-node_modules-yarn-full.tar"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "scanning node_modules using pnpm with no packages",
 			args: []string{"", "--experimental-oci-image", "../../internal/image/fixtures/test-node_modules-pnpm-empty.tar"},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "scanning node_modules using pnpm with some packages",
 			args: []string{"", "--experimental-oci-image", "../../internal/image/fixtures/test-node_modules-pnpm-full.tar"},
-			exit: 1,
+			exit: 0,
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/osv-scanner/scan/main.go
+++ b/cmd/osv-scanner/scan/main.go
@@ -251,7 +251,7 @@ func action(context *cli.Context, stdout, stderr io.Writer) (reporter.Reporter, 
 		},
 	}, r)
 
-	if err != nil && !errors.Is(err, osvscanner.VulnerabilitiesFoundErr) {
+	if err != nil && !errors.Is(err, osvscanner.NoPackagesFoundErr) && !errors.Is(err, osvscanner.VulnerabilitiesFoundErr) {
 		return r, err
 	}
 


### PR DESCRIPTION
## What does this PR do?

When syncing our fork with the upstream repository, the main method has been splat in multiple functions (one per subcommand), hence overwriting an important change we made and its tests. 

This PR fixes this situation and ensure osv-scanner won't return a non-zero code