### PR TITLE
[STAL-2295] Downgrade `packageurl-go` to `v0.1.1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.5.9
 	github.com/muesli/reflow v0.3.0
 	github.com/owenrumney/go-sarif/v2 v2.3.3
-	github.com/package-url/packageurl-go v0.1.3
+	github.com/package-url/packageurl-go v0.1.1
 	github.com/pandatix/go-cvss v0.6.2
 	github.com/spdx/tools-golang v0.5.5
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVn
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.3.3 h1:ubWDJcF5i3L/EIOER+ZyQ03IfplbSU1BLOE26uKQIIU=
 github.com/owenrumney/go-sarif/v2 v2.3.3/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=
-github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
-github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/Da5l+RtzyU=
+github.com/package-url/packageurl-go v0.1.1/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pandatix/go-cvss v0.6.2 h1:TFiHlzUkT67s6UkelHmK6s1INKVUG7nlKYiWWDTITGI=
 github.com/pandatix/go-cvss v0.6.2/go.mod h1:jDXYlQBZrc8nvrMUVVvTG8PhmuShOnKrxP53nOFkt8Q=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=

--- a/internal/utility/purl/purl.go
+++ b/internal/utility/purl/purl.go
@@ -19,7 +19,7 @@ var EcosystemToPURLMapper = map[models.Ecosystem]string{
 	models.EcosystemNPM:         packageurl.TypeNPM,
 	models.EcosystemConanCenter: packageurl.TypeConan,
 	models.EcosystemCratesIO:    packageurl.TypeCargo,
-	models.EcosystemPub:         packageurl.TypePub,
+	models.EcosystemPub:         "pub",
 	models.EcosystemHex:         packageurl.TypeHex,
 	models.EcosystemCRAN:        packageurl.TypeCran,
 }

--- a/pkg/reporter/purl/purl.go
+++ b/pkg/reporter/purl/purl.go
@@ -17,7 +17,7 @@ var ecosystemToPURLMapper = map[models.Ecosystem]string{
 	models.EcosystemNPM:         packageurl.TypeNPM,
 	models.EcosystemConanCenter: packageurl.TypeConan,
 	models.EcosystemCratesIO:    packageurl.TypeCargo,
-	models.EcosystemPub:         packageurl.TypePub,
+	models.EcosystemPub:         "pub",
 	models.EcosystemHex:         packageurl.TypeHex,
 	models.EcosystemCRAN:        packageurl.TypeCran,
 }


### PR DESCRIPTION
## What does this PR do?

Downgrade `packageurl-go` to `v0.1.1` as we currently have a mismatch between what versions are using between repositories which results in different results as `v0.1.3` uses a URL encoder.

## Additional Notes
