### PR TITLE
🐛 Fixing maven version and name location on mixed sources

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -1316,6 +1316,7 @@ Filtered 16 vulnerabilities from output
 | https://osv.dev/CVE-2019-5094       | 6.7  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2019-5188       | 6.7  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2022-1304       | 7.8  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DLA-3910-1          |      | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4535-1          |      | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-f3fp-gc8g-vw66 | 5.9  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-g2j6-57v7-gm8c | 6.1  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -1529,6 +1530,7 @@ Filtered 16 vulnerabilities from output
 | https://osv.dev/CVE-2019-5094       | 6.7  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2019-5188       | 6.7  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2022-1304       | 7.8  | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DLA-3910-1          |      | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4535-1          |      | Debian    | e2fsprogs                      | 1.43.4-2+deb9u2                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-f3fp-gc8g-vw66 | 5.9  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/GHSA-g2j6-57v7-gm8c | 6.1  | Go        | github.com/opencontainers/runc | v1.0.1                             | fixtures/sbom-insecure/postgres-stretch.cdx.xml |

--- a/pkg/lockfile/fixtures/maven/two-packages-mixed-version.xml
+++ b/pkg/lockfile/fixtures/maven/two-packages-mixed-version.xml
@@ -1,0 +1,18 @@
+<project>
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.42.${mavenVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/pkg/lockfile/fixtures/maven/two-packages-mixed-version.xml
+++ b/pkg/lockfile/fixtures/maven/two-packages-mixed-version.xml
@@ -11,7 +11,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-log4j12-${mavenVersion}</artifactId>
       <version>1.7.25</version>
     </dependency>
   </dependencies>

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -53,8 +53,9 @@ func buildProjectProperties(lockfile MavenLockFile) map[string]string {
 }
 
 /*
-You can see the regex working here : https://regex101.com/r/inAPiN/2
-*/
+ * You can see the interpolationReg working here : https://regex101.com/r/inAPiN/2
+ * You can see the isMixedReg working here : https://regex101.com/r/KG4tS6/1
+ */
 func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fieldToResolve string) (string, *models.FilePosition) {
 	var position *models.FilePosition
 	variablesCount := 0

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -60,7 +60,9 @@ func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fi
 	variablesCount := 0
 
 	interpolationReg := cachedregexp.MustCompile(`\${([^}]+)}`)
+	isMixedReg := cachedregexp.MustCompile(`.+\${[^}]+}|\$[^}]+}.+`)
 	projectProperties := buildProjectProperties(lockfile)
+	isMixed := isMixedReg.MatchString(fieldToResolve)
 
 	result := interpolationReg.ReplaceAllFunc([]byte(fieldToResolve), func(bytes []byte) []byte {
 		variablesCount += 1
@@ -124,7 +126,7 @@ func (mld MavenLockDependency) resolvePropertiesValue(lockfile MavenLockFile, fi
 		return []byte(property)
 	})
 
-	if variablesCount > 1 {
+	if variablesCount > 1 || isMixed {
 		position = nil
 	}
 

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -182,6 +182,67 @@ func TestParseMavenLock_OnePackageWithMultipleVersionVariable(t *testing.T) {
 	})
 }
 
+func TestParseMavenLock_TwoPackageWithMixedVersionDefinition(t *testing.T) {
+	t.Parallel()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	path := filepath.FromSlash(filepath.Join(dir, "fixtures/maven/two-packages-mixed-version.xml"))
+	packages, err := lockfile.ParseMavenLock(path)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	expectPackages(t, packages, []lockfile.PackageDetails{
+		{
+			Name:           "io.netty:netty-all",
+			Version:        "4.1.42.3.0",
+			PackageManager: models.Maven,
+			Ecosystem:      lockfile.MavenEcosystem,
+			CompareAs:      lockfile.MavenEcosystem,
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 7, End: 11},
+				Column:   models.Position{Start: 5, End: 18},
+				Filename: path,
+			},
+			NameLocation: &models.FilePosition{
+				Line:     models.Position{Start: 9, End: 9},
+				Column:   models.Position{Start: 19, End: 28},
+				Filename: path,
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 10, End: 10},
+				Column:   models.Position{Start: 16, End: 38},
+				Filename: path,
+			},
+		},
+		{
+			Name:           "org.slf4j:slf4j-log4j12",
+			Version:        "1.7.25",
+			Ecosystem:      lockfile.MavenEcosystem,
+			CompareAs:      lockfile.MavenEcosystem,
+			PackageManager: models.Maven,
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 12, End: 16},
+				Column:   models.Position{Start: 5, End: 18},
+				Filename: path,
+			},
+			NameLocation: &models.FilePosition{
+				Line:     models.Position{Start: 14, End: 14},
+				Column:   models.Position{Start: 19, End: 32},
+				Filename: path,
+			},
+			VersionLocation: &models.FilePosition{
+				Line:     models.Position{Start: 15, End: 15},
+				Column:   models.Position{Start: 16, End: 22},
+				Filename: path,
+			},
+		},
+	})
+}
+
 func TestParseMavenLock_TwoPackages(t *testing.T) {
 	t.Parallel()
 	dir, err := os.Getwd()

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -219,7 +219,7 @@ func TestParseMavenLock_TwoPackageWithMixedVersionDefinition(t *testing.T) {
 			},
 		},
 		{
-			Name:           "org.slf4j:slf4j-log4j12",
+			Name:           "org.slf4j:slf4j-log4j12-3.0",
 			Version:        "1.7.25",
 			Ecosystem:      lockfile.MavenEcosystem,
 			CompareAs:      lockfile.MavenEcosystem,
@@ -231,7 +231,7 @@ func TestParseMavenLock_TwoPackageWithMixedVersionDefinition(t *testing.T) {
 			},
 			NameLocation: &models.FilePosition{
 				Line:     models.Position{Start: 14, End: 14},
-				Column:   models.Position{Start: 19, End: 32},
+				Column:   models.Position{Start: 19, End: 48},
 				Filename: path,
 			},
 			VersionLocation: &models.FilePosition{


### PR DESCRIPTION
## What does this PR do?

When a maven dependency is using a mix between a property and a static version, we need to report where the location is used and not where the property is declared. The only moment we want to override the property is when the property is alone in the version tag.
