### PR TITLE
Adding an action to auto-sync upstream repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DataDog/asm-vm

--- a/.github/workflows/auto-fetch-upstream.yml
+++ b/.github/workflows/auto-fetch-upstream.yml
@@ -1,0 +1,46 @@
+name: 'Upstream Sync'
+
+on:
+  schedule:
+    - cron:  '0 7 * * 1' # scheduled at 07:00 every Monday
+
+  workflow_dispatch:  # click the button on Github repo!
+    inputs:
+      sync_test_mode: # Adds a boolean option that appears during manual workflow run for easy test mode config
+        description: 'Fork Sync Test Mode'
+        type: boolean
+        default: false
+
+jobs:
+  sync_latest_from_upstream:
+    runs-on: ubuntu-latest
+    name: Sync latest commits from upstream repo
+
+    steps:
+      # Step 1: run a standard checkout action, provided by github
+      - name: Checkout target repo
+        uses: actions/checkout@v3
+
+      # Step 2: run the sync action
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
+        with:
+          target_sync_branch: main
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          upstream_sync_branch: main
+          upstream_sync_repo: google/osv-scanner
+          # Set test_mode true during manual dispatch to run tests instead of the true action
+          test_mode: ${{ inputs.sync_test_mode }}
+
+      # Step 3: Display a sample message based on the sync output var 'has_new_commits'
+      - name: New commits found
+        if: steps.sync.outputs.has_new_commits == 'true'
+        run: echo "New commits were found to sync."
+
+      - name: No new commits
+        if: steps.sync.outputs.has_new_commits == 'false'
+        run: echo "There were no new commits."
+
+      - name: Show value of 'has_new_commits'
+        run: echo ${{ steps.sync.outputs.has_new_commits }}

--- a/.github/workflows/auto-fetch-upstream.yml
+++ b/.github/workflows/auto-fetch-upstream.yml
@@ -24,6 +24,8 @@ jobs:
       # Step 1: run a standard checkout action, provided by github
       - name: Checkout target repo
         uses: actions/checkout@v3
+        with:
+          ref: main
 
       # Step 2: run the sync action
       - name: Sync upstream changes

--- a/.github/workflows/auto-fetch-upstream.yml
+++ b/.github/workflows/auto-fetch-upstream.yml
@@ -3,6 +3,10 @@ name: 'Upstream Sync'
 on:
   schedule:
     - cron:  '0 7 * * 1' # scheduled at 07:00 every Monday
+  push: # Only for testing purposes
+    branches:
+      - "marc.wieser/github_action_to_auto-fetch"
+
 
   workflow_dispatch:  # click the button on Github repo!
     inputs:
@@ -31,7 +35,7 @@ jobs:
           upstream_sync_branch: main
           upstream_sync_repo: google/osv-scanner
           # Set test_mode true during manual dispatch to run tests instead of the true action
-          test_mode: ${{ inputs.sync_test_mode }}
+          test_mode: true
 
       # Step 3: Display a sample message based on the sync output var 'has_new_commits'
       - name: New commits found

--- a/.github/workflows/auto-fetch-upstream.yml
+++ b/.github/workflows/auto-fetch-upstream.yml
@@ -1,13 +1,13 @@
-name: 'Upstream Sync'
+name: "Upstream Sync"
 
 on:
   schedule:
-    - cron:  '0 7 * * 1' # scheduled at 07:00 every Monday
+    - cron: "0 7 * * 1" # scheduled at 07:00 every Monday
 
-  workflow_dispatch:  # click the button on Github repo!
+  workflow_dispatch: # click the button on Github repo!
     inputs:
       sync_test_mode: # Adds a boolean option that appears during manual workflow run for easy test mode config
-        description: 'Fork Sync Test Mode'
+        description: "Fork Sync Test Mode"
         type: boolean
         default: false
 

--- a/.github/workflows/auto-fetch-upstream.yml
+++ b/.github/workflows/auto-fetch-upstream.yml
@@ -3,10 +3,6 @@ name: 'Upstream Sync'
 on:
   schedule:
     - cron:  '0 7 * * 1' # scheduled at 07:00 every Monday
-  push: # Only for testing purposes
-    branches:
-      - "marc.wieser/github_action_to_auto-fetch"
-
 
   workflow_dispatch:  # click the button on Github repo!
     inputs:
@@ -37,7 +33,7 @@ jobs:
           upstream_sync_branch: main
           upstream_sync_repo: google/osv-scanner
           # Set test_mode true during manual dispatch to run tests instead of the true action
-          test_mode: true
+          test_mode: ${{ inputs.sync_test_mode }}
 
       # Step 3: Display a sample message based on the sync output var 'has_new_commits'
       - name: New commits found


### PR DESCRIPTION
This PR do 2 things related to contributions : 
- Add a github action to auto sync upstream repository in a regular manner, it will run every monday
- Add a CODEOWNER to enforce a review by asm-vm team