### PR TITLE
[K9VULN-1327] feat: support npm workspaces for resolving dependency locations

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -50,6 +50,7 @@ core,github.com/atotto/clipboard,BSD-3-Clause,Copyright (c) 2013 Ato Araki. All 
 core,github.com/aymanbagabas/go-osc52/v2,MIT,Copyright (c) 2022 Ayman Bagabas
 core,github.com/aymerick/douceur/css,MIT,Copyright (c) 2015 Aymerick JEHANNE
 core,github.com/aymerick/douceur/parser,MIT,Copyright (c) 2015 Aymerick JEHANNE
+core,github.com/bmatcuk/doublestar/v4,MIT,Copyright (c) 2014 Bob Matcuk
 core,github.com/charmbracelet/bubbles/cursor,MIT,"Copyright (c) 2020-2023 Charmbracelet, Inc"
 core,github.com/charmbracelet/bubbles/help,MIT,"Copyright (c) 2020-2023 Charmbracelet, Inc"
 core,github.com/charmbracelet/bubbles/key,MIT,"Copyright (c) 2020-2023 Charmbracelet, Inc"

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	deps.dev/util/semver v0.0.0-20240711010811-c5a1406b0470
 	github.com/BurntSushi/toml v1.4.0
 	github.com/CycloneDX/cyclonedx-go v0.9.0
+	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.26.6
 	github.com/charmbracelet/glamour v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/bmatcuk/doublestar/v4 v4.8.1 h1:54Bopc5c2cAvhLRAzqOGCYHYyhcDHsFF4wWIR5wKP38=
+github.com/bmatcuk/doublestar/v4 v4.8.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=

--- a/pkg/lockfile/fixtures/package-json/workspaces/folder/package.json
+++ b/pkg/lockfile/fixtures/package-json/workspaces/folder/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "workspace-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}

--- a/pkg/lockfile/fixtures/package-json/workspaces/other-folder/workspace-2/package.json
+++ b/pkg/lockfile/fixtures/package-json/workspaces/other-folder/workspace-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "workspace-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "semver": "^7.3.2"
+  }
+}

--- a/pkg/lockfile/fixtures/package-json/workspaces/package-lock.json
+++ b/pkg/lockfile/fixtures/package-json/workspaces/package-lock.json
@@ -1,0 +1,53 @@
+{
+  "name": "workspaces",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "workspaces",
+      "version": "1.0.0",
+      "workspaces": [
+        "folder",
+        "other-folder/**"
+      ]
+    },
+    "folder": {
+      "name": "workspace-1",
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/workspace-1": {
+      "resolved": "folder",
+      "link": true
+    },
+    "node_modules/workspace-2": {
+      "resolved": "other-folder/workspace-2",
+      "link": true
+    },
+    "other-folder/workspace-2": {
+      "version": "1.0.0",
+      "dependencies": {
+        "semver": "^7.3.2"
+      }
+    }
+  }
+}

--- a/pkg/lockfile/fixtures/package-json/workspaces/package.json
+++ b/pkg/lockfile/fixtures/package-json/workspaces/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "workspaces",
+  "version": "1.0.0",
+  "workspaces": [
+    "folder",
+    "other-folder/**"
+  ]
+}


### PR DESCRIPTION
### Problem

OSV-Scanner's npm lockfile parsing currently doesn't handle npm workspaces, leading to incomplete dependency location information and direct detection. When scanning monorepos that use workspaces, dependencies defined in workspace packages aren't properly discovered and matched with their target versions in the respective package.json files.

### Solution

Now, we support workspace packages by:

- Detecting workspace patterns in the root dependency's `workspaces` field in package-lock.json (lockfile version 2 and above only)
- Then collecting dependency information from each workspace package (figuring out what the dependencies are of *a specfic* workspace package)
- Matching dependencies against their target versions defined in both the root and workspace package.json files, by figuring out what possible workspace package.json files could be used (again, using doublestar to handle the globstar pattern)
- Correctly detecting file locations for dependencies found in workspace packages

## Additional Notes

A third-party dependency, [doublestar](https://github.com/bmatcuk/doublestar), was brought in because the go stdlib doesn't handle the ["globstar"](https://www.linuxjournal.com/content/globstar-new-bash-globbing-option) when matching file patterns, though npm (and yarn, for that matter) workspaces allow it. As such, we should handle the globstar, though writing my own implementation from scratch seems unnecessary.
