### PR TITLE
[K9VULN-2381] fix(maven): add parent path to log message when it couldn't be reached

### DIFF
--- a/pkg/lockfile/parse-maven-lock.go
+++ b/pkg/lockfile/parse-maven-lock.go
@@ -368,9 +368,9 @@ func (e MavenLockExtractor) decodeMavenFile(f DepFile, depth int, visitedPath ma
 	}
 
 	parentPath := e.resolveParentFilename(parsedLockfile.Parent, f.Path())
-	if _, err := os.Stat(parentPath); errors.Is(err, os.ErrNotExist) {
+	if _, err = os.Stat(parentPath); errors.Is(err, os.ErrNotExist) {
 		// If the parent pom does not exist, it still can be in an external repository, but it is unreachable from the parser
-		_, _ = fmt.Fprintf(os.Stderr, "Maven lockfile parser couldn't reach the parent because it is not locally defined\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Maven lockfile parser couldn't reach the parent because it is not locally defined: %s\n", parentPath)
 		return parsedLockfile, nil
 	}
 


### PR DESCRIPTION
## What does this PR do?

This improves the log message in Maven parsing, so we can know if the parent path file is empty (remote config) or if the parent file is unreachable for whatever reason

## Additional Notes
