### PR TITLE
Defend against regex failure

### DIFF
--- a/internal/json/utils.go
+++ b/internal/json/utils.go
@@ -49,7 +49,9 @@ func ExtractPackageIndexes(pkgName, targetedVersion, content string) []int {
 	} else {
 		versionRegex = cachedregexp.QuoteMeta(targetedVersion)
 	}
-	pkgMatcher := cachedregexp.MustCompile(`"(?P<pkgName>` + pkgName + `)\"\s*:\s*\"(?P<version>` + versionRegex + `)"`)
+	pkgNameRegex := cachedregexp.QuoteMeta(pkgName)
+
+	pkgMatcher := cachedregexp.MustCompile(`"(?P<pkgName>` + pkgNameRegex + `)\"\s*:\s*\"(?P<version>` + versionRegex + `)"`)
 	result := pkgMatcher.FindAllStringSubmatchIndex(content, -1)
 
 	if len(result) == 0 || len(result[0]) < 6 {


### PR DESCRIPTION
## What does this PR do?

We saw an error like below trying to scan a customers repo ([log here](https://app.datadoghq.com/logs?query=service%3Acode-workload-runner-sca%20panic&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZYXHC3wZfU3IQAAABhBWllYSER5QUFBQ2pmWGxGNXZlR1hnQUQAAAAkMDE5NjE3MWMtNjQ3OC00MzEzLWJhNGQtNDAyMmUzOTYxYTI0AAB4wA&fromUser=true&graphType=waterfall&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=7513271439295205086&storage=hot&stream_sort=desc&viz=stream&from_ts=1744139169448&to_ts=1744140069448&live=true)) - to guard against this case of a package name including a special regex character we now escape the string before inputting it as a regex

> osv-scanner panicked: regexp: Compile(`"(?P<pkgName>? )\"\s*:\s*\"(?P<version>babel/runtime@npm:\^7\.0\.0)"`): error parsing regexp: missing argument to repetition operator: `?`