### PR TITLE
Update go local folder reporting to treat it as internal dependency without known version

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -4882,6 +4882,35 @@ No package sources found, --help for usage information.
       }
     },
     {
+      "bom-ref": "pkg:golang/github.com/Private/packages/pkg/util/backoff@1.0.0",
+      "type": "library",
+      "name": "github.com/Private/packages/pkg/util/backoff",
+      "version": "1.0.0",
+      "licenses": [],
+      "purl": "pkg:golang/github.com/Private/packages/pkg/util/backoff@1.0.0",
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"go.mod/",/"line_start/":10,/"line_end/":10,/"column_start/":1,/"column_end/":101},/"name/":{/"file_name/":/"go.mod/",/"line_start/":10,/"line_end/":10,/"column_start/":50,/"column_end/":94},/"version/":{/"file_name/":/"go.mod/",/"line_start/":10,/"line_end/":10,/"column_start/":96,/"column_end/":101}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kubernetes/apimachinery",
+      "type": "library",
+      "name": "github.com/kubernetes/apimachinery",
+      "licenses": [],
+      "purl": "pkg:golang/github.com/kubernetes/apimachinery",
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{/"block/":{/"file_name/":/"go.mod/",/"line_start/":9,/"line_end/":9,/"column_start/":1,/"column_end/":78}}"
+          }
+        ]
+      }
+    },
+    {
       "bom-ref": "pkg:golang/stdlib@1.21.3",
       "type": "library",
       "name": "stdlib",
@@ -5107,7 +5136,7 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/Gemfile.lock fi
 Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/Pipfile.lock file and found 1 package
 Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/composer/composer.lock file and found 123 packages
 Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/conan.lock file and found 1 package
-Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/go.mod file and found 2 packages
+Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/go.mod file and found 4 packages
 Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/gradle.lockfile file and found 1 package
 Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/mix.lock file and found 1 package
 Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/npm/package-lock.json file and found 1 package
@@ -5120,6 +5149,7 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/pubspec.lock fi
 Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/renv.lock file and found 1 package
 Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/requirements.txt file and found 1 package
 Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-8/yarn/yarn.lock file and found 1 package
+Filtered 1 local package/s from the scan.
 
 ---
 

--- a/cmd/osv-scanner/fixtures/encoding-integration-test-locks/UTF-8/go.mod
+++ b/cmd/osv-scanner/fixtures/encoding-integration-test-locks/UTF-8/go.mod
@@ -3,3 +3,8 @@ module my-library
 go 1.21.3
 
 require github.com/BurntSushi/toml v1.0.0
+require github.com/kubernetes/apimachinery v0.27.16
+require github.com/cenkalti/backoff/v4 v4.3.0
+
+replace github.com/kubernetes/apimachinery => ../../../../../../random-folder
+replace github.com/cenkalti/backoff/v4 v4.3.0 => github.com/Private/packages/pkg/util/backoff v1.0.0

--- a/cmd/osv-scanner/fixtures/encoding-integration-test-locks/UTF-8/go.sum
+++ b/cmd/osv-scanner/fixtures/encoding-integration-test-locks/UTF-8/go.sum
@@ -1,1 +1,2 @@
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/DataDog/apis v1.0.0/go.mod h1:+vx/8Og+LmYCujGqF47DvfXodP4t7vrnbAsS3XDluLM=

--- a/pkg/lockfile/parse-go-lock.go
+++ b/pkg/lockfile/parse-go-lock.go
@@ -2,11 +2,12 @@ package lockfile
 
 import (
 	"fmt"
-	"github.com/google/osv-scanner/internal/cachedregexp"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/osv-scanner/internal/cachedregexp"
 
 	"github.com/google/osv-scanner/internal/utility/fileposition"
 	"golang.org/x/exp/maps"

--- a/pkg/lockfile/parse-go-lock_test.go
+++ b/pkg/lockfile/parse-go-lock_test.go
@@ -560,18 +560,13 @@ func TestParseGoLock_Replacements_Local(t *testing.T) {
 			},
 		},
 		{
-			Name:      "./fork/net",
+			Name:      "golang.org/x/net",
 			Version:   "",
 			Ecosystem: lockfile.GoEcosystem,
 			CompareAs: lockfile.GoEcosystem,
 			BlockLocation: models.FilePosition{
 				Line:     models.Position{Start: 7, End: 7},
 				Column:   models.Position{Start: 5, End: 42},
-				Filename: path,
-			},
-			NameLocation: &models.FilePosition{
-				Line:     models.Position{Start: 7, End: 7},
-				Column:   models.Position{Start: 32, End: 42},
 				Filename: path,
 			},
 		},


### PR DESCRIPTION
## What does this PR do?

This PR aims to solve an issue with go internal links : when a replace is defined on a package, for example : 

```golang
replace go.pkg.in/foo/bar v1.0.0 => ../../foo/bar/
```

Then osv-scanner reports a purl `pkg:golang/../../foo/bar/` which is an invalid one, and which does not give any useful information about the package. To improve this, this PR stops doing the replace on such cases and instead reports the original library name and drop the version as it is a local file. The reported purl will be `pkg:golang/go.pkg.in/foo/bar`

