### PR TITLE
[K9VULN-1326] feat: set IsDirect for direct dependencies in NPM and Maven packages

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -702,6 +702,7 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
             "MIT"
           ],
           "metadata": {
+            "is-direct": "true",
             "package-manager": "NPM"
           }
         },
@@ -740,6 +741,7 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
             "Apache-2.0"
           ],
           "metadata": {
+            "is-direct": "true",
             "package-manager": "NPM"
           }
         },
@@ -778,6 +780,7 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
             "MIT"
           ],
           "metadata": {
+            "is-direct": "true",
             "package-manager": "NPM"
           }
         }
@@ -844,6 +847,7 @@ Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 3 pac
             "MIT"
           ],
           "metadata": {
+            "is-direct": "true",
             "package-manager": "NPM"
           }
         },
@@ -882,6 +886,7 @@ Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 3 pac
             "Apache-2.0"
           ],
           "metadata": {
+            "is-direct": "true",
             "package-manager": "NPM"
           }
         },
@@ -920,6 +925,7 @@ Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 3 pac
             "MIT"
           ],
           "metadata": {
+            "is-direct": "true",
             "package-manager": "NPM"
           }
         }
@@ -1035,6 +1041,7 @@ Filtered 1 vulnerability from output
             "MIT"
           ],
           "metadata": {
+            "is-direct": "true",
             "package-manager": "NPM"
           }
         },
@@ -1076,6 +1083,7 @@ Filtered 1 vulnerability from output
             "Apache-2.0"
           ],
           "metadata": {
+            "is-direct": "true",
             "package-manager": "NPM"
           }
         },
@@ -1114,6 +1122,7 @@ Filtered 1 vulnerability from output
             "MIT"
           ],
           "metadata": {
+            "is-direct": "true",
             "package-manager": "NPM"
           }
         }
@@ -1185,6 +1194,7 @@ Scanned <rootdir>/fixtures/locks-licenses/package-lock.json file and found 3 pac
             "Apache-2.0"
           ],
           "metadata": {
+            "is-direct": "true",
             "package-manager": "NPM"
           }
         }
@@ -1430,6 +1440,7 @@ Filtered 16 vulnerabilities from output
 | https://osv.dev/CVE-2024-4603       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2024-5535       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2024-6119       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/CVE-2024-9143       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3008-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3325-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3449-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -1465,6 +1476,7 @@ Filtered 16 vulnerabilities from output
 | https://osv.dev/CVE-2021-36770      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2023-31484      | 8.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2023-47038      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DLA-3926-1          |      | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3072-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3189-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3316-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -1644,6 +1656,7 @@ Filtered 16 vulnerabilities from output
 | https://osv.dev/CVE-2024-4603       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2024-5535       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2024-6119       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/CVE-2024-9143       |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3008-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3325-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3449-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -1679,6 +1692,7 @@ Filtered 16 vulnerabilities from output
 | https://osv.dev/CVE-2021-36770      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2023-31484      | 8.1  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2023-47038      | 7.8  | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DLA-3926-1          |      | Debian    | perl                           | 5.24.1-3+deb9u7                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3072-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3189-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3316-1          |      | Debian    | postgresql-11                  | 11.15-1.pgdg90+1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -2408,6 +2422,10 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
       "purl": "pkg:maven/com.foobar/common@1.0-SNAPSHOT",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Maven"
         }
@@ -2427,6 +2445,10 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
       "version": "3.0.2",
       "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Maven"
@@ -5999,6 +6021,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Maven"
         }
@@ -6078,6 +6104,10 @@ No package sources found, --help for usage information.
       "version": "1.0.2",
       "purl": "pkg:npm/wrappy@1.0.2",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -9734,6 +9764,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Maven"
         }
@@ -9813,6 +9847,10 @@ Filtered 1 local package/s from the scan.
       "version": "1.0.2",
       "purl": "pkg:npm/wrappy@1.0.2",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -13468,6 +13506,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Maven"
         }
@@ -13547,6 +13589,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "1.0.2",
       "purl": "pkg:npm/wrappy@1.0.2",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NPM"
@@ -13797,6 +13843,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/Windows-1252/yarn/yar
       "purl": "pkg:maven/com.foobar/common@1.0-SNAPSHOT",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Maven"
         }
@@ -13816,6 +13866,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/Windows-1252/yarn/yar
       "version": "3.0.2",
       "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Maven"

--- a/cmd/osv-scanner/__snapshots__/update_test.snap
+++ b/cmd/osv-scanner/__snapshots__/update_test.snap
@@ -34,7 +34,7 @@ Warning: `update` exists as both a subcommand of OSV-Scanner and as a file on th
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.0</version>
+      <version>2.18.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pkg/lockfile/node-modules-npm-v1_test.go
+++ b/pkg/lockfile/node-modules-npm-v1_test.go
@@ -74,6 +74,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackageDev(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  true,
 		},
 	})
 }
@@ -351,7 +352,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-1",
@@ -366,7 +367,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-2",
@@ -409,7 +410,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-3",
@@ -424,7 +425,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-4",
@@ -439,7 +440,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-5",
@@ -454,7 +455,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-6",
@@ -469,7 +470,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "postcss-calc",
@@ -512,7 +513,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 	})
 }
