### PR TITLE
Add debug logging for yarn

### DIFF
--- a/pkg/lockfile/parse-yarn-lock.go
+++ b/pkg/lockfile/parse-yarn-lock.go
@@ -35,6 +35,14 @@ func shouldSkipYarnLine(line string) bool {
 
 func parseYarnPackageGroup(group []string) YarnPackage {
 	name, targetVersions := extractYarnPackageNameAndTargetVersions(group[0])
+	if strings.Contains(name, "?") {
+		_, _ = fmt.Fprintf(
+			os.Stderr,
+			"Received package name of %s including question mark for group %v \n",
+			name,
+			group,
+		)
+	}
 
 	return YarnPackage{
 		Name:           name,


### PR DESCRIPTION
## What does this PR do?

- We are seeing an issue in which a customer's yarn lockfile is being parsed and producing a package with a name of `?`, so this adds logging to help debug how that could be happening 

## Additional Notes
- This checks if a `?` is a substring as the [log](https://app.datadoghq.com/logs?query=host%3Ai-01f5a4861aaa4b123%20service%3Acode-workload-runner-sca%20container_id%3A90e92330c00b2f427d3cc5e2e9af99b50e26e21bc1b614f0f5250941e719ac5a%20filename%3A0.log&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40repo_id&context_event=AZYWpEWVAABDK2ZJGPVTMQAH&event=AwAAAZYWpD9yeEklggAAABhBWllXcEVXVkFBQkRLMlpKR1BWVE1RQUcAAAAkMDE5NjE2YTQtYTE3Yy00NTMyLWI0YzctOThkZTc4MmJlN2M4AApeGQ&fromUser=true&graphType=waterfall&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6754505749636751&storage=hot&stream_sort=time%2Cdesc&to_event=AwAAAZYWpNffAgpCNAAAABhBWllXcE9IVEFBRFdlLU95bzRNMGJRQUMAAAAkMDE5NjE2YTYtYTdhMC00MjIwLTlkMWQtNjEwNGZmOGE2N2JlAAsXhQ&viz=&from_ts=1744136285075&to_ts=1744136624096&live=false) indicates that the parsed package name might include whitespace as well 
