### PR TITLE
Fixing the github token in env vars

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -38,7 +38,7 @@ jobs:
           GORELEASER_CROSS_VERSION: v1.24-v2.7.0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker run --rm -e CGO_ENABLED=1 \
+          docker run --rm -e CGO_ENABLED=1 -e GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}} \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v `pwd`:/go/src/osv-scanner \
             -w /go/src/osv-scanner \


### PR DESCRIPTION
## About this PR

This PR is a follow-up of using goreleaser as I previously forgot to pass the github token to let it publish the release