@@ -629,7 +630,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_OptionalPackage(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev", "optional"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "supports-color",

--- a/pkg/lockfile/node-modules-npm-v1_test.go
+++ b/pkg/lockfile/node-modules-npm-v1_test.go
@@ -21,7 +21,6 @@ func TestNodeModulesExtractor_Extract_npm_v1_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, _, err := testParsingNodeModules(t, "fixtures/npm/empty.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -33,7 +32,6 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackage(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/one-package.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -50,6 +48,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackage(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -58,7 +57,6 @@ func TestNodeModulesExtractor_Extract_npm_v1_OnePackageDev(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/one-package-dev.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -84,7 +82,6 @@ func TestNodeModulesExtractor_Extract_npm_v1_TwoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/two-packages.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -101,6 +98,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_TwoPackages(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "supports-color",
@@ -113,6 +111,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_TwoPackages(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -121,7 +120,6 @@ func TestNodeModulesExtractor_Extract_npm_v1_ScopedPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/scoped-packages.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -138,6 +136,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_ScopedPackages(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "@babel/code-frame",
@@ -150,6 +149,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_ScopedPackages(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -158,7 +158,6 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/nested-dependencies.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -175,6 +174,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "postcss",
@@ -187,6 +187,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 9, End: 10},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "postcss-calc",
@@ -199,6 +200,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "supports-color",
@@ -211,6 +213,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 9, End: 10},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "supports-color",
@@ -223,6 +226,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -231,7 +235,6 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependenciesDup(t *testing.T)
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/nested-dependencies-dup.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -252,6 +255,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependenciesDup(t *testing.T)
 			Column:   models.Position{Start: 9, End: 10},
 			Filename: filePath,
 		},
+		IsDirect: true,
 	})
 
 	expectPackage(t, packages, lockfile.PackageDetails{
@@ -265,6 +269,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependenciesDup(t *testing.T)
 			Column:   models.Position{Start: 5, End: 6},
 			Filename: filePath,
 		},
+		IsDirect: true,
 	})
 
 	expectPackage(t, packages, lockfile.PackageDetails{
@@ -278,6 +283,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_NestedDependenciesDup(t *testing.T)
 			Column:   models.Position{Start: 9, End: 10},
 			Filename: filePath,
 		},
+		IsDirect: true,
 	})
 }
 
@@ -285,7 +291,6 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/commits.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -303,6 +308,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "ansi-styles",
@@ -316,6 +322,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "babel-preset-php",
@@ -329,6 +336,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "is-number-1",
@@ -343,6 +351,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-1",
@@ -357,6 +366,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-2",
@@ -370,6 +380,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "is-number-2",
@@ -383,6 +394,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Column:   models.Position{Start: 9, End: 10},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "is-number-3",
@@ -397,6 +409,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-3",
@@ -411,6 +424,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-4",
@@ -425,6 +439,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-5",
@@ -439,6 +454,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-6",
@@ -453,6 +469,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "postcss-calc",
@@ -466,6 +483,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "raven-js",
@@ -479,6 +497,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "slick-carousel",
@@ -493,6 +512,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 	})
 }
@@ -501,7 +521,6 @@ func TestNodeModulesExtractor_Extract_npm_v1_Files(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/files.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -519,6 +538,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Files(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "other_package",
@@ -532,6 +552,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Files(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -540,7 +561,6 @@ func TestNodeModulesExtractor_Extract_npm_v1_Alias(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/alias.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -557,6 +577,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Alias(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "string-width",
@@ -569,6 +590,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Alias(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "string-width",
@@ -581,6 +603,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_Alias(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -589,7 +612,6 @@ func TestNodeModulesExtractor_Extract_npm_v1_OptionalPackage(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/optional-package.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -607,6 +629,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_OptionalPackage(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev", "optional"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "supports-color",
@@ -620,6 +643,7 @@ func TestNodeModulesExtractor_Extract_npm_v1_OptionalPackage(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"optional"},
+			IsDirect:  true,
 		},
 	})
 }

--- a/pkg/lockfile/node-modules-npm-v2_test.go
+++ b/pkg/lockfile/node-modules-npm-v2_test.go
@@ -76,6 +76,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackageDev(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  true,
 		},
 	})
 }
@@ -140,7 +141,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_ScopedPackages(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
-			IsDirect: true,
 		},
 		{
 			Name:           "@babel/code-frame",
@@ -153,7 +153,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_ScopedPackages(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
-			IsDirect: true,
 		},
 	})
 }
@@ -178,7 +177,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
-			IsDirect: true,
 		},
 		{
 			Name:           "postcss",
@@ -191,7 +189,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
-			IsDirect: true,
 		},
 		{
 			Name:           "postcss-calc",
@@ -204,7 +201,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
-			IsDirect: true,
 		},
 		{
 			Name:           "supports-color",
@@ -217,7 +213,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
-			IsDirect: true,
 		},
 		{
 			Name:           "supports-color",
@@ -230,7 +225,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
-			IsDirect: true,
 		},
 	})
 }
