### PR TITLE
Run goreleaser-cross to cross compile with cgo

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -34,20 +34,22 @@ jobs:
       - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3
       - name: Run GoReleaser
         id: run-goreleaser
-        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean
         env:
+          GORELEASER_CROSS_VERSION: v1.24-v2.7.0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker run --rm -e CGO_ENABLED=1 \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v `pwd`:/go/src/osv-scanner \
+            -w /go/src/osv-scanner \
+            ghcr.io/goreleaser/goreleaser-cross:$GORELEASER_CROSS_VERSION --clean
       - name: Generate subject
         id: hash
         env:
           ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
         run: |
           set -euo pipefail
-          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          checksum_file=$(cat dist/artifacts.json | jq -r '.[] | select (.type=="Checksum") | .path')
           echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
   provenance:
     needs: [goreleaser]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,32 +4,114 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - main: ./cmd/osv-scanner/
-    id: osv-scanner
+  - id: darwin-amd64
+    main: ./cmd/osv-scanner/
     binary: osv-scanner
     env:
       - CGO_ENABLED=1
       - GO111MODULE=on
+      - CC=o64-clang
+      - CXX=o64-clang++
+    goarch:
+      - amd64
+    goos:
+      - darwin
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
     ldflags:
       # prettier-ignore
       - '-s -w -X github.com/DataDog/osv-scanner/internal/version.OSVVersion={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
+  - id: darwin-arm64
+    main: ./cmd/osv-scanner/
+    binary: osv-scanner
+    env:
+      - CGO_ENABLED=1
+      - GO111MODULE=on
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    goarch:
+      - arm64
     goos:
-      # Further testing before supporting freebsd
-      # - freebsd
-      - windows
-      - linux
       - darwin
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      # prettier-ignore
+      - '-s -w -X github.com/DataDog/osv-scanner/internal/version.OSVVersion={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
+  - id: linux-amd64
+    main: ./cmd/osv-scanner/
+    binary: osv-scanner
+    env:
+      - CGO_ENABLED=1
+      - GO111MODULE=on
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
     goarch:
       - amd64
-      # 32bit does not compile at the moment because of spdx dependency
-      # - '386'
-      # Further testing before supporting arm
-      # - arm
+    goos:
+      - linux
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      # prettier-ignore
+      - '-s -w -X github.com/DataDog/osv-scanner/internal/version.OSVVersion={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
+  - id: linux-arm64
+    main: ./cmd/osv-scanner/
+    binary: osv-scanner
+    env:
+      - CGO_ENABLED=1
+      - GO111MODULE=on
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    goarch:
       - arm64
-
+    goos:
+      - linux
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      # prettier-ignore
+      - '-s -w -X github.com/DataDog/osv-scanner/internal/version.OSVVersion={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
+  - id: windows-amd64
+    main: ./cmd/osv-scanner/
+    binary: osv-scanner
+    env:
+      - CGO_ENABLED=1
+      - GO111MODULE=on
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    goarch:
+      - amd64
+    goos:
+      - windows
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      # prettier-ignore
+      - '-s -w -X github.com/DataDog/osv-scanner/internal/version.OSVVersion={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
+  - id: windows-arm64
+    main: ./cmd/osv-scanner/
+    binary: osv-scanner
+    env:
+      - CGO_ENABLED=1
+      - GO111MODULE=on
+      - CC=/llvm-mingw/bin/aarch64-w64-mingw32-gcc
+      - CXX=/llvm-mingw/bin/aarch64-w64-mingw32-g++
+    goarch:
+      - arm64
+    goos:
+      - windows
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      # prettier-ignore
+      - '-s -w -X github.com/DataDog/osv-scanner/internal/version.OSVVersion={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}}'
 archives:
   - formats: ["zip"]
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
## What does this PR do?

This PR aims to fix the release process now that we need to use CGO to compile osv-scanner with tree-sitter. It does that by using goreleaser-cross, the recommended tool by goreleaser team when dealing with cgo.

It works by embedding multiple compiler in a single docker container and defining for each target which compiler it have to use.

See https://github.com/goreleaser/goreleaser-cross for more information about the tool