### PR TITLE
[K9VULN-3618] Filter out packages with ranged versions

### DIFF
--- a/cmd/osv-scanner/__snapshots__/update_test.snap
+++ b/cmd/osv-scanner/__snapshots__/update_test.snap
@@ -34,7 +34,7 @@ Warning: `update` exists as both a subcommand of OSV-Scanner and as a file on th
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.2</version>
+      <version>2.18.3</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pkg/osvscanner/__snapshots__/vulnerability_result_internal_test.snap
+++ b/pkg/osvscanner/__snapshots__/vulnerability_result_internal_test.snap
@@ -85,6 +85,18 @@
 }
 ---
 
+[Test_assembleResult/group_vulnerabilities_ignore_ranged_versions - 1]
+{
+  "results": [],
+  "experimental_config": {
+    "licenses": {
+      "summary": false,
+      "allowlist": null
+    }
+  }
+}
+---
+
 [Test_assembleResult/group_vulnerabilities_with_all_packages_included - 1]
 {
   "results": [

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -34,6 +34,10 @@ func exportMetadata(rawPkg scannedPackage) map[models.PackageMetadataType]string
 	return metadata
 }
 
+func packageHasRangedVersion(scannedPackage scannedPackage) bool {
+	return strings.ContainsAny(scannedPackage.Version, ",><")
+}
+
 // buildVulnerabilityResults takes the responses from the OSV API and the deps.dev API
 // and converts this into a VulnerabilityResults. As part is this, it groups
 // vulnerability information by source location.
@@ -55,6 +59,9 @@ func buildVulnerabilityResults(
 	for i, rawPkg := range packages {
 		includePackage := actions.ShowAllPackages
 		var pkg models.PackageVulns
+		if packageHasRangedVersion(rawPkg) {
+			continue
+		}
 
 		if rawPkg.Commit != "" {
 			pkg.Package.Commit = rawPkg.Commit
@@ -157,10 +164,6 @@ func buildVulnerabilityResults(
 	}
 
 	return results
-}
-
-func packageHasRangedVersion(scannedPackage scannedPackage) bool {
-	return strings.ContainsAny(scannedPackage.Version, ",><")
 }
 
 // grouped by source location.

--- a/pkg/osvscanner/vulnerability_result.go
+++ b/pkg/osvscanner/vulnerability_result.go
@@ -34,7 +34,7 @@ func exportMetadata(rawPkg scannedPackage) map[models.PackageMetadataType]string
 	return metadata
 }
 
-// buildVulnerablityResults takes the responses from the OSV API and the deps.dev API
+// buildVulnerabilityResults takes the responses from the OSV API and the deps.dev API
 // and converts this into a VulnerabilityResults. As part is this, it groups
 // vulnerability information by source location.
 // TODO: This function is getting long, we should refactor it
@@ -159,6 +159,10 @@ func buildVulnerabilityResults(
 	return results
 }
 
+func packageHasRangedVersion(scannedPackage scannedPackage) bool {
+	return strings.ContainsAny(scannedPackage.Version, ",><")
+}
+
 // grouped by source location.
 func groupBySource(r reporter.Reporter, packages []scannedPackage, artifacts []models.ScannedArtifact) models.VulnerabilityResults {
 	output := models.VulnerabilityResults{
@@ -168,6 +172,9 @@ func groupBySource(r reporter.Reporter, packages []scannedPackage, artifacts []m
 	groupedBySource := map[models.SourceInfo][]models.PackageVulns{}
 
 	for _, p := range packages {
+		if packageHasRangedVersion(p) {
+			continue
+		}
 		var pkg models.PackageVulns
 		switch {
 		case p.Ecosystem != "" && p.Name != "":

--- a/pkg/osvscanner/vulnerability_result_internal_test.go
+++ b/pkg/osvscanner/vulnerability_result_internal_test.go
@@ -11,6 +11,63 @@ import (
 	"github.com/google/osv-scanner/pkg/reporter"
 )
 
+func Test_packageHasRangedVersion(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		pkg            scannedPackage
+		expectedResult bool
+	}
+	tests := []struct {
+		name string
+		args args
+	}{{
+		name: "no ranged version",
+		args: args{
+			pkg: scannedPackage{
+				Version: "1.0.0",
+			},
+			expectedResult: false,
+		},
+	},
+		{
+			name: "contains <",
+			args: args{
+				pkg: scannedPackage{
+					Version: "<=0.27.6",
+				},
+				expectedResult: true,
+			},
+		},
+		{
+			name: "contains >",
+			args: args{
+				pkg: scannedPackage{
+					Version: ">=0.27.6",
+				},
+				expectedResult: true,
+			},
+		},
+		{
+			name: "contains all",
+			args: args{
+				pkg: scannedPackage{
+					Version: ">=0.15.0,<0.16.0",
+				},
+				expectedResult: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := packageHasRangedVersion(tt.args.pkg)
+			if got != tt.args.expectedResult {
+				t.Errorf("packageHasRangedVersion() got = %v, want %v for %v", got, tt.args.expectedResult, tt.args.pkg)
+			}
+		})
+	}
+}
+
 func Test_assembleResult(t *testing.T) {
 	t.Parallel()
 	type args struct {
@@ -61,6 +118,36 @@ func Test_assembleResult(t *testing.T) {
 			},
 			Source: models.SourceInfo{
 				Path: "other-dir/package-lock.json",
+				Type: "lockfile",
+			},
+		},
+	}
+	packagesWithRangedVersions := []scannedPackage{
+		{
+			Name:      "pkg-1",
+			Ecosystem: lockfile.Ecosystem("npm"),
+			Version:   ">=1.0.0",
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 1, End: 1},
+				Column:   models.Position{Start: 1, End: 1},
+				Filename: "dir/package-lock.json",
+			},
+			Source: models.SourceInfo{
+				Path: "dir/package-lock.json",
+				Type: "lockfile",
+			},
+		},
+		{
+			Name:      "pkg-2",
+			Ecosystem: lockfile.Ecosystem("npm"),
+			Version:   "<=1.0.0",
+			BlockLocation: models.FilePosition{
+				Line:     models.Position{Start: 1, End: 1},
+				Column:   models.Position{Start: 1, End: 1},
+				Filename: "dir/package-lock.json",
+			},
+			Source: models.SourceInfo{
+				Path: "dir/package-lock.json",
 				Type: "lockfile",
 			},
 		},
@@ -210,7 +297,22 @@ func Test_assembleResult(t *testing.T) {
 			},
 			config: &config.ConfigManager{},
 		},
-	}}
+	}, {
+		name: "group_vulnerabilities_ignore_ranged_versions",
+		args: args{
+			r:            &reporter.VoidReporter{},
+			packages:     packagesWithRangedVersions,
+			vulnsResp:    vulnsResp,
+			licensesResp: makeLicensesResp(),
+			actions: ScannerActions{
+				ExperimentalScannerActions: ExperimentalScannerActions{
+					ShowAllPackages:       false,
+					ScanLicensesAllowlist: nil,
+				},
+				CallAnalysisStates: callAnalysisStates,
+			},
+			config: &config.ConfigManager{},
+		}}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## What does this PR do?

- We should ignore ranged versions in the osv scanner, as they are not supported in our system

## Testing
- Scanning the following requirements [file](https://gist.github.com/rjcoulter22/489c19e91f266e43904952b679f8b691) both before and after the change
     - Result before: https://gist.github.com/rjcoulter22/eab70e25e0df31ec0dc49128cec22248
     - Result after: https://gist.github.com/rjcoulter22/72c76f978e02d5e8c6844833b91869df

## Things the reviewer should know 
- This also updates a snapshot that was causing a CI test to fail
- This change will have to be backported to the `datadog-sbom-generator`