@@ -255,7 +249,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependenciesDup(t *testing.T)
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
-			IsDirect: true,
 		},
 		{
 			Name:           "supports-color",
@@ -268,7 +261,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependenciesDup(t *testing.T)
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
-			IsDirect: true,
 		},
 	})
 }
@@ -309,7 +301,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
-			IsDirect: true,
+			IsDirect: false,
 		},
 		{
 			Name:           "babel-preset-php",
@@ -325,7 +317,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-1",
@@ -341,7 +333,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-1",
@@ -372,7 +364,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-2",
@@ -403,7 +395,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-3",
@@ -434,7 +426,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-5",
@@ -450,7 +442,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "postcss-calc",
@@ -464,7 +456,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
-			IsDirect: true,
+			IsDirect: false,
 		},
 		{
 			Name:           "raven-js",
@@ -495,7 +487,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 	})
 }
@@ -523,6 +515,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Files(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  true,
 		},
 		{
 			Name:           "abbrev",
@@ -631,6 +624,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OptionalPackage(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"optional"},
+			IsDirect:  true,
 		},
 		{
 			Name:           "supports-color",

--- a/pkg/lockfile/node-modules-npm-v2_test.go
+++ b/pkg/lockfile/node-modules-npm-v2_test.go
@@ -21,7 +21,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, _, err := testParsingNodeModules(t, "fixtures/npm/empty.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -33,7 +32,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackage(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/one-package.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -51,6 +49,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackage(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -59,7 +58,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_OnePackageDev(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/one-package-dev.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -86,7 +84,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_TwoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/two-packages.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -104,6 +101,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_TwoPackages(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "supports-color",
@@ -117,6 +115,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_TwoPackages(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -125,7 +124,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_ScopedPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/scoped-packages.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -142,6 +140,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_ScopedPackages(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "@babel/code-frame",
@@ -154,6 +153,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_ScopedPackages(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -162,7 +162,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/nested-dependencies.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -179,6 +178,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "postcss",
@@ -191,6 +191,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "postcss-calc",
@@ -203,6 +204,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "supports-color",
@@ -215,6 +217,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "supports-color",
@@ -227,6 +230,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependencies(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -235,7 +239,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependenciesDup(t *testing.T)
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/nested-dependencies-dup.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -252,6 +255,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependenciesDup(t *testing.T)
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "supports-color",
@@ -264,6 +268,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_NestedDependenciesDup(t *testing.T)
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -272,7 +277,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/commits.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -291,6 +295,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "ansi-styles",
@@ -304,6 +309,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "babel-preset-php",
@@ -319,6 +325,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-1",
@@ -334,6 +341,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-1",
@@ -348,6 +356,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-2",
@@ -363,6 +372,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-2",
@@ -377,6 +387,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-3",
@@ -392,6 +403,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-3",
@@ -406,6 +418,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-4",
@@ -421,6 +434,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-5",
@@ -436,6 +450,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "postcss-calc",
@@ -449,6 +464,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "raven-js",
@@ -463,6 +479,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "slick-carousel",
@@ -478,6 +495,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Commits(t *testing.T) {
 				Filename: filePath,
 			},
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 	})
 }
@@ -486,7 +504,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_Files(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/files.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -542,7 +559,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_Alias(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/alias.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -560,6 +576,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Alias(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "string-width",
@@ -573,6 +590,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Alias(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "string-width",
@@ -586,6 +604,7 @@ func TestNodeModulesExtractor_Extract_npm_v2_Alias(t *testing.T) {
 				Column:   models.Position{Start: 5, End: 6},
 				Filename: filePath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -594,7 +613,6 @@ func TestNodeModulesExtractor_Extract_npm_v2_OptionalPackage(t *testing.T) {
 	t.Parallel()
 
 	packages, filePath, err := testParsingNodeModules(t, "fixtures/npm/optional-package.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}

--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -445,6 +445,7 @@ func (e MavenLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 			NameLocation:    artifactPosition,
 			VersionLocation: versionPosition,
 			PackageManager:  models.Maven,
+			IsDirect:        true,
 		}
 		if scope := strings.TrimSpace(lockPackage.Scope); scope != "" && scope != "compile" {
 			// Only append non-default scope (compile is the default scope).

--- a/pkg/lockfile/parse-maven-lock_test.go
+++ b/pkg/lockfile/parse-maven-lock_test.go
@@ -96,7 +96,6 @@ func TestParseMavenLock_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseMavenLock(filepath.FromSlash("fixtures/maven/empty.xml"))
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -139,6 +138,7 @@ func TestParseMavenLock_OnePackage(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 21},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -178,6 +178,7 @@ func TestParseMavenLock_OnePackageWithMultipleVersionVariable(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 40},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -217,6 +218,7 @@ func TestParseMavenLock_TwoPackageWithMixedVersionDefinition(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 38},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.slf4j:slf4j-log4j12-3.0",
@@ -239,6 +241,7 @@ func TestParseMavenLock_TwoPackageWithMixedVersionDefinition(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 22},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -278,6 +281,7 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 28},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.slf4j:slf4j-log4j12",
@@ -300,6 +304,7 @@ func TestParseMavenLock_TwoPackages(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 22},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -339,6 +344,7 @@ func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 				Column:   models.Position{Start: 18, End: 30},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.slf4j:slf4j-log4j12",
@@ -361,6 +367,7 @@ func TestParseMavenLock_WithDependencyManagement(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 22},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -400,6 +407,7 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 				Column:   models.Position{Start: 23, End: 28},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.mine:my.package",
@@ -422,6 +430,7 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 				Column:   models.Position{Start: 25, End: 30},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.mine:ranged-package",
@@ -444,6 +453,7 @@ func TestParseMavenLock_Interpolation(t *testing.T) {
 				Column:   models.Position{Start: 20, End: 42},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -484,6 +494,7 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Column:   models.Position{Start: 18, End: 23},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "io.netty:netty-all",
@@ -506,6 +517,7 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Column:   models.Position{Start: 18, End: 30},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.slf4j:slf4j-log4j12",
@@ -528,6 +540,7 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 22},
 				Filename: childPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.mine:mypackage",
@@ -550,6 +563,7 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Column:   models.Position{Start: 23, End: 28},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.mine:my.package",
@@ -572,6 +586,7 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Column:   models.Position{Start: 25, End: 30},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "dev.foo:bar",
@@ -594,6 +609,7 @@ func TestMavenLock_WithParent(t *testing.T) {
 				Column:   models.Position{Start: 12, End: 24},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -634,6 +650,7 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 				Column:   models.Position{Start: 18, End: 23},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "io.netty:netty-all",
@@ -656,6 +673,7 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 				Column:   models.Position{Start: 18, End: 30},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.slf4j:slf4j-log4j12",
@@ -678,6 +696,7 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 22},
 				Filename: childPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.mine:mypackage",
@@ -700,6 +719,7 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 				Column:   models.Position{Start: 23, End: 28},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.mine:my.package",
@@ -722,6 +742,7 @@ func TestMavenLock_WithParentDirOnly(t *testing.T) {
 				Column:   models.Position{Start: 25, End: 30},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -762,6 +783,7 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 				Column:   models.Position{Start: 18, End: 23},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "io.netty:netty-all",
@@ -784,6 +806,7 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 				Column:   models.Position{Start: 18, End: 30},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.slf4j:slf4j-log4j12",
@@ -806,6 +829,7 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 22},
 				Filename: childPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.mine:mypackage",
@@ -828,6 +852,7 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 				Column:   models.Position{Start: 23, End: 28},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.mine:my.package",
@@ -850,6 +875,7 @@ func TestMavenLock_WithParentWithoutRelativePath(t *testing.T) {
 				Column:   models.Position{Start: 25, End: 30},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -890,6 +916,7 @@ func TestMavenLock_WithParent_Child_Project(t *testing.T) {
 				Column:   models.Position{Start: 12, End: 30},
 				Filename: childPath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -931,6 +958,7 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Column:   models.Position{Start: 18, End: 23},
 				Filename: rootPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "io.netty:netty-all",
@@ -953,6 +981,7 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Column:   models.Position{Start: 18, End: 30},
 				Filename: rootPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.slf4j:slf4j-log4j12",
@@ -975,6 +1004,7 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 22},
 				Filename: parentPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.mine:mypackage",
@@ -997,6 +1027,7 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Column:   models.Position{Start: 23, End: 28},
 				Filename: rootPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "org.mine:my.package",
@@ -1019,6 +1050,7 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Column:   models.Position{Start: 20, End: 42},
 				Filename: rootPath,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "dev.foo:bar",
@@ -1041,6 +1073,7 @@ func TestMavenLock_WithMultipleParents(t *testing.T) {
 				Column:   models.Position{Start: 12, End: 24},
 				Filename: rootPath,
 			},
+			IsDirect: true,
 		},
 	})
 }
@@ -1167,6 +1200,7 @@ func TestParseMavenLock_WithScope(t *testing.T) {
 				Column:   models.Position{Start: 16, End: 21},
 				Filename: path,
 			},
+			IsDirect: true,
 		},
 		{
 			Name:           "junit:junit",
@@ -1191,6 +1225,7 @@ func TestParseMavenLock_WithScope(t *testing.T) {
 				Filename: path,
 			},
 			DepGroups: []string{"test"},
+			IsDirect:  true,
 		},
 	})
 }
@@ -1232,6 +1267,7 @@ func TestParseMavenLock_WithUnusedDependencyManagementDependencies(t *testing.T)
 				Filename: path,
 			},
 			DepGroups: nil,
+			IsDirect:  true,
 		},
 	})
 }
