### PR TITLE
[K9VULN-1326] feat: set IsDirect for direct dependencies in PNPM and Yarn packages

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -1445,6 +1445,8 @@ Filtered 16 vulnerabilities from output
 | https://osv.dev/DLA-3325-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3449-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3530-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DLA-3942-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DLA-3942-2          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4539-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4539-3          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4661-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -1661,6 +1663,8 @@ Filtered 16 vulnerabilities from output
 | https://osv.dev/DLA-3325-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3449-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DLA-3530-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DLA-3942-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DLA-3942-2          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4539-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4539-3          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-4661-1          |      | Debian    | openssl                        | 1.1.0l-1~deb9u5                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
@@ -6089,6 +6093,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -9836,6 +9844,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"
         }
@@ -13581,6 +13593,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "1.0.2",
       "purl": "pkg:npm/balanced-match@1.0.2",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Yarn"

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -6065,6 +6065,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:npm/acorn@8.7.0",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Pnpm"
         }
@@ -9808,6 +9812,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:npm/acorn@8.7.0",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Pnpm"
         }
@@ -13549,6 +13557,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "8.7.0",
       "purl": "pkg:npm/acorn@8.7.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Pnpm"

--- a/pkg/lockfile/__snapshots__/match-package-json_test.snap
+++ b/pkg/lockfile/__snapshots__/match-package-json_test.snap
@@ -40,7 +40,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/name-conflict/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "aws-sdk-client-mock-jest",
@@ -80,7 +81,8 @@
         "end": 30
       },
       "file_name": "<rootdir>/fixtures/package-json/name-conflict/package.json"
-    }
+    },
+    "isDirect": true
   }
 ]
 ---
@@ -126,7 +128,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/one-package/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   }
 ]
 ---
@@ -172,7 +175,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/resolutions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "fast-xml-parser",
@@ -212,7 +216,8 @@
         "end": 21
       },
       "file_name": "<rootdir>/fixtures/package-json/resolutions/package.json"
-    }
+    },
+    "isDirect": true
   },
   {
     "name": "@aws-sdk/core",
@@ -252,7 +257,8 @@
         "end": 19
       },
       "file_name": "<rootdir>/fixtures/package-json/resolutions/package.json"
-    }
+    },
+    "isDirect": true
   }
 ]
 ---
@@ -298,7 +304,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "bar",
@@ -339,7 +346,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "baz",
@@ -380,7 +388,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "boo",
@@ -421,7 +430,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "qux",
@@ -462,7 +472,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "asd",
@@ -503,7 +514,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "til",
@@ -544,7 +556,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "elf",
@@ -585,7 +598,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "two",
@@ -626,7 +640,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "thr",
@@ -667,7 +682,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "lat",
@@ -708,7 +724,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "dyl",
@@ -749,7 +766,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "kpg",
@@ -790,7 +808,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "abc",
@@ -831,7 +850,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "cde",
@@ -872,7 +892,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "dd",
@@ -913,7 +934,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "dd2",
@@ -954,7 +976,8 @@
       },
       "file_name": "<rootdir>/fixtures/package-json/multiple-versions/package.json"
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   }
 ]
 ---
@@ -978,7 +1001,8 @@
       },
       "file_name": ""
     },
-    "packageManager": "NPM"
+    "packageManager": "NPM",
+    "isDirect": true
   },
   {
     "name": "debug",
@@ -1019,7 +1043,8 @@
         "end": 11
       },
       "file_name": "<rootdir>/fixtures/package-json/transitive/package.json"
-    }
+    },
+    "isDirect": true
   },
   {
     "name": "jear",
@@ -1059,7 +1084,8 @@
         "end": 10
       },
       "file_name": "<rootdir>/fixtures/package-json/transitive/package.json"
-    }
+    },
+    "isDirect": true
   },
   {
     "name": "shelljs",
@@ -1077,7 +1103,8 @@
         "end": 0
       },
       "file_name": ""
-    }
+    },
+    "isDirect": true
   },
   {
     "name": "velocityjs",
@@ -1095,7 +1122,8 @@
         "end": 0
       },
       "file_name": ""
-    }
+    },
+    "isDirect": true
   }
 ]
 ---

