### PR TITLE
Include "osv-scanner:is-direct-dependency" property on pipfile and poetry

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -6210,6 +6210,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:pypi/markupsafe@2.1.1",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Pipfile"
         }
@@ -6229,6 +6233,10 @@ No package sources found, --help for usage information.
       "version": "1.23.3",
       "purl": "pkg:pypi/numpy@1.23.3",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Poetry"
@@ -9937,6 +9945,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:pypi/markupsafe@2.1.1",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Pipfile"
         }
@@ -9956,6 +9968,10 @@ Filtered 1 local package/s from the scan.
       "version": "1.23.3",
       "purl": "pkg:pypi/numpy@1.23.3",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Poetry"
@@ -13663,6 +13679,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:pypi/markupsafe@2.1.1",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Pipfile"
         }
@@ -13682,6 +13702,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "1.23.3",
       "purl": "pkg:pypi/numpy@1.23.3",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Poetry"

--- a/cmd/osv-scanner/__snapshots__/update_test.snap
+++ b/cmd/osv-scanner/__snapshots__/update_test.snap
@@ -34,7 +34,7 @@ Warning: `update` exists as both a subcommand of OSV-Scanner and as a file on th
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.0-rc1</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pkg/lockfile/match-pipfile.go
+++ b/pkg/lockfile/match-pipfile.go
@@ -50,6 +50,8 @@ func (m PipfileMatcher) Match(sourcefile DepFile, packages []PackageDetails) err
 					versionLocation.Filename = sourcefile.Path()
 					packages[key].VersionLocation = versionLocation
 				}
+
+				packages[key].IsDirect = true
 			}
 		}
 	}

--- a/pkg/lockfile/match-pipfile_test.go
+++ b/pkg/lockfile/match-pipfile_test.go
@@ -87,6 +87,7 @@ func TestPipfileMatcher_Match_OnePackage(t *testing.T) {
 				Column:   models.Position{Start: 15, End: 16},
 				Filename: sourceFile.Path(),
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -149,6 +150,7 @@ func TestPipfileMatcher_Match_TransitiveDependencies(t *testing.T) {
 				Column:   models.Position{Start: 11, End: 15},
 				Filename: sourceFile.Path(),
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "ply",
@@ -168,6 +170,7 @@ func TestPipfileMatcher_Match_TransitiveDependencies(t *testing.T) {
 				Column:   models.Position{Start: 8, End: 12},
 				Filename: sourceFile.Path(),
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "sqlparse",

--- a/pkg/lockfile/match-pyproject-toml_test.go
+++ b/pkg/lockfile/match-pyproject-toml_test.go
@@ -87,6 +87,7 @@ func TestPyprojectTomlMatcher_Match_OnePackage(t *testing.T) {
 				Column:   models.Position{Start: 10, End: 18},
 				Filename: sourceFile.Path(),
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -137,6 +138,7 @@ func TestPyprojectTomlMatcher_Match_TransitiveDependencies(t *testing.T) {
 				Column:   models.Position{Start: 10, End: 18},
 				Filename: sourceFile.Path(),
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "proto-plus",
@@ -156,6 +158,7 @@ func TestPyprojectTomlMatcher_Match_TransitiveDependencies(t *testing.T) {
 				Column:   models.Position{Start: 15, End: 17},
 				Filename: sourceFile.Path(),
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "protobuf",


### PR DESCRIPTION
## What does this PR do?

- Include "osv-scanner:is-direct-dependency" property on Pipenv and Poetry package managers