@@ -1273,6 +1309,7 @@ func TestParseMavenLock_WithOverriddenDependencyVersions(t *testing.T) {
 				Filename: path,
 			},
 			DepGroups: nil,
+			IsDirect:  true,
 		},
 	})
 }
@@ -1314,6 +1351,7 @@ func TestParseMavenLock_WithProjectVersionProperty(t *testing.T) {
 				Filename: path,
 			},
 			DepGroups: nil,
+			IsDirect:  true,
 		},
 		{
 			Name:           "dev.bar:foo",
@@ -1338,6 +1376,7 @@ func TestParseMavenLock_WithProjectVersionProperty(t *testing.T) {
 				Filename: path,
 			},
 			DepGroups: nil,
+			IsDirect:  true,
 		},
 	})
 }
@@ -1375,6 +1414,7 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 				Filename: path,
 			},
 			DepGroups: nil,
+			IsDirect:  true,
 		},
 		{
 			Name:           "com.google.code.findbugs:jsr305",
@@ -1399,6 +1439,7 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 				Filename: path,
 			},
 			DepGroups: nil,
+			IsDirect:  true,
 		},
 		{
 			Name:           "io.ktor:ktor-server-netty-jvm",
@@ -1423,6 +1464,7 @@ func TestParseMavenLock_ResolveProperties(t *testing.T) {
 				Filename: path,
 			},
 			DepGroups: nil,
+			IsDirect:  true,
 		},
 	})
 }