--- a/pkg/lockfile/match-package-json.go
+++ b/pkg/lockfile/match-package-json.go
@@ -51,6 +51,7 @@ func updatePackageLocations(pkg *PackageDetails, nameLocation *models.FilePositi
 	// Update version location
 	versionLocation.Filename = sourcefilePath
 	pkg.VersionLocation = versionLocation
+	pkg.IsDirect = true
 }
 
 func (m PackageJSONMatcher) Match(sourcefile DepFile, packages []PackageDetails) error {

--- a/pkg/lockfile/match-package-json_test.go
+++ b/pkg/lockfile/match-package-json_test.go
@@ -65,6 +65,7 @@ func TestPackageJSONMatcher_Match_OnePackage(t *testing.T) {
 			Name:           "lodash",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"^4.0.0"},
+			IsDirect:       true,
 		},
 	}
 	err = packageJSONMatcher.Match(sourceFile, packages)
@@ -88,22 +89,27 @@ func TestPackageJSONMatcher_Match_TransitiveDependencies(t *testing.T) {
 			Name:           "commander",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"~2.0.0"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "debug",
 			TargetVersions: []string{"^0.7", "~0.7.2"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "jear",
 			TargetVersions: []string{"^0.1.4"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "shelljs",
 			TargetVersions: []string{"~0.1.4"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "velocityjs",
 			TargetVersions: []string{"~0.3.15"},
+			IsDirect:       true,
 		},
 	}
 	err = packageJSONMatcher.Match(sourceFile, packages)
@@ -127,10 +133,12 @@ func TestPackageJSONMatcher_Match_NameConflict(t *testing.T) {
 			Name:           "aws-sdk-client-mock",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"^2.1.1"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "aws-sdk-client-mock-jest",
 			TargetVersions: []string{"^2.1.1"},
+			IsDirect:       true,
 		},
 	}
 	err = packageJSONMatcher.Match(sourceFile, packages)
@@ -155,16 +163,19 @@ func TestPackageJSONMatcher_Match_Resolutions(t *testing.T) {
 			Version:        "4.2.5",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"4.2.5"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "fast-xml-parser",
 			Version:        "4.4.0",
 			TargetVersions: []string{"^4.2.5"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "@aws-sdk/core",
 			Version:        "3.535.0",
 			TargetVersions: []string{"^3.535.0"},
+			IsDirect:       true,
 		},
 	}
 	err = packageJSONMatcher.Match(sourceFile, packages)
@@ -189,102 +200,119 @@ func TestPackageJSONMatcher_Match_Target_Version(t *testing.T) {
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"1.0.0 - 2.9999.9999"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "bar",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{">=1.0.2 <2.1.2"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "baz",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{">1.0.2 <=2.3.4"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "boo",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"1.5.3"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "qux",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"<1.0.0 || >=2.3.1 <2.4.5 || >=2.5.2 <3.0.0"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "asd",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"http://asdf.com/asdf.tar.gz"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "til",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"~1.5"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "elf",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"~1.5.3"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "two",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"1.x"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "thr",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"1.5.x"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "lat",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"latest"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "dyl",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"file:../dyl"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "kpg",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"npm:pkg@1.5.0"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "abc",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"1"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "cde",
 			Version:        "1.5.3",
 			PackageManager: models.NPM,
 			TargetVersions: []string{">1.0.2"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "dd",
 			Version:        "0.0.0-use.local",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"javascript/datadog"},
+			IsDirect:       true,
 		},
 		{
 			Name:           "dd2",
 			Version:        "0.0.0-use.local",
 			PackageManager: models.NPM,
 			TargetVersions: []string{"javascript/datadog"},
+			IsDirect:       true,
 		},
 	}
 	err = packageJSONMatcher.Match(sourceFile, packages)

--- a/pkg/lockfile/parse-pnpm-lock-v9_test.go
+++ b/pkg/lockfile/parse-pnpm-lock-v9_test.go
@@ -12,7 +12,6 @@ func TestParsePnpmLock_v9_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/no-packages.v9.yaml")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -24,7 +23,6 @@ func TestParsePnpmLock_v9_OnePackage(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/one-package.v9.yaml")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -37,6 +35,7 @@ func TestParsePnpmLock_v9_OnePackage(t *testing.T) {
 			TargetVersions: []string{"^8.11.3"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -45,7 +44,6 @@ func TestParsePnpmLock_v9_OnePackageDev(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/one-package-dev.v9.yaml")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -58,6 +56,7 @@ func TestParsePnpmLock_v9_OnePackageDev(t *testing.T) {
 			TargetVersions: []string{"^8.11.3"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -66,7 +65,6 @@ func TestParsePnpmLock_v9_ScopedPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/scoped-packages.v9.yaml")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -79,6 +77,7 @@ func TestParsePnpmLock_v9_ScopedPackages(t *testing.T) {
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -87,7 +86,6 @@ func TestParsePnpmLock_v9_PeerDependencies(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/peer-dependencies.v9.yaml")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -100,6 +98,7 @@ func TestParsePnpmLock_v9_PeerDependencies(t *testing.T) {
 			TargetVersions: []string{"^5.3.2"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "acorn",
@@ -107,6 +106,7 @@ func TestParsePnpmLock_v9_PeerDependencies(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 	})
 }
@@ -115,7 +115,6 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/peer-dependencies-advanced.v9.yaml")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -127,6 +126,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "@eslint/eslintrc",
@@ -134,6 +134,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "@typescript-eslint/eslint-plugin",
@@ -142,6 +143,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^5.12.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "@typescript-eslint/parser",
@@ -150,6 +152,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^5.12.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "@typescript-eslint/type-utils",
@@ -157,6 +160,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "@typescript-eslint/typescript-estree",
@@ -164,6 +168,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "@typescript-eslint/utils",
@@ -171,6 +176,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "debug",
@@ -178,6 +184,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "eslint",
@@ -186,6 +193,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^8.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "has-flag",
@@ -193,6 +201,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "supports-color",
@@ -200,6 +209,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "tsutils",
@@ -207,6 +217,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "typescript",
@@ -215,6 +226,7 @@ func TestParsePnpmLock_v9_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^4.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -223,7 +235,6 @@ func TestParsePnpmLock_v9_MultipleVersions(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/multiple-versions.v9.yaml")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -235,6 +246,7 @@ func TestParsePnpmLock_v9_MultipleVersions(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "uuid",
@@ -243,6 +255,7 @@ func TestParsePnpmLock_v9_MultipleVersions(t *testing.T) {
 			TargetVersions: []string{"^8.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "xmlbuilder",
@@ -250,6 +263,7 @@ func TestParsePnpmLock_v9_MultipleVersions(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 	})
 }
@@ -258,7 +272,6 @@ func TestParsePnpmLock_v9_Commits(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/commits.v9.yaml")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -272,6 +285,7 @@ func TestParsePnpmLock_v9_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "02fa893d619d3da85411acc8fd4e2eea0e95a9d9",
+			IsDirect:       true,
 		},
 		{
 			Name:           "is-number",
@@ -281,6 +295,7 @@ func TestParsePnpmLock_v9_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "98e8ff1da1a89f93d1397a24d7413ed15421c139",
+			IsDirect:       true,
 		},
 	})
 }
@@ -289,7 +304,6 @@ func TestParsePnpmLock_v9_MixedGroups(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/mixed-groups.v9.yaml")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -302,6 +316,7 @@ func TestParsePnpmLock_v9_MixedGroups(t *testing.T) {
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "uuid",
@@ -310,6 +325,7 @@ func TestParsePnpmLock_v9_MixedGroups(t *testing.T) {
 			TargetVersions: []string{"^8.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "is-number",
@@ -318,6 +334,7 @@ func TestParsePnpmLock_v9_MixedGroups(t *testing.T) {
 			TargetVersions: []string{"^7.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }

--- a/pkg/lockfile/parse-pnpm-lock.go
+++ b/pkg/lockfile/parse-pnpm-lock.go
@@ -33,9 +33,11 @@ type PnpmLockDependency struct {
 	Version   string `yaml:"version"`
 }
 
-type PnpmLockPackages map[string]PnpmLockPackage
-type PnpmSpecifiers map[string]string
-type PnpmDependencies map[string]PnpmLockDependency
+type (
+	PnpmLockPackages map[string]PnpmLockPackage
+	PnpmSpecifiers   map[string]string
+	PnpmDependencies map[string]PnpmLockDependency
+)
 
 type PnpmImporters struct {
 	Dot struct {
@@ -236,6 +238,7 @@ func parsePnpmLock(lockfile PnpmLockfile) []PackageDetails {
 		var targetVersions []string
 		var targetVersion string
 		var dependencyVersion string
+		var isDirect bool
 
 		// Find target and dependency version
 		if sp, ok := lockfile.Specifiers[name]; ok {
@@ -243,12 +246,14 @@ func parsePnpmLock(lockfile PnpmLockfile) []PackageDetails {
 			targetVersion = sp
 			dependencyVersion = ""
 			if _, v, f := getVersionInfo(name, lockfile.Dependencies, lockfile.OptionalDependencies, lockfile.DevDependencies); f {
+				isDirect = true
 				dependencyVersion = v
 			}
 		} else if sp, v, f := getVersionInfo(name, lockfile.Dependencies, lockfile.Importers.Dot.Dependencies, lockfile.Importers.Dot.OptionalDependencies, lockfile.Importers.Dot.DevDependencies); f {
 			// lockfile version >6.0
 			targetVersion = sp
 			dependencyVersion = v
+			isDirect = true
 		}
 
 		// Sanitize the target/dependency version
@@ -273,6 +278,7 @@ func parsePnpmLock(lockfile PnpmLockfile) []PackageDetails {
 			CompareAs:      PnpmEcosystem,
 			Commit:         commit,
 			DepGroups:      depGroups,
+			IsDirect:       isDirect,
 		})
 	}
 

--- a/pkg/lockfile/parse-pnpm-lock_test.go
+++ b/pkg/lockfile/parse-pnpm-lock_test.go
@@ -90,7 +90,6 @@ func TestParsePnpmLock_Empty(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/empty.yaml")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -102,7 +101,6 @@ func TestParsePnpmLock_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParsePnpmLock("fixtures/pnpm/no-packages.yaml")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -131,6 +129,7 @@ func TestParsePnpmLock_OnePackage(t *testing.T) {
 			TargetVersions: []string{"^8.7.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -178,6 +177,7 @@ func TestParsePnpmLock_OnePackage_MatcherFailed(t *testing.T) {
 			TargetVersions: []string{"^8.7.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 
@@ -206,6 +206,7 @@ func TestParsePnpmLock_OnePackageV6Lockfile(t *testing.T) {
 			TargetVersions: []string{"8.7.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -231,6 +232,7 @@ func TestParsePnpmLock_OnePackageDev(t *testing.T) {
 			TargetVersions: []string{"^8.7.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -256,6 +258,7 @@ func TestParsePnpmLock_ScopedPackages(t *testing.T) {
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -281,6 +284,7 @@ func TestParsePnpmLock_ScopedPackagesV6Lockfile(t *testing.T) {
 			TargetVersions: []string{"^5.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -306,6 +310,7 @@ func TestParsePnpmLock_PeerDependencies(t *testing.T) {
 			TargetVersions: []string{"^5.3.2"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "acorn",
@@ -314,6 +319,7 @@ func TestParsePnpmLock_PeerDependencies(t *testing.T) {
 			TargetVersions: []string{"^8.7.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -339,6 +345,7 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^5.12.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "@typescript-eslint/parser",
@@ -347,6 +354,7 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^5.12.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "@typescript-eslint/type-utils",
@@ -354,6 +362,7 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "@typescript-eslint/types",
@@ -361,6 +370,7 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "@typescript-eslint/typescript-estree",
@@ -368,6 +378,7 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "@typescript-eslint/utils",
@@ -375,6 +386,7 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "eslint-utils",
@@ -382,6 +394,7 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "eslint",
@@ -390,6 +403,7 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 			TargetVersions: []string{"^8.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "tsutils",
@@ -397,6 +411,7 @@ func TestParsePnpmLock_PeerDependenciesAdvanced(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 	})
 }
@@ -422,6 +437,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			TargetVersions: []string{"^2.1087.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "base64-js",
@@ -429,6 +445,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "buffer",
@@ -436,6 +453,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "events",
@@ -443,6 +461,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "ieee754",
@@ -457,6 +476,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "jmespath",
@@ -464,6 +484,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "punycode",
@@ -478,6 +499,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "sax",
@@ -485,6 +507,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "url",
@@ -492,6 +515,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "uuid",
@@ -499,6 +523,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "xml2js",
@@ -506,6 +531,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 		{
 			Name:           "xmlbuilder",
@@ -513,6 +539,7 @@ func TestParsePnpmLock_MultiplePackages(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 	})
 }
@@ -537,6 +564,7 @@ func TestParsePnpmLock_MultipleVersions(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "uuid",
@@ -545,6 +573,7 @@ func TestParsePnpmLock_MultipleVersions(t *testing.T) {
 			TargetVersions: []string{"^8.0.0"},
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "xmlbuilder",
@@ -552,6 +581,7 @@ func TestParsePnpmLock_MultipleVersions(t *testing.T) {
 			PackageManager: models.Pnpm,
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
+			IsDirect:       false,
 		},
 	})
 }
@@ -579,6 +609,7 @@ func TestParsePnpmLock_Tarball(t *testing.T) {
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "",
 			DepGroups:      []string{"dev"},
+			IsDirect:       true,
 		},
 	})
 }
@@ -671,6 +702,7 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "6104ae42cd32c3d724036d3964678f197b2c9cdb",
+			IsDirect:       true,
 		},
 		{
 			Name:           "@my-scope/my-package",
@@ -680,6 +712,7 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "267087851ad5fac92a184749c27cd539e2fc862e",
+			IsDirect:       true,
 		},
 		{
 			Name:           "@my-scope/my-other-package",
@@ -688,6 +721,7 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "fbfc962ab51eb1d754749b68c064460221fbd689",
+			IsDirect:       false,
 		},
 		{
 			Name:           "faker-parser",
@@ -696,6 +730,7 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "d2dc42a9351d4d89ec48c525e34f612b6d77993f",
+			IsDirect:       false,
 		},
 		{
 			Name:           "mocks",
@@ -705,6 +740,7 @@ func TestParsePnpmLock_Commits(t *testing.T) {
 			Ecosystem:      lockfile.PnpmEcosystem,
 			CompareAs:      lockfile.PnpmEcosystem,
 			Commit:         "590f321b4eb3f692bb211bd74e22947639a6f79d",
+			IsDirect:       true,
 		},
 	})
 }
@@ -731,6 +767,7 @@ func TestParsePnpmLock_Files(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
+			IsDirect:       true,
 		},
 		{
 			Name:           "a-local-package",
@@ -739,6 +776,7 @@ func TestParsePnpmLock_Files(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
+			IsDirect:       false,
 		},
 		{
 			Name:           "a-nested-local-package",
@@ -747,6 +785,7 @@ func TestParsePnpmLock_Files(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
+			IsDirect:       false,
 		},
 		{
 			Name:           "one-up",
@@ -755,6 +794,7 @@ func TestParsePnpmLock_Files(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
+			IsDirect:       false,
 		},
 		{
 			Name:           "one-up-with-peer",
@@ -763,6 +803,7 @@ func TestParsePnpmLock_Files(t *testing.T) {
 			Ecosystem:      lockfile.NpmEcosystem,
 			CompareAs:      lockfile.NpmEcosystem,
 			Commit:         "",
+			IsDirect:       false,
 		},
 	})
 }

--- a/pkg/lockfile/parse-yarn-lock-v1_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v1_test.go
@@ -29,7 +29,6 @@ func TestParseYarnLock_v1_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/empty.v1.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}

--- a/pkg/lockfile/parse-yarn-lock-v2_test.go
+++ b/pkg/lockfile/parse-yarn-lock-v2_test.go
@@ -29,7 +29,6 @@ func TestParseYarnLock_v2_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseYarnLock("fixtures/yarn/empty.v2.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}

--- a/pkg/lockfile/parse-yarn-lock.go
+++ b/pkg/lockfile/parse-yarn-lock.go
@@ -73,7 +73,7 @@ func extractYarnPackageNameAndTargetVersions(str string) (string, []string) {
 
 	var name, right string
 	var isScoped bool
-	var targetVersions = make([]string, 0)
+	targetVersions := make([]string, 0)
 
 	for _, part := range parts {
 		part = strings.TrimPrefix(part, " ")


### PR DESCRIPTION
### Problem

Currently, we do not mark dependencies as direct for PNPM or Yarn packages, which is necessary so we can filter out direct dependencies when we ingest this data.

### Solution
Set the `IsDirect` field for PNPM and Yarn packages. In PNPM, we simply check if it's in the `specifiers` object and a corresponding version exists in either the lockfile's `dependencies`, `optionalDependencies`, or `devDependencies` for lockfile versions below 6. Otherwise, we check if the version info can be found in the `dependencies`, OR the `importers` field's "dot" `dependencies`, `optionalDependencies`, or `devDependencies`.

In Yarn, it's slightly different. There is no way to differentiate whether or not a dependency is direct or not without looking it up in `package.json`, so I've set `IsDirect` to true for all of them. So I'm putting this PR up as a draft, but I will sync with Marc about this and whether or not we want to improve the direct dependency heuristics.

> [!NOTE]
> This PR is based off of #133, so that it's easy to see what the actual changes are, and to incorporate test changes on not-relevant code.