### PR TITLE
[K9VULN-1326] feat: set `IsDirect` for direct dependencies in Nuget and Bundler packages

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -4529,6 +4529,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:gem/RedCloth@4.2.9",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -4770,6 +4774,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:gem/chronic@0.10.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -4789,6 +4797,10 @@ No package sources found, --help for usage information.
       "version": "1.0.9",
       "purl": "pkg:gem/coderay@1.0.9",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -4927,6 +4939,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:gem/cucumber-rails@1.4.0",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -4959,6 +4975,10 @@ No package sources found, --help for usage information.
       "version": "0.10.0",
       "purl": "pkg:gem/cucumber-websteps@0.10.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -5018,6 +5038,10 @@ No package sources found, --help for usage information.
       "version": "2.0.2",
       "purl": "pkg:gem/database_cleaner@2.0.2",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -5090,6 +5114,10 @@ No package sources found, --help for usage information.
       "version": "4.9.0",
       "purl": "pkg:gem/factory_girl@4.9.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -5175,6 +5203,10 @@ No package sources found, --help for usage information.
       "version": "4.6.0",
       "purl": "pkg:gem/jquery-rails@4.6.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -5443,6 +5475,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:gem/rack-openid@1.4.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -5541,6 +5577,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:gem/rails@7.1.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -5626,6 +5666,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:gem/rspec-activemodel-mocks@1.2.0",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -5645,6 +5689,10 @@ No package sources found, --help for usage information.
       "version": "1.2.1",
       "purl": "pkg:gem/rspec-collection_matchers@1.2.1",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -5718,6 +5766,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:gem/rspec@3.13.0",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -5738,6 +5790,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:gem/ruby-openid@2.9.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -5757,6 +5813,10 @@ No package sources found, --help for usage information.
       "version": "1.7.3",
       "purl": "pkg:gem/sqlite3@1.7.3",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -5881,6 +5941,10 @@ No package sources found, --help for usage information.
       "version": "3.0.12",
       "purl": "pkg:gem/will_paginate@3.0.12",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -8343,6 +8407,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:gem/RedCloth@4.2.9",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -8584,6 +8652,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:gem/chronic@0.10.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -8603,6 +8675,10 @@ Filtered 1 local package/s from the scan.
       "version": "1.0.9",
       "purl": "pkg:gem/coderay@1.0.9",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -8741,6 +8817,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:gem/cucumber-rails@1.4.0",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -8773,6 +8853,10 @@ Filtered 1 local package/s from the scan.
       "version": "0.10.0",
       "purl": "pkg:gem/cucumber-websteps@0.10.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -8832,6 +8916,10 @@ Filtered 1 local package/s from the scan.
       "version": "2.0.2",
       "purl": "pkg:gem/database_cleaner@2.0.2",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -8904,6 +8992,10 @@ Filtered 1 local package/s from the scan.
       "version": "4.9.0",
       "purl": "pkg:gem/factory_girl@4.9.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -8989,6 +9081,10 @@ Filtered 1 local package/s from the scan.
       "version": "4.6.0",
       "purl": "pkg:gem/jquery-rails@4.6.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -9257,6 +9353,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:gem/rack-openid@1.4.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -9355,6 +9455,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:gem/rails@7.1.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -9440,6 +9544,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:gem/rspec-activemodel-mocks@1.2.0",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -9459,6 +9567,10 @@ Filtered 1 local package/s from the scan.
       "version": "1.2.1",
       "purl": "pkg:gem/rspec-collection_matchers@1.2.1",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -9532,6 +9644,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:gem/rspec@3.13.0",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -9552,6 +9668,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:gem/ruby-openid@2.9.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -9571,6 +9691,10 @@ Filtered 1 local package/s from the scan.
       "version": "1.7.3",
       "purl": "pkg:gem/sqlite3@1.7.3",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -9695,6 +9819,10 @@ Filtered 1 local package/s from the scan.
       "version": "3.0.12",
       "purl": "pkg:gem/will_paginate@3.0.12",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12109,6 +12237,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:gem/RedCloth@4.2.9",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12350,6 +12482,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:gem/chronic@0.10.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12369,6 +12505,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "1.0.9",
       "purl": "pkg:gem/coderay@1.0.9",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12507,6 +12647,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:gem/cucumber-rails@1.4.0",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -12539,6 +12683,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "0.10.0",
       "purl": "pkg:gem/cucumber-websteps@0.10.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12598,6 +12746,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "2.0.2",
       "purl": "pkg:gem/database_cleaner@2.0.2",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12670,6 +12822,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "4.9.0",
       "purl": "pkg:gem/factory_girl@4.9.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -12755,6 +12911,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "4.6.0",
       "purl": "pkg:gem/jquery-rails@4.6.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -13023,6 +13183,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:gem/rack-openid@1.4.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -13121,6 +13285,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:gem/rails@7.1.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -13206,6 +13374,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:gem/rspec-activemodel-mocks@1.2.0",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -13225,6 +13397,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "1.2.1",
       "purl": "pkg:gem/rspec-collection_matchers@1.2.1",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -13298,6 +13474,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:gem/rspec@3.13.0",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -13318,6 +13498,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:gem/ruby-openid@2.9.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
         }