@@ -1431,7 +1473,6 @@ func TestParseMavenLock_NoVersion(t *testing.T) {
 	t.Parallel()
 	lockfileRelativePath := "fixtures/maven/no-version.xml"
 	packages, err := lockfile.ParseMavenLock(lockfileRelativePath)
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -1443,6 +1484,7 @@ func TestParseMavenLock_NoVersion(t *testing.T) {
 			PackageManager: models.Maven,
 			Ecosystem:      lockfile.MavenEcosystem,
 			CompareAs:      lockfile.MavenEcosystem,
+			IsDirect:       true,
 		},
 	})
 }

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -96,6 +96,7 @@ func TestParseNpmLock_v1_OnePackageDev(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev"},
+			IsDirect:  true,
 		},
 	})
 }
@@ -398,7 +399,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-1",
@@ -413,7 +414,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-2",
@@ -456,7 +457,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-3",
@@ -471,7 +472,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-4",
@@ -486,7 +487,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-5",
@@ -501,7 +502,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-6",
@@ -516,7 +517,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "postcss-calc",
@@ -559,7 +560,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "280b560161b751ba226d50c7db1e0a14a78c2de0",
 			DepGroups: []string{"dev"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 	})
 }
@@ -691,7 +692,7 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev", "optional"},
-			IsDirect:  false,
+			IsDirect:  true,
 		},
 		{
 			Name:           "supports-color",
@@ -726,7 +727,7 @@ func TestParseNpmLock_v1_SamePackageDifferentGroups(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			DepGroups:      []string{"dev"},
-			IsDirect:       false,
+			IsDirect:       true,
 		},
 		{
 			Name:           "table",

--- a/pkg/lockfile/parse-npm-lock-v1_test.go
+++ b/pkg/lockfile/parse-npm-lock-v1_test.go
@@ -33,7 +33,6 @@ func TestParseNpmLock_v1_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseNpmLock("fixtures/npm/empty.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -66,6 +65,7 @@ func TestParseNpmLock_v1_OnePackage(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 	})
 }
@@ -125,6 +125,7 @@ func TestParseNpmLock_v1_TwoPackages(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 		{
 			Name:           "supports-color",
@@ -137,6 +138,7 @@ func TestParseNpmLock_v1_TwoPackages(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 	})
 }
@@ -166,6 +168,7 @@ func TestParseNpmLock_v1_ScopedPackages(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 		{
 			Name:           "@babel/code-frame",
@@ -178,6 +181,7 @@ func TestParseNpmLock_v1_ScopedPackages(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 	})
 }
@@ -207,6 +211,7 @@ func TestParseNpmLock_v1_NestedDependencies(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 		{
 			Name:           "postcss",
@@ -219,6 +224,7 @@ func TestParseNpmLock_v1_NestedDependencies(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 		{
 			Name:           "postcss-calc",
@@ -231,6 +237,7 @@ func TestParseNpmLock_v1_NestedDependencies(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 		{
 			Name:           "supports-color",
@@ -243,6 +250,7 @@ func TestParseNpmLock_v1_NestedDependencies(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 		{
 			Name:           "supports-color",
@@ -255,6 +263,7 @@ func TestParseNpmLock_v1_NestedDependencies(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 	})
 }
@@ -288,6 +297,7 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		},
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
+		IsDirect:  true,
 	})
 
 	expectPackage(t, packages, lockfile.PackageDetails{
@@ -301,6 +311,7 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		},
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
+		IsDirect:  true,
 	})
 
 	expectPackage(t, packages, lockfile.PackageDetails{
@@ -314,6 +325,7 @@ func TestParseNpmLock_v1_NestedDependenciesDup(t *testing.T) {
 		},
 		Ecosystem: lockfile.NpmEcosystem,
 		CompareAs: lockfile.NpmEcosystem,
+		IsDirect:  true,
 	})
 }
 
@@ -343,6 +355,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "3b1bb80b302c2e552685dc8a029797ec832ea7c9",
+			IsDirect:  true,
 		},
 		{
 			Name:           "ansi-styles",
@@ -356,6 +369,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			IsDirect:  true,
 		},
 		{
 			Name:           "babel-preset-php",
@@ -369,6 +383,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-1",
@@ -383,6 +398,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-1",
@@ -397,6 +413,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "be5935f8d2595bcd97b05718ef1eeae08d812e10",
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-2",
@@ -410,6 +427,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-2",
@@ -423,6 +441,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82dcc8e914dabd9305ab9ae580709a7825e824f5",
+			IsDirect:  true,
 		},
 		{
 			Name:           "is-number-3",
@@ -437,6 +456,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-3",
@@ -451,6 +471,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-4",
@@ -465,6 +486,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-5",
@@ -479,6 +501,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "is-number-6",
@@ -493,6 +516,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "postcss-calc",
@@ -506,6 +530,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			IsDirect:  true,
 		},
 		{
 			Name:           "raven-js",
@@ -519,6 +544,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "c2b377e7a254264fd4a1fe328e4e3cfc9e245570",
+			IsDirect:  true,
 		},
 		{
 			Name:           "slick-carousel",
@@ -533,6 +559,7 @@ func TestParseNpmLock_v1_Commits(t *testing.T) {
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "280b560161b751ba226d50c7db1e0a14a78c2de0",
 			DepGroups: []string{"dev"},
+			IsDirect:  false,
 		},
 	})
 }
