### PR TITLE
[K9VULN-4192] Skip packages not in ruby lockfile

### DIFF
--- a/cmd/osv-scanner/__snapshots__/main_test.snap
+++ b/cmd/osv-scanner/__snapshots__/main_test.snap
@@ -493,7 +493,9 @@ Filtered 16 vulnerabilities from output
 | https://osv.dev/DSA-5650-1          |      | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2022-1271       | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2024-3094       | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/CVE-2025-31115      |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5123-1          |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DSA-5895-1          |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 
 ---
@@ -1786,7 +1788,9 @@ Filtered 16 vulnerabilities from output
 | https://osv.dev/DSA-5650-1          |      | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2022-1271       | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2024-3094       | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/CVE-2025-31115      |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5123-1          |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DSA-5895-1          |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 
 ---
@@ -2019,7 +2023,9 @@ Filtered 16 vulnerabilities from output
 | https://osv.dev/DSA-5650-1          |      | Debian    | util-linux                     | 2.29.2-1+deb9u1                    | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2022-1271       | 8.8  | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/CVE-2024-3094       | 10.0 | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/CVE-2025-31115      |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 | https://osv.dev/DSA-5123-1          |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
+| https://osv.dev/DSA-5895-1          |      | Debian    | xz-utils                       | 5.2.2-1.2+deb9u1                   | fixtures/sbom-insecure/postgres-stretch.cdx.xml |
 +-------------------------------------+------+-----------+--------------------------------+------------------------------------+-------------------------------------------------+
 
 ---

--- a/pkg/lockfile/__snapshots__/match-gemfile_test.snap
+++ b/pkg/lockfile/__snapshots__/match-gemfile_test.snap
@@ -1,4 +1,47 @@
 
+[TestGemfileMatcher_Filter_Not_In_Lockfile - 1]
+[
+  {
+    "name": "zeitwerk",
+    "version": "2.6.0",
+    "blockLocation": {
+      "line": {
+        "start": 3,
+        "end": 3
+      },
+      "column": {
+        "start": 1,
+        "end": 24
+      },
+      "file_name": "<rootdir>/fixtures/bundler/lockfile-not-synced/Gemfile"
+    },
+    "versionLocation": {
+      "line": {
+        "start": 3,
+        "end": 3
+      },
+      "column": {
+        "start": 17,
+        "end": 24
+      },
+      "file_name": "<rootdir>/fixtures/bundler/lockfile-not-synced/Gemfile"
+    },
+    "nameLocation": {
+      "line": {
+        "start": 3,
+        "end": 3
+      },
+      "column": {
+        "start": 5,
+        "end": 15
+      },
+      "file_name": "<rootdir>/fixtures/bundler/lockfile-not-synced/Gemfile"
+    },
+    "packageManager": "Bundler"
+  }
+]
+---
+
 [TestGemfileMatcher_Match_Groups - 1]
 [
   {

--- a/pkg/lockfile/fixtures/bundler/lockfile-not-synced/Gemfile
+++ b/pkg/lockfile/fixtures/bundler/lockfile-not-synced/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'zeitwerk', '2.6.0'
+gem 'websocket-extensions', '0.1.5'
+
+# Only installed in jruby platform
+platform :jruby do
+  gem 'tzinfo-data'
+end

--- a/pkg/lockfile/fixtures/bundler/lockfile-not-synced/Gemfile
+++ b/pkg/lockfile/fixtures/bundler/lockfile-not-synced/Gemfile
@@ -3,7 +3,3 @@ source 'https://rubygems.org'
 gem 'zeitwerk', '2.6.0'
 gem 'websocket-extensions', '0.1.5'
 
-# Only installed in jruby platform
-platform :jruby do
-  gem 'tzinfo-data'
-end

--- a/pkg/lockfile/fixtures/bundler/lockfile-not-synced/Gemfile.lock
+++ b/pkg/lockfile/fixtures/bundler/lockfile-not-synced/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    zeitwerk (2.6.0)
+
+PLATFORMS
+  aarch64-linux
+  ruby
+
+DEPENDENCIES
+  tzinfo-data
+  zeitwerk (= 2.6.0)
+
+BUNDLED WITH
+   2.5.11

--- a/pkg/lockfile/match-gemfile.go
+++ b/pkg/lockfile/match-gemfile.go
@@ -221,7 +221,12 @@ func indexPackages(packages []PackageDetails) map[string]*PackageDetails {
 
 func enrichPackagesWithLocation(sourceFile DepFile, gems []gemMetadata, packagesByName map[string]*PackageDetails) {
 	for _, gem := range gems {
-		pkg := packagesByName[gem.name]
+		pkg, ok := packagesByName[gem.name]
+		// If packages exist in the Gemfile but not in the Gemfile.lock, we skip the package as we treat the lockfile as
+		// the source of truth
+		if !ok {
+			continue
+		}
 
 		pkg.BlockLocation = models.FilePosition{
 			Line:     gem.blockLine,

--- a/pkg/lockfile/match-gemfile_test.go
+++ b/pkg/lockfile/match-gemfile_test.go
@@ -148,3 +148,27 @@ func TestGemfileMatcher_Match_Groups(t *testing.T) {
 
 	testutility.NewSnapshot().WithJSONNormalization().MatchJSON(t, packages)
 }
+
+func TestGemfileMatcher_Filter_Not_In_Lockfile(t *testing.T) {
+	t.Parallel()
+
+	sourceFile, err := lockfile.OpenLocalDepFile("fixtures/bundler/lockfile-not-synced/Gemfile")
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	packages := []lockfile.PackageDetails{
+		{
+			Name:           "zeitwerk",
+			Version:        "2.6.0",
+			PackageManager: models.Bundler,
+		},
+	}
+
+	err = gemfileMatcher.Match(sourceFile, packages)
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	testutility.NewSnapshot().WithJSONNormalization().MatchJSON(t, packages)
+}


### PR DESCRIPTION
## What does this PR do?

In cases where the `Gemfile.lock` was out of sync with the `Gemfile` we would panic as we were under the assumption these files would be in sync - this modifies the scanner so that we discard packages that are not present in the lockfile.

## Testing
- Added unit test, ran the scanner locally on [repo](https://github.com/DataDog/system-tests/tree/main) that previously failed successfully
- Updated snapshot to get CI to pass