@@ -13337,6 +13521,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "1.7.3",
       "purl": "pkg:gem/sqlite3@1.7.3",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"
@@ -13461,6 +13649,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "3.0.12",
       "purl": "pkg:gem/will_paginate@3.0.12",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "Bundler"

--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -2477,6 +2477,10 @@ Warning: `scan` exists as both a subcommand of OSV-Scanner and as a file on the 
       "purl": "pkg:nuget/Test.Core@6.0.5",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
         }
@@ -6141,6 +6145,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:nuget/Downloader@3.1.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
         }
@@ -6160,6 +6168,10 @@ No package sources found, --help for usage information.
       "version": "5.1.0",
       "purl": "pkg:nuget/MaterialDesignThemes@5.1.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
@@ -6181,6 +6193,10 @@ No package sources found, --help for usage information.
       "purl": "pkg:nuget/Test.Core@6.0.5",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
         }
@@ -6200,6 +6216,10 @@ No package sources found, --help for usage information.
       "version": "6.0.6",
       "purl": "pkg:nuget/Test.Core@6.0.6",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
@@ -9892,6 +9912,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:nuget/Downloader@3.1.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
         }
@@ -9911,6 +9935,10 @@ Filtered 1 local package/s from the scan.
       "version": "5.1.0",
       "purl": "pkg:nuget/MaterialDesignThemes@5.1.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
@@ -9932,6 +9960,10 @@ Filtered 1 local package/s from the scan.
       "purl": "pkg:nuget/Test.Core@6.0.5",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
         }
@@ -9951,6 +9983,10 @@ Filtered 1 local package/s from the scan.
       "version": "6.0.6",
       "purl": "pkg:nuget/Test.Core@6.0.6",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
@@ -13642,6 +13678,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:nuget/Downloader@3.1.2",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
         }
@@ -13661,6 +13701,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "5.1.0",
       "purl": "pkg:nuget/MaterialDesignThemes@5.1.0",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