@@ -563,6 +590,7 @@ func TestParseNpmLock_v1_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			IsDirect:  true,
 		},
 		{
 			Name:           "other_package",
@@ -576,6 +604,7 @@ func TestParseNpmLock_v1_Files(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			Commit:    "",
+			IsDirect:  true,
 		},
 	})
 }
@@ -605,6 +634,7 @@ func TestParseNpmLock_v1_Alias(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 		{
 			Name:           "string-width",
@@ -617,6 +647,7 @@ func TestParseNpmLock_v1_Alias(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 		{
 			Name:           "string-width",
@@ -629,6 +660,7 @@ func TestParseNpmLock_v1_Alias(t *testing.T) {
 			},
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
+			IsDirect:  true,
 		},
 	})
 }
@@ -659,6 +691,7 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"dev", "optional"},
+			IsDirect:  false,
 		},
 		{
 			Name:           "supports-color",
@@ -672,6 +705,7 @@ func TestParseNpmLock_v1_OptionalPackage(t *testing.T) {
 			Ecosystem: lockfile.NpmEcosystem,
 			CompareAs: lockfile.NpmEcosystem,
 			DepGroups: []string{"optional"},
+			IsDirect:  true,
 		},
 	})
 }
@@ -680,7 +714,6 @@ func TestParseNpmLock_v1_SamePackageDifferentGroups(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseNpmLock("fixtures/npm/same-package-different-groups.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -693,6 +726,7 @@ func TestParseNpmLock_v1_SamePackageDifferentGroups(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 		{
 			Name:           "table",
@@ -700,6 +734,7 @@ func TestParseNpmLock_v1_SamePackageDifferentGroups(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "ajv",
@@ -707,6 +742,7 @@ func TestParseNpmLock_v1_SamePackageDifferentGroups(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -159,6 +159,7 @@ func TestParseNpmLock_v2_OnePackageDev(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			DepGroups:      []string{"dev"},
+			IsDirect:       true,
 		},
 	})
 }
@@ -185,6 +186,7 @@ func TestParseNpmLock_v2_LinkDependency(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			DepGroups:      []string{"dev"},
+			IsDirect:       true,
 		},
 	})
 }
@@ -244,7 +246,6 @@ func TestParseNpmLock_v2_ScopedPackages(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			IsDirect:       true,
 		},
 		{
 			Name:           "@babel/code-frame",
@@ -252,7 +253,6 @@ func TestParseNpmLock_v2_ScopedPackages(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			IsDirect:       true,
 		},
 	})
 }
@@ -277,7 +277,6 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			IsDirect:       true,
 		},
 		{
 			Name:           "postcss",
@@ -285,7 +284,6 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			IsDirect:       true,
 		},
 		{
 			Name:           "postcss-calc",
@@ -293,7 +291,6 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			IsDirect:       true,
 		},
 		{
 			Name:           "supports-color",
@@ -301,7 +298,6 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			IsDirect:       true,
 		},
 		{
 			Name:           "supports-color",
@@ -309,7 +305,6 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			IsDirect:       true,
 		},
 	})
 }
@@ -334,7 +329,6 @@ func TestParseNpmLock_v2_NestedDependenciesDup(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			IsDirect:       true,
 		},
 		{
 			Name:           "supports-color",
@@ -342,7 +336,6 @@ func TestParseNpmLock_v2_NestedDependenciesDup(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			IsDirect:       true,
 		},
 	})
 }
