### PR TITLE
[K9VULN-3618] Fix `goreleaser` workflow

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,10 +8,7 @@ builds:
     id: osv-scanner
     binary: osv-scanner
     env:
-      # goreleaser does not work with CGO, it could also complicate
-      # usage by users in CI/CD systems like Terraform Cloud where
-      # they are unable to install libraries.
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
       - GO111MODULE=on
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
@@ -34,7 +31,7 @@ builds:
       - arm64
 
 archives:
-  - format: zip
+  - formats: ["zip"]
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   name_template: "{{ .ProjectName }}_SHA256SUMS"

--- a/scripts/build_snapshot.sh
+++ b/scripts/build_snapshot.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-goreleaser build --rm-dist --single-target --snapshot
+goreleaser build --clean --single-target --snapshot


### PR DESCRIPTION
## What does this PR do?

When trying to cut a new [release](https://github.com/DataDog/osv-scanner/releases/tag/v0.13.0) `goreleaser` is [failing](https://github.com/DataDog/osv-scanner/actions/runs/13768617711/job/38502729355#step:6:44) due to an issue building a tree sitter library that required `cgo`, this fixes the issue by setting the `CGO_ENABLED` flag set to 1 (true)

## Testing
Reproduced error linked in failing build locally running `build_snapshot.sh` and verified command succeeded after changes were introduced 

## Additional Notes
- The goreleaser config was also modified to move off of deprecated flags as outlined [here](https://goreleaser.com/deprecations/#after_3) and [here](https://goreleaser.com/deprecations/#-rm-dist)
- The comment about `CGO` not working with goreleaser was added a while back in this upstream [PR](https://github.com/google/osv-scanner/pull/38/files)