@@ -13682,6 +13726,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "purl": "pkg:nuget/Test.Core@6.0.5",
       "properties": [
         {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
+        {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"
         }
@@ -13701,6 +13749,10 @@ Scanned <rootdir>/fixtures/encoding-integration-test-locks/UTF-16/yarn/yarn.lock
       "version": "6.0.6",
       "purl": "pkg:nuget/Test.Core@6.0.6",
       "properties": [
+        {
+          "name": "osv-scanner:is-direct",
+          "value": "true"
+        },
         {
           "name": "osv-scanner:package-manager",
           "value": "NuGet"

--- a/pkg/lockfile/parse-gemfile-lock_test.go
+++ b/pkg/lockfile/parse-gemfile-lock_test.go
@@ -74,7 +74,6 @@ func TestParseGemfileLock_NoSpecSection(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/no-spec-section.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -86,7 +85,6 @@ func TestParseGemfileLock_NoGemSection(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/no-gem-section.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -98,7 +96,6 @@ func TestParseGemfileLock_NoGems(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/no-gems.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -110,7 +107,6 @@ func TestParseGemfileLock_OneGem(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/one-gem.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -122,6 +118,7 @@ func TestParseGemfileLock_OneGem(t *testing.T) {
 			PackageManager: models.Bundler,
 			Ecosystem:      lockfile.BundlerEcosystem,
 			CompareAs:      lockfile.BundlerEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -130,7 +127,6 @@ func TestParseGemfileLock_SomeGems(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/some-gems.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -156,6 +152,7 @@ func TestParseGemfileLock_SomeGems(t *testing.T) {
 			PackageManager: models.Bundler,
 			Ecosystem:      lockfile.BundlerEcosystem,
 			CompareAs:      lockfile.BundlerEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -164,7 +161,6 @@ func TestParseGemfileLock_MultipleGems(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/multiple-gems.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -176,6 +172,7 @@ func TestParseGemfileLock_MultipleGems(t *testing.T) {
 			PackageManager: models.Bundler,
 			Ecosystem:      lockfile.BundlerEcosystem,
 			CompareAs:      lockfile.BundlerEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "coderay",
@@ -190,6 +187,7 @@ func TestParseGemfileLock_MultipleGems(t *testing.T) {
 			PackageManager: models.Bundler,
 			Ecosystem:      lockfile.BundlerEcosystem,
 			CompareAs:      lockfile.BundlerEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "method_source",
@@ -204,6 +202,7 @@ func TestParseGemfileLock_MultipleGems(t *testing.T) {
 			PackageManager: models.Bundler,
 			Ecosystem:      lockfile.BundlerEcosystem,
 			CompareAs:      lockfile.BundlerEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "thor",
@@ -219,7 +218,6 @@ func TestParseGemfileLock_Rails(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/rails.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -462,6 +460,7 @@ func TestParseGemfileLock_Rails(t *testing.T) {
 			PackageManager: models.Bundler,
 			Ecosystem:      lockfile.BundlerEcosystem,
 			CompareAs:      lockfile.BundlerEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "rails-dom-testing",
@@ -554,7 +553,6 @@ func TestParseGemfileLock_Rubocop(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/rubocop.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -608,6 +606,7 @@ func TestParseGemfileLock_Rubocop(t *testing.T) {
 			PackageManager: models.Bundler,
 			Ecosystem:      lockfile.BundlerEcosystem,
 			CompareAs:      lockfile.BundlerEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "rubocop-ast",
@@ -637,7 +636,6 @@ func TestParseGemfileLock_HasLocalGem(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/has-local-gem.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -649,6 +647,7 @@ func TestParseGemfileLock_HasLocalGem(t *testing.T) {
 			PackageManager: models.Bundler,
 			Ecosystem:      lockfile.BundlerEcosystem,
 			CompareAs:      lockfile.BundlerEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "actionpack",
@@ -860,7 +859,6 @@ func TestParseGemfileLock_HasGitGem(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseGemfileLock("fixtures/bundler/has-git-gem.lock")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -881,6 +879,7 @@ func TestParseGemfileLock_HasGitGem(t *testing.T) {
 			Ecosystem:      lockfile.BundlerEcosystem,
 			CompareAs:      lockfile.BundlerEcosystem,
 			Commit:         "5904fc9a70683b8749aa2861257d0c8c01eae4aa",
+			IsDirect:       true,
 		},
 		{
 			Name:           "concurrent-ruby",

--- a/pkg/lockfile/parse-nuget-lock-v1_test.go
+++ b/pkg/lockfile/parse-nuget-lock-v1_test.go
@@ -36,7 +36,6 @@ func TestParseNuGetLock_v1_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseNuGetLock("fixtures/nuget/empty.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -48,7 +47,6 @@ func TestParseNuGetLock_v1_OneFramework_OnePackage(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseNuGetLock("fixtures/nuget/one-framework-one-package.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -60,6 +58,7 @@ func TestParseNuGetLock_v1_OneFramework_OnePackage(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      lockfile.NuGetEcosystem,
 			CompareAs:      lockfile.NuGetEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -68,7 +67,6 @@ func TestParseNuGetLock_v1_OneFramework_TwoPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseNuGetLock("fixtures/nuget/one-framework-two-packages.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -80,6 +78,7 @@ func TestParseNuGetLock_v1_OneFramework_TwoPackages(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      lockfile.NuGetEcosystem,
 			CompareAs:      lockfile.NuGetEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "Test.System",
@@ -87,6 +86,7 @@ func TestParseNuGetLock_v1_OneFramework_TwoPackages(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      lockfile.NuGetEcosystem,
 			CompareAs:      lockfile.NuGetEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -95,7 +95,6 @@ func TestParseNuGetLock_v1_TwoFrameworks_MixedPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseNuGetLock("fixtures/nuget/two-frameworks-mixed-packages.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -107,6 +106,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_MixedPackages(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      lockfile.NuGetEcosystem,
 			CompareAs:      lockfile.NuGetEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "Test.System",
@@ -114,6 +114,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_MixedPackages(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      lockfile.NuGetEcosystem,
 			CompareAs:      lockfile.NuGetEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "Test.System",
@@ -121,6 +122,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_MixedPackages(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      lockfile.NuGetEcosystem,
 			CompareAs:      lockfile.NuGetEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -129,7 +131,6 @@ func TestParseNuGetLock_v1_TwoFrameworks_DifferentPackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseNuGetLock("fixtures/nuget/two-frameworks-different-packages.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -141,6 +142,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_DifferentPackages(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      lockfile.NuGetEcosystem,
 			CompareAs:      lockfile.NuGetEcosystem,
+			IsDirect:       true,
 		},
 		{
 			Name:           "Test.System",
@@ -148,6 +150,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_DifferentPackages(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      lockfile.NuGetEcosystem,
 			CompareAs:      lockfile.NuGetEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -156,7 +159,6 @@ func TestParseNuGetLock_v1_TwoFrameworks_DuplicatePackages(t *testing.T) {
 	t.Parallel()
 
 	packages, err := lockfile.ParseNuGetLock("fixtures/nuget/two-frameworks-duplicate-packages.v1.json")
-
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -168,6 +170,7 @@ func TestParseNuGetLock_v1_TwoFrameworks_DuplicatePackages(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      lockfile.NuGetEcosystem,
 			CompareAs:      lockfile.NuGetEcosystem,
+			IsDirect:       true,
 		},
 	})
 }
@@ -209,6 +212,7 @@ func TestParseNuGetLock_v1_OneFramework_OnePackage_MatchedFailed(t *testing.T) {
 			PackageManager: models.NuGet,
 			Ecosystem:      lockfile.NuGetEcosystem,
 			CompareAs:      lockfile.NuGetEcosystem,
+			IsDirect:       true,
 		},
 	})
 

--- a/pkg/lockfile/parse-nuget-lock.go
+++ b/pkg/lockfile/parse-nuget-lock.go
@@ -23,8 +23,10 @@ type NuGetLockfile struct {
 	Dependencies map[string]map[string]NuGetLockPackage `json:"dependencies"`
 }
 
-const NuGetEcosystem Ecosystem = "NuGet"
-const projectDependencyType = "Project"
+const (
+	NuGetEcosystem        Ecosystem = "NuGet"
+	projectDependencyType string    = "Project"
+)
 
 func parseNuGetLockDependencies(dependencies map[string]NuGetLockPackage) map[string]PackageDetails {
 	details := map[string]PackageDetails{}
@@ -39,6 +41,7 @@ func parseNuGetLockDependencies(dependencies map[string]NuGetLockPackage) map[st
 			PackageManager: models.NuGet,
 			Ecosystem:      NuGetEcosystem,
 			CompareAs:      NuGetEcosystem,
+			IsDirect:       dependency.Type == "Direct",
 		}
 	}
 
@@ -70,7 +73,6 @@ func (e NuGetLockExtractor) Extract(f DepFile) ([]PackageDetails, error) {
 	var parsedLockfile *NuGetLockfile
 
 	err := json.NewDecoder(f).Decode(&parsedLockfile)
-
 	if err != nil {
 		return []PackageDetails{}, fmt.Errorf("could not extract from %s: %w", f.Path(), err)
 	}


### PR DESCRIPTION
### Problem

Currently, we do not mark dependencies as direct for Nuget or Bundler packages, which is necessary so we can filter out direct dependencies when we ingest this data.

### Solution

Set the IsDirect field for Nuget and Bundler packages. In Nuget, we simply check if the `dependencyType` is set to `Direct`. In Bundler, it's a little more involved, since the file format of `Gemfile.lock` is not a conventional file format used, and so the manual parsing of the file has to be adjusted. Here we process the `dependencies` "table", which contains all direct dependencies listed in the `Gemfile`, so some stateful logic was added for this. 