@@ -378,7 +371,6 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
-			IsDirect:       true,
 		},
 		{
 			Name:           "babel-preset-php",
@@ -389,7 +381,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
 			DepGroups:      []string{"dev"},
-			IsDirect:       false,
+			IsDirect:       true,
 		},
 		{
 			Name:           "is-number-1",
@@ -400,7 +392,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups:      []string{"dev"},
-			IsDirect:       false,
+			IsDirect:       true,
 		},
 		{
 			Name:           "is-number-1",
@@ -421,7 +413,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
 			DepGroups:      []string{"dev"},
-			IsDirect:       false,
+			IsDirect:       true,
 		},
 		{
 			Name:           "is-number-2",
@@ -442,7 +434,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
 			DepGroups:      []string{"dev"},
-			IsDirect:       false,
+			IsDirect:       true,
 		},
 		{
 			Name:           "is-number-3",
@@ -463,7 +455,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups:      []string{"dev"},
-			IsDirect:       false,
+			IsDirect:       true,
 		},
 		{
 			Name:           "is-number-5",
@@ -474,7 +466,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups:      []string{"dev"},
-			IsDirect:       false,
+			IsDirect:       true,
 		},
 		{
 			Name:           "postcss-calc",
@@ -483,7 +475,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
-			IsDirect:       true,
+			IsDirect:       false,
 		},
 		{
 			Name:           "raven-js",
@@ -504,7 +496,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "280b560161b751ba226d50c7db1e0a14a78c2de0",
 			DepGroups:      []string{"dev"},
-			IsDirect:       false,
+			IsDirect:       true,
 		},
 	})
 }
@@ -532,6 +524,7 @@ func TestParseNpmLock_v2_Files(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
 			DepGroups:      []string{"dev"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "abbrev",
@@ -620,6 +613,7 @@ func TestParseNpmLock_v2_OptionalPackage(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			DepGroups:      []string{"optional"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "supports-color",
@@ -648,7 +642,6 @@ func TestParseNpmLock_v2_SamePackageDifferentGroups(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			DepGroups:      []string{"dev"},
-			IsDirect:       false,
 		},
 		{
 			Name:           "table",
@@ -656,7 +649,6 @@ func TestParseNpmLock_v2_SamePackageDifferentGroups(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			IsDirect:       true,
 		},
 		{
 			Name:           "ajv",
@@ -664,7 +656,6 @@ func TestParseNpmLock_v2_SamePackageDifferentGroups(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
-			IsDirect:       false,
 		},
 	})
 }

--- a/pkg/lockfile/parse-npm-lock-v2_test.go
+++ b/pkg/lockfile/parse-npm-lock-v2_test.go
@@ -81,6 +81,7 @@ func TestParseNpmLock_v2_OnePackage(t *testing.T) {
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -128,6 +129,7 @@ func TestParseNpmLock_v2_OnePackage_MatcherFailed(t *testing.T) {
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 
@@ -208,6 +210,7 @@ func TestParseNpmLock_v2_TwoPackages(t *testing.T) {
 			TargetVersions: []string{"^1.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "supports-color",
@@ -216,6 +219,7 @@ func TestParseNpmLock_v2_TwoPackages(t *testing.T) {
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -240,6 +244,7 @@ func TestParseNpmLock_v2_ScopedPackages(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "@babel/code-frame",
@@ -247,6 +252,7 @@ func TestParseNpmLock_v2_ScopedPackages(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -271,6 +277,7 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "postcss",
@@ -278,6 +285,7 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "postcss-calc",
@@ -285,6 +293,7 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "supports-color",
@@ -292,6 +301,7 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "supports-color",
@@ -299,6 +309,7 @@ func TestParseNpmLock_v2_NestedDependencies(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -323,6 +334,7 @@ func TestParseNpmLock_v2_NestedDependenciesDup(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "supports-color",
@@ -330,6 +342,7 @@ func TestParseNpmLock_v2_NestedDependenciesDup(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -356,6 +369,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "3b1bb80b302c2e552685dc8a029797ec832ea7c9",
+			IsDirect:       true,
 		},
 		{
 			Name:           "ansi-styles",
@@ -364,6 +378,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
+			IsDirect:       true,
 		},
 		{
 			Name:           "babel-preset-php",
@@ -374,6 +389,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "c5a7ba5e0ad98b8db1cb8ce105403dd4b768cced",
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 		{
 			Name:           "is-number-1",
@@ -384,6 +400,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 		{
 			Name:           "is-number-1",
@@ -393,6 +410,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "be5935f8d2595bcd97b05718ef1eeae08d812e10",
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 		{
 			Name:           "is-number-2",
@@ -403,6 +421,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 		{
 			Name:           "is-number-2",
@@ -412,6 +431,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "82dcc8e914dabd9305ab9ae580709a7825e824f5",
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 		{
 			Name:           "is-number-3",
@@ -422,6 +442,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 		{
 			Name:           "is-number-3",
@@ -431,6 +452,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "82ae8802978da40d7f1be5ad5943c9e550ab2c89",
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 		{
 			Name:           "is-number-4",
@@ -441,6 +463,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 		{
 			Name:           "is-number-5",
@@ -451,6 +474,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "af885e2e890b9ef0875edd2b117305119ee5bdc5",
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 		{
 			Name:           "postcss-calc",
@@ -459,6 +483,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
+			IsDirect:       true,
 		},
 		{
 			Name:           "raven-js",
@@ -468,6 +493,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "c2b377e7a254264fd4a1fe328e4e3cfc9e245570",
+			IsDirect:       true,
 		},
 		{
 			Name:           "slick-carousel",
@@ -478,6 +504,7 @@ func TestParseNpmLock_v2_Commits(t *testing.T) {
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "280b560161b751ba226d50c7db1e0a14a78c2de0",
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 	})
 }
@@ -548,6 +575,7 @@ func TestParseNpmLock_v2_Alias(t *testing.T) {
 			TargetVersions: []string{"^7.0.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "string-width",
@@ -556,6 +584,7 @@ func TestParseNpmLock_v2_Alias(t *testing.T) {
 			TargetVersions: []string{"^4.2.0"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "string-width",
@@ -564,6 +593,7 @@ func TestParseNpmLock_v2_Alias(t *testing.T) {
 			TargetVersions: []string{"^5.1.2"},
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -606,7 +636,6 @@ func TestParseNpmLock_v2_SamePackageDifferentGroups(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseNpmLock("fixtures/npm/same-package-different-groups.v2.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -619,6 +648,7 @@ func TestParseNpmLock_v2_SamePackageDifferentGroups(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			DepGroups:      []string{"dev"},
+			IsDirect:       false,
 		},
 		{
 			Name:           "table",
@@ -626,6 +656,7 @@ func TestParseNpmLock_v2_SamePackageDifferentGroups(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "ajv",
@@ -633,6 +664,7 @@ func TestParseNpmLock_v2_SamePackageDifferentGroups(t *testing.T) {
 			PackageManager: models.NPM,
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
+			IsDirect:       false,
 		},
 	})
 }

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -137,7 +137,6 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency, path s
 
 		version := detail.Version
 		finalVersion := version
-		direct := !detail.Dev
 		commit := ""
 
 		// If the package is aliased, get the name and version
@@ -177,7 +176,7 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency, path s
 			},
 			Commit:    commit,
 			DepGroups: detail.depGroups(),
-			IsDirect:  direct,
+			IsDirect:  true,
 		})
 	}
 
@@ -253,11 +252,14 @@ func parseNpmLockPackages(packages map[string]*NpmLockPackage, path string) map[
 		// the dependencies with the version written as it appears in the package.json
 		var targetVersions []string
 		var targetVersion string
+		var isDirect bool
 		rootKey := extractRootKeyPackageName(namePath)
 		if p, ok := packages[""]; ok {
 			if dep, ok := p.Dependencies[rootKey]; ok {
 				targetVersion = dep
+				isDirect = true
 			} else if devDep, ok := p.DevDependencies[rootKey]; ok {
+				isDirect = true
 				targetVersion = devDep
 			}
 		}
@@ -280,8 +282,6 @@ func parseNpmLockPackages(packages map[string]*NpmLockPackage, path string) map[
 			targetVersions = []string{targetVersion}
 		}
 
-		direct := !detail.Dev && !detail.Optional && !detail.DevOptional && strings.HasPrefix(namePath, "node_modules/")
-
 		if !detail.Link {
 			details.add(finalName+"@"+finalVersion, PackageDetails{
 				Name:           finalName,
@@ -297,7 +297,7 @@ func parseNpmLockPackages(packages map[string]*NpmLockPackage, path string) map[
 					Filename: path,
 				},
 				DepGroups: detail.depGroups(),
-				IsDirect:  direct,
+				IsDirect:  isDirect,
 			})
 		}
 	}

--- a/pkg/lockfile/parse-npm-lock.go
+++ b/pkg/lockfile/parse-npm-lock.go
@@ -137,6 +137,7 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency, path s
 
 		version := detail.Version
 		finalVersion := version
+		direct := !detail.Dev
 		commit := ""
 
 		// If the package is aliased, get the name and version
@@ -176,6 +177,7 @@ func parseNpmLockDependencies(dependencies map[string]*NpmLockDependency, path s
 			},
 			Commit:    commit,
 			DepGroups: detail.depGroups(),
+			IsDirect:  direct,
 		})
 	}
 
@@ -278,6 +280,8 @@ func parseNpmLockPackages(packages map[string]*NpmLockPackage, path string) map[
 			targetVersions = []string{targetVersion}
 		}
 
+		direct := !detail.Dev && !detail.Optional && !detail.DevOptional && strings.HasPrefix(namePath, "node_modules/")
+
 		if !detail.Link {
 			details.add(finalName+"@"+finalVersion, PackageDetails{
 				Name:           finalName,
@@ -293,6 +297,7 @@ func parseNpmLockPackages(packages map[string]*NpmLockPackage, path string) map[
 					Filename: path,
 				},
 				DepGroups: detail.depGroups(),
+				IsDirect:  direct,
 			})
 		}
 	}


### PR DESCRIPTION
### Problem

Currently, we do not mark dependencies as direct for NPM or Maven packages, which is necessary so we can filter out direct dependencies when we ingest this data.

### Solution

Set the IsDirect field for NPM and Maven packages. In Maven, all packages are direct so this is always true. But in NPM, that's not the case. The heuristics for setting IsDirect to true for NPM packages is solely based on whether or not the package is present in the list of `dependencies` or `devDependencies` for the root packge `""`. When we're dealing with older npm lockfiles (v1), we always set `IsDirect` to true since everything is thrown under the dependencies